### PR TITLE
Redis 모듈 및 infra-compose 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Root
 ├── apps ( spring-applications )
 │   └── 📦 commerce-api
 ├── modules ( reusable-configurations )
-│   └── 📦 jpa
+│   ├── 📦 jpa
+│   └── 📦 redis
 └── supports ( add-ons )
     ├── 📦 monitoring
     └── 📦 logging

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))
@@ -17,4 +18,5 @@ dependencies {
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
 }

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
   config:
     import:
       - jpa.yml
+      - redis.yml
       - logging.yml
       - monitoring.yml
 

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -14,8 +14,55 @@ services:
     volumes:
       - mysql-8-data:/var/lib/mysql
 
+  redis-master:
+    image: redis:7.0
+    container_name: redis-master
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_master_data:/data
+    command:
+      [
+        "redis-server", # redis 서버 실행 명령어
+        "--appendonly", "yes", # AOF (AppendOnlyFile) 영속성 기능 켜기
+        "--save", "",
+        "--latency-monitor-threshold", "100", # 특정 command 가 지정 시간(ms) 이상 걸리면 monitor 기록
+      ]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "PING"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  redis-readonly:
+    image: redis:7.0
+    container_name: redis-readonly
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    ports:
+      - "6380:6379"
+    volumes:
+      - redis_readonly_data:/data
+    command:
+      [
+        "redis-server",
+        "--appendonly", "yes",
+        "--appendfsync", "everysec",
+        "--replicaof", "redis-master", "6379", # replica 모드로 실행 + 서비스 명, 서비스 포트
+        "--replica-read-only", "yes", # 읽기 전용으로 설정
+        "--latency-monitor-threshold", "100",
+      ]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6380", "PING"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
 volumes:
   mysql-8-data:
+  redis_master_data:
+  redis_readonly_data:
 
 networks:
   default:

--- a/modules/redis/build.gradle.kts
+++ b/modules/redis/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api("org.springframework.boot:spring-boot-starter-data-redis")
+
+    testFixturesImplementation("com.redis:testcontainers-redis")
+}

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
@@ -1,0 +1,101 @@
+package com.loopers.config.redis;
+
+
+import io.lettuce.core.ReadFrom;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+@Configuration
+@EnableConfigurationProperties(RedisProperties.class)
+public class RedisConfig{
+    private static final String CONNECTION_MASTER = "redisConnectionMaster";
+    public static final String REDIS_TEMPLATE_MASTER = "redisTemplateMaster";
+
+    private final RedisProperties redisProperties;
+
+    public RedisConfig(RedisProperties redisProperties){
+        this.redisProperties = redisProperties;
+    }
+
+    @Primary
+    @Bean
+    public LettuceConnectionFactory defaultRedisConnectionFactory() {
+        int database = redisProperties.database();
+        RedisNodeInfo master = redisProperties.master();
+        List<RedisNodeInfo> replicas = redisProperties.replicas();
+        return lettuceConnectionFactory(
+                database, master, replicas,
+                b -> b.readFrom(ReadFrom.REPLICA_PREFERRED)
+        );
+    }
+
+    @Qualifier(CONNECTION_MASTER)
+    @Bean
+    public LettuceConnectionFactory masterRedisConnectionFactory() {
+        int database = redisProperties.database();
+        RedisNodeInfo master = redisProperties.master();
+        List<RedisNodeInfo> replicas = redisProperties.replicas();
+        return lettuceConnectionFactory(
+                database, master, replicas,
+                b -> b.readFrom(ReadFrom.MASTER)
+        );
+    }
+
+    @Primary
+    @Bean
+    public RedisTemplate<String, String> defaultRedisTemplate(LettuceConnectionFactory lettuceConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        return defaultRedisTemplate(redisTemplate, lettuceConnectionFactory);
+    }
+
+    @Qualifier(REDIS_TEMPLATE_MASTER)
+    @Bean
+    public RedisTemplate<String, String> masterRedisTemplate(
+            @Qualifier(CONNECTION_MASTER) LettuceConnectionFactory lettuceConnectionFactory
+    ) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        return defaultRedisTemplate(redisTemplate, lettuceConnectionFactory);
+    }
+
+
+    private LettuceConnectionFactory lettuceConnectionFactory(
+            int database,
+            RedisNodeInfo master,
+            List<RedisNodeInfo> replicas,
+            Consumer<LettuceClientConfiguration.LettuceClientConfigurationBuilder> customizer
+    ){
+        LettuceClientConfiguration.LettuceClientConfigurationBuilder builder = LettuceClientConfiguration.builder();
+        if(customizer != null) customizer.accept(builder);
+        LettuceClientConfiguration clientConfig = builder.build();
+        RedisStaticMasterReplicaConfiguration masterReplicaConfig = new RedisStaticMasterReplicaConfiguration(master.host(), master.port());
+        masterReplicaConfig.setDatabase(database);
+        for(RedisNodeInfo r : replicas){
+            masterReplicaConfig.addNode(r.host(), r.port());
+        }
+        return new LettuceConnectionFactory(masterReplicaConfig, clientConfig);
+    }
+
+    private <K,V> RedisTemplate<K,V> defaultRedisTemplate(
+            RedisTemplate<K,V> template,
+            LettuceConnectionFactory connectionFactory
+    ){
+        StringRedisSerializer s = new StringRedisSerializer();
+        template.setKeySerializer(s);
+        template.setValueSerializer(s);
+        template.setHashKeySerializer(s);
+        template.setHashValueSerializer(s);
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisNodeInfo.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisNodeInfo.java
@@ -1,0 +1,6 @@
+package com.loopers.config.redis;
+
+public record RedisNodeInfo(
+        String host,
+        int port
+) { }

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisProperties.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisProperties.java
@@ -1,0 +1,12 @@
+package com.loopers.config.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(value = "datasource.redis")
+public record RedisProperties(
+        int database,
+        RedisNodeInfo master,
+        List<RedisNodeInfo> replicas
+) { }

--- a/modules/redis/src/main/resources/redis.yml
+++ b/modules/redis/src/main/resources/redis.yml
@@ -1,0 +1,36 @@
+spring:
+  data:
+    redis:
+      repositories:
+        enabled: false
+
+datasource:
+  redis:
+    database: 0
+    master:
+      host: ${REDIS_MASTER_HOST}
+      port: ${REDIS_MASTER_PORT}
+    replicas:
+      - host: ${REDIS_REPLICA_1_HOST}
+        port: ${REDIS_REPLICA_1_PORT}
+
+---
+spring.config.activate.on-profile: local, test
+
+datasource:
+  redis:
+    master:
+      host: localhost
+      port: 6379
+    replicas:
+      - host: localhost
+        port: 6380
+
+---
+spring.config.activate.on-profile: dev
+
+---
+spring.config.activate.on-profile: qa
+
+---
+spring.config.activate.on-profile: prd

--- a/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
+++ b/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
@@ -1,0 +1,22 @@
+package com.loopers.testcontainers;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.utility.DockerImageName;
+
+@Configuration
+public class RedisTestContainersConfig {
+    private static final RedisContainer redisContainer = new RedisContainer(DockerImageName.parse("redis:latest"));
+
+    static {
+        redisContainer.start();
+    }
+
+    public RedisTestContainersConfig() {
+        System.setProperty("datasource.redis.database", "0");
+        System.setProperty("datasource.redis.master.host", redisContainer.getHost());
+        System.setProperty("datasource.redis.host.port", String.valueOf(redisContainer.getFirstMappedPort()));
+        System.setProperty("datasource.redis.replicas[0].host", redisContainer.getHost());
+        System.setProperty("datasource.redis.replicas[0].port", String.valueOf(redisContainer.getFirstMappedPort()));
+    }
+}

--- a/modules/redis/src/testFixtures/java/com/loopers/utils/RedisCleanUp.java
+++ b/modules/redis/src/testFixtures/java/com/loopers/utils/RedisCleanUp.java
@@ -1,0 +1,20 @@
+package com.loopers.utils;
+
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisCleanUp {
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    public RedisCleanUp(RedisConnectionFactory redisConnectionFactory) {
+        this.redisConnectionFactory = redisConnectionFactory;
+    }
+
+    public void truncateAll(){
+        try (RedisConnection connection = redisConnectionFactory.getConnection()) {
+            connection.serverCommands().flushAll();
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "loopers-java-spring-template"
 include(
     ":apps:commerce-api",
     ":modules:jpa",
+    ":modules:redis",
     ":supports:jackson",
     ":supports:logging",
     ":supports:monitoring",


### PR DESCRIPTION
Redis 의존성의 경우, `master - readonly` 형태의 운영 환경을 가정하고 추가하였습니다.
`infra-compose.yml` 의 경우, master 및 readonly 설정을 포함하게 하여 로컬 개발 환경에서도 동일한 환경을 구성할 수 있도록 하였습니다.
`:modules:redis` 의 경우, Lettuce 설정을 활용해 master 및 readonly 용 커넥션 및 RedisTemplate 을 지원하도록 추가하였습니다.

> TestContainers 의 경우, `com.redis` 의 라이브러리를 활용하였는데 이는 TestContainers 공식 레디스 이미지 컨테이너가 지원되지 않아서입니다.