### PR TITLE
[volume-5] 인덱스와 캐싱을 통한 읽기 성능 최적화

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/CatalogProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/CatalogProductFacade.java
@@ -94,7 +94,8 @@ public class CatalogProductFacade {
         // 캐시 저장
         productCacheService.cacheProductList(brandId, normalizedSort, page, size, result);
         
-        return result;
+        // 로컬 캐시의 좋아요 수 델타 적용 (DB 조회 결과에도 델타 반영)
+        return productCacheService.applyLikeCountDelta(result);
     }
 
     /**
@@ -133,7 +134,8 @@ public class CatalogProductFacade {
         // 캐시에 저장
         productCacheService.cacheProduct(productId, result);
         
-        return result;
+        // 로컬 캐시의 좋아요 수 델타 적용 (DB 조회 결과에도 델타 반영)
+        return productCacheService.applyLikeCountDelta(result);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java
@@ -1,0 +1,154 @@
+package com.loopers.application.catalog;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+/**
+ * 상품 조회 결과를 Redis에 캐시하는 서비스.
+ * <p>
+ * 상품 목록 조회와 상품 상세 조회 결과를 캐시하여 성능을 향상시킵니다.
+ * </p>
+ * <p>
+ * <b>캐시 전략:</b>
+ * <ul>
+ *   <li><b>상품 목록:</b> 첫 3페이지만 캐시하여 메모리 사용량 최적화</li>
+ *   <li><b>상품 상세:</b> 모든 상품 상세 정보 캐시</li>
+ * </ul>
+ * </p>
+ *
+ * @author Loopers
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductCacheService {
+
+    private static final String CACHE_KEY_PREFIX_LIST = "product:list:";
+    private static final String CACHE_KEY_PREFIX_DETAIL = "product:detail:";
+    private static final Duration CACHE_TTL = Duration.ofMinutes(1); // 1분 TTL
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 상품 목록 조회 결과를 캐시에서 조회합니다.
+     * <p>
+     * 페이지 번호와 관계없이 캐시를 확인하고, 캐시에 있으면 반환합니다.
+     * 캐시에 없으면 null을 반환하여 DB 조회를 유도합니다.
+     * </p>
+     *
+     * @param brandId 브랜드 ID (null이면 전체)
+     * @param sort 정렬 기준
+     * @param page 페이지 번호
+     * @param size 페이지당 상품 수
+     * @return 캐시된 상품 목록 (없으면 null)
+     */
+    public ProductInfoList getCachedProductList(Long brandId, String sort, int page, int size) {
+        try {
+            String key = buildListCacheKey(brandId, sort, page, size);
+            String cachedValue = redisTemplate.opsForValue().get(key);
+            
+            if (cachedValue == null) {
+                return null;
+            }
+            return objectMapper.readValue(cachedValue, new TypeReference<ProductInfoList>() {});
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * 상품 목록 조회 결과를 캐시에 저장합니다.
+     * <p>
+     * 첫 3페이지인 경우에만 캐시에 저장합니다.
+     * </p>
+     *
+     * @param brandId 브랜드 ID (null이면 전체)
+     * @param sort 정렬 기준
+     * @param page 페이지 번호
+     * @param size 페이지당 상품 수
+     * @param productInfoList 캐시할 상품 목록
+     */
+    public void cacheProductList(Long brandId, String sort, int page, int size, ProductInfoList productInfoList) {
+        // 3페이지까지만 캐시 저장
+        if (page > 2) {
+            return;
+        }
+        
+        try {
+            String key = buildListCacheKey(brandId, sort, page, size);
+            String value = objectMapper.writeValueAsString(productInfoList);
+            redisTemplate.opsForValue().set(key, value, CACHE_TTL);
+        } catch (Exception e) {
+            // 캐시 저장 실패는 무시 (DB 조회로 폴백 가능)
+        }
+    }
+
+    /**
+     * 상품 상세 조회 결과를 캐시에서 조회합니다.
+     *
+     * @param productId 상품 ID
+     * @return 캐시된 상품 정보 (없으면 null)
+     */
+    public ProductInfo getCachedProduct(Long productId) {
+        try {
+            String key = buildDetailCacheKey(productId);
+            String cachedValue = redisTemplate.opsForValue().get(key);
+            
+            if (cachedValue == null) {
+                return null;
+            }
+            return objectMapper.readValue(cachedValue, new TypeReference<ProductInfo>() {});
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * 상품 상세 조회 결과를 캐시에 저장합니다.
+     *
+     * @param productId 상품 ID
+     * @param productInfo 캐시할 상품 정보
+     */
+    public void cacheProduct(Long productId, ProductInfo productInfo) {
+        try {
+            String key = buildDetailCacheKey(productId);
+            String value = objectMapper.writeValueAsString(productInfo);
+            redisTemplate.opsForValue().set(key, value, CACHE_TTL);
+        } catch (Exception e) {
+            // 캐시 저장 실패는 무시 (DB 조회로 폴백 가능)
+        }
+    }
+
+    /**
+     * 상품 목록 캐시 키를 생성합니다.
+     *
+     * @param brandId 브랜드 ID (null이면 "all")
+     * @param sort 정렬 기준
+     * @param page 페이지 번호
+     * @param size 페이지당 상품 수
+     * @return 캐시 키
+     */
+    private String buildListCacheKey(Long brandId, String sort, int page, int size) {
+        String brandPart = brandId != null ? "brand:" + brandId : "brand:all";
+        // sort가 null이면 기본값 "latest" 사용 (컨트롤러와 동일한 기본값)
+        String sortValue = sort != null ? sort : "latest";
+        return String.format("%s%s:sort:%s:page:%d:size:%d", 
+            CACHE_KEY_PREFIX_LIST, brandPart, sortValue, page, size);
+    }
+
+    /**
+     * 상품 상세 캐시 키를 생성합니다.
+     *
+     * @param productId 상품 ID
+     * @return 캐시 키
+     */
+    private String buildDetailCacheKey(Long productId) {
+        return CACHE_KEY_PREFIX_DETAIL + productId;
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -19,7 +19,23 @@ import lombok.NoArgsConstructor;
  * @version 1.0
  */
 @Entity
-@Table(name = "product")
+@Table(
+    name = "product",
+    indexes = {
+        // 브랜드 필터 + 좋아요 순 정렬 최적화 (복합 인덱스: ref_brand_id, like_count)
+        @Index(name = "idx_product_brand_likes", columnList = "ref_brand_id,like_count"),
+        // 브랜드 필터 + 최신순 정렬 최적화 (복합 인덱스: ref_brand_id, created_at)
+        @Index(name = "idx_product_brand_created", columnList = "ref_brand_id,created_at"),
+        // 브랜드 필터 + 가격순 정렬 최적화 (복합 인덱스: ref_brand_id, price)
+        @Index(name = "idx_product_brand_price", columnList = "ref_brand_id,price"),
+        // 전체 조회 + 좋아요 순 정렬 최적화
+        @Index(name = "idx_product_likes", columnList = "like_count"),
+        // 전체 조회 + 가격순 정렬 최적화
+        @Index(name = "idx_product_price", columnList = "price"),
+        // 전체 조회 + 최신순 정렬 최적화
+        @Index(name = "idx_product_created", columnList = "created_at")
+    }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Product extends BaseEntity {

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeTest.java
@@ -1,5 +1,6 @@
 package com.loopers.application.like;
 
+import com.loopers.application.catalog.ProductCacheService;
 import com.loopers.domain.like.Like;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.domain.product.Product;
@@ -11,6 +12,9 @@ import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,10 +30,20 @@ import static org.mockito.Mockito.never;
 @DisplayName("LikeFacade 좋아요 등록/취소/중복 방지 흐름 검증")
 class LikeFacadeTest {
 
-    private LikeFacade likeFacade;
-    private UserRepository userRepository;
-    private ProductRepository productRepository;
+    @Mock
     private LikeRepository likeRepository;
+    
+    @Mock
+    private UserRepository userRepository;
+    
+    @Mock
+    private ProductRepository productRepository;
+    
+    @Mock
+    private ProductCacheService productCacheService;
+
+    @InjectMocks
+    private LikeFacade likeFacade;
 
     private static final String DEFAULT_USER_ID = "testuser";
     private static final Long DEFAULT_USER_INTERNAL_ID = 1L;
@@ -37,15 +51,7 @@ class LikeFacadeTest {
 
     @BeforeEach
     void setUp() {
-        userRepository = mock(UserRepository.class);
-        productRepository = mock(ProductRepository.class);
-        likeRepository = mock(LikeRepository.class);
-
-        likeFacade = new LikeFacade(
-            likeRepository,
-            userRepository,
-            productRepository
-        );
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test


### PR DESCRIPTION
## 📌 Summary

Round 5 읽기 성능 최적화 작업을 완료했습니다. 상품 목록 조회 성능 개선을 위해 다음과 같은 작업을 수행했습니다:

1. **인덱스 설계 및 추가** [9631946](https://github.com/Loopers-dev-lab/loopers-spring-java-template/pull/125/commits/8f0ac9b1051ffc515fdd2693bfd14fa60aa6d485)
브랜드 필터링과 정렬 조합을 위한 복합 인덱스를 추가하고, 
전체 조회 시 정렬을 위한 단일 인덱스를 추가하여 쿼리 패턴에 맞춘 
인덱스 최적화를 진행했습니다.

2. **Redis 캐시 구현** [9631946](https://github.com/Loopers-dev-lab/loopers-spring-java-template/pull/125/commits/9631946311727ba0c3c8fb117cfc6c8e2995a617)
Cache Aside 패턴으로 상품 목록과 상세 조회 결과를 캐싱하고, 
RedisTemplate을 직접 사용하여 캐시 흐름을 명시적으로 제어했습니다. 
또한 메모리 최적화를 위해 첫 3페이지만 캐시하는 전략을 적용했습니다.

3. **좋아요 수 실시간 반영 전략** [3d58ac9](https://github.com/Loopers-dev-lab/loopers-spring-java-template/pull/125/commits/3d58ac9793e4befeb44a31b36c3a7875f59f35d9)
배치 동기화를 통해 좋아요 수 집계의 쓰기 부하를 줄이되 
로컬 캐시(ConcurrentHashMap)로 좋아요 수 델타를 관리하여 
정합성을 보완하도록 했습니다.

## 💬 Review Points
### 1. 캐시 범위 하드코딩 vs 동적 설정에 대한 고민

현재는 첫 3페이지만 캐시하도록 하드코딩하여 구현했습니다.
 `ProductCacheService.java`의 `cacheProductList` 메서드에서 `page > 2`인 경우 
캐시 저장을 하지 않도록 처리하고 있습니다. 해당 코드는 `apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java` 파일의
 97-100라인에서 확인하실 수 있습니다.

```java
public void cacheProductList(Long brandId, String sort, int page, int size, ProductInfoList productInfoList) {
    // 3페이지까지만 캐시 저장
    if (page > 2) {
        return;
    }
    // ...
}
```

이렇게 구현한 이유는 대부분의 사용자가 첫 페이지에서 목록을 조회한 후 이탈할 것이고,
3페이지 이상 조회하는 경우는 적을 것이라 판단했기 때문입니다. 
하지만 실제 운영 상황에서는 사용자의 행동 패턴에 따라 캐시 범위를 조정해야 할 필요가 있을 것 같습니다. 
예를 들어, 프로모션 기간과 그렇지 않은 기간에 따라 변경하거나, 
판매되는 상품 중 고관여도 상품군들이 비중이 늘어나는 등 변화가 있을 때
별도의 배포 없이 변경할 수 있으면 좋을 것 같다는 생각이 들었습니다.

이를 위해 Redis에 `max_cache_pages`라는 키로 integer 값을 저장하여
그 페이지수만큼 관리하는 방법을 고려해보았습니다.
이 방식의 장점은 배포 없이 동적으로 변경이 가능하다는 점이지만,
변수가 예상치 못하게 사라져도 발견하기 어려울 수 있다는 단점이 있습니다.

캐시 범위를 동적으로 관리할 수 있는 적절한 방법이 있을지,
그리고 하드코딩, Redis 설정값, 설정 파일(application.yml) 로 관리 하는 등
실무에서 더 적절한 방법 이 있을지 의견을 여쭙고 싶습니다.

### 2. 로컬 캐시 vs Redis 직접 업데이트에 대한 고민

현재는 로컬 캐시(ConcurrentHashMap)를 사용하여 좋아요 수 델타를 관리하고 있습니다.
캐시 조회 시 델타를 적용하여 반환하도록 구현했으며, 관련 코드는 
`apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java` 파일의 48라인과 189-270라인에서 확인하실 수 있습니다.

```java
private final ConcurrentHashMap<Long, Long> likeCountDeltaCache = new ConcurrentHashMap<>();

public void incrementLikeCountDelta(Long productId) {
    likeCountDeltaCache.merge(productId, 1L, Long::sum);
}

public ProductInfo applyLikeCountDelta(ProductInfo productInfo) {
    Long delta = likeCountDeltaCache.get(productInfo.productDetail().getId());
    if (delta == null || delta == 0) {
        return productInfo;
    }
    // 델타 적용 로직...
}
```

이러한 방식을 선택한 배경은 다음과 같습니다. 
인기 게시물에 좋아요가 집중되는 상황에서도 쓰기에 부하가 걸리지 않도록 하기 위해
락을 사용하지 않고, unique index가 걸린 테이블에 append only 방식으로 사용하며,
배치 작업으로 집계하여 업데이트하는 방식을 사용하고 있습니다.
배치가 돌 때마다 캐시는 갱신되니 별도의 TTL이나 evict policy를 적용할 필요는 없는 장점이 있습니다.
하지만 배치가 업데이트 되기까지 데이터 차이가 발생한다는 단점이 있어서 로컬 캐시로 오차를 줄이고자 했습니다.

이 과정에서 두 가지 방식을 고민했습니다. 첫 번째는 Redis에 직접 업데이트하는 방식인데요,
Redis에 저장하는 경우 필터별 목록들을 전부 갱신해야 하다보니
Redis에 불필요하게 많은 부하가 될 것 같았습니다.
다만 Redis JSON이나 HashSet을 사용하면 Redis 자체로 관리해서 효율적일 것 같다는 생각도 들었습니다.
두 번째는 현재 선택한 로컬 캐시 방식으로, 
배치로 업데이트 되는 사이에 가장 빠르게 사용할 수 있고, 
아직까지는 단일 인스턴스를 가정한 상황이기에 데이터 이격이 걱정되지 않는 상황이라 
문제해결에 용이하다고 판단했습니다.

실무적으로 사용하기에 로컬 캐시와 Redis 직접 업데이트 중 더 적절한 방법이 무엇일지,
그리고 Redis JSON이나 HashSet을 활용한 방식이
현재 로컬 캐시 방식보다 더 나은 선택일지 의견을 주시면 감사하겠습니다.
또한 향후 멀티 인스턴스 환경으로 확장할 때를 고려하면 어떤 방식이 더 적절할지도 궁금합니다.

### 3. 인덱스 수 최적화에 대한 고민

현재는 브랜드 필터 유무와 정렬 기준 조합에 따라 총 6개의 인덱스를 추가했습니다.
브랜드 필터와 정렬을 함께 사용하는 경우를 위한 복합 인덱스 3개와,
전체 조회 시 정렬만 사용하는 경우를 위한 단일 인덱스 3개로 구성했습니다.
관련 코드는 `apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java` 파일의 22-37라인에서 확인하실 수 있습니다.

```java
@Table(
    name = "product",
    indexes = {
        // 브랜드 필터 + 정렬 (복합 인덱스 3개)
        @Index(name = "idx_product_brand_likes", columnList = "ref_brand_id,like_count"),
        @Index(name = "idx_product_brand_created", columnList = "ref_brand_id,created_at"),
        @Index(name = "idx_product_brand_price", columnList = "ref_brand_id,price"),
        // 전체 조회 + 정렬 (단일 인덱스 3개)
        @Index(name = "idx_product_likes", columnList = "like_count"),
        @Index(name = "idx_product_price", columnList = "price"),
        @Index(name = "idx_product_created", columnList = "created_at")
    }
)
```

인덱스가 너무 많으면 쓰기 성능의 저하가 있을 수 있다는 점을 우려했지만,
현재 상황에서 자주 업데이트되는 값은 `like_count`와 `stock` 2개의 필드뿐입니다. 
`stock`은 인덱스에 포함되지 않기 때문에 수정이 있더라도 인덱스를 수정할 필요가 없고,
`like_count`는 실시간으로 업데이트하지 않고 배치로 처리하므로
상대적으로 수정 빈도를 낮춰놓은 상태이기 때문에
인덱스를 추가해도 큰 문제가 되지는 않을 것이라 판단했습니다.

복합 인덱스로 통합을 시도해보았지만,
`created, brand_id` 순으로 구성하면 브랜드로 필터할 때 인덱스가 활용되지 않고
`brand_id, created` 순으로 하면 전체 좋아요순으로 조회할 때 인덱스가 활용되지 않아
복합 인덱스 하나만으로 처리하기는 어려울 것 같았습니다.

다른 방법으로는 기획자와 협의해서 좋아요순인 항목은 100개까지만 보이도록 하고,
SortedSet으로 관리하는 방식도 고려해볼 수 있을 것 같습니다.
좋아요순으로 100위 바깥에 있는 상품은 사용자에게 그렇게 큰 가치는 없어 보이기 때문입니다.
이 방식의 장점은 인덱스 수를 줄일 수 있고 Redis SortedSet으로 관리하면 성능도 좋을 것이라는 점이지만,
기획 변경이 필요하고 다른 정렬 옵션과의 일관성 문제가 있을 수 있습니다.

인덱스 수를 줄일 수 있는 더 좋은 방법이 있을지,
그리고 SortedSet 방식이 실무에서 적절한 선택일지,
또는 다른 대안이 있을지 피드백 부탁드립니다.

### 4. Cache Aside 패턴과 RedisTemplate 직접 사용

Cache Aside 패턴을 적용하여 캐시를 우선 조회하고,
없는 경우에만 DB에서 조회하도록 구현했습니다.
상품 목록과 상품 상세 조회 모두에 동일한 패턴을 적용했으며,
관련 코드는 `apps/commerce-api/src/main/java/com/loopers/application/catalog/CatalogProductFacade.java` 파일의 
상품 목록 조회 메서드(46-98라인)와 상품 상세 조회 메서드(111-138라인)에서 확인하실 수 있습니다.

```java
public ProductInfoList getProducts(Long brandId, String sort, int page, int size) {
    // 캐시에서 조회 시도
    ProductInfoList cachedResult = productCacheService.getCachedProductList(brandId, normalizedSort, page, size);
    if (cachedResult != null) {
        return cachedResult;
    }
    
    // 캐시에 없으면 DB에서 조회
    // ... DB 조회 로직 ...
    
    // 캐시 저장
    productCacheService.cacheProductList(brandId, normalizedSort, page, size, result);
    return productCacheService.applyLikeCountDelta(result);
}
```

이 방식을 선택한 이유는 캐시 흐름을 명시적으로 제어할 수 있고,
캐시 저장과 조회 시점을 명확히 파악하여 디버깅과 유지보수가 용이하기 때문입니다.
또한 DB 부하를 줄이기 위해 캐시를 우선 조회하고,
없는 경우에만 DB 조회하도록 설계했습니다.

### 5. 예외 처리 및 폴백 전략

캐시 저장과 조회 실패 시 예외를 잡아 null을 반환하거나 무시하여
DB 조회로 폴백하도록 구현했습니다.
관련 코드는 `apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java` 파일에서 확인하실 수 있으며,
캐시 조회 실패 시 null 반환은 79-81라인과 133-135라인에서,
캐시 저장 실패 시 무시는 106-108라인과 149-151라인에서 처리하고 있습니다.

이렇게 구현한 이유는 캐시가 성능 최적화를 위한 것이므로
실패해도 서비스는 정상 동작해야 하며,
Redis 장애 시에도 사용자 경험에 영향을 주지 않도록 설계했기 때문입니다.

## ✅ Checklist

### 1. 인덱스 설계 및 구현
- [x] **복합 인덱스 설계 (브랜드 필터 + 정렬)**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java` (22-37라인)
  - 브랜드 필터 + 좋아요 순: `idx_product_brand_likes` (ref_brand_id, like_count)
  - 브랜드 필터 + 최신순: `idx_product_brand_created` (ref_brand_id, created_at)
  - 브랜드 필터 + 가격순: `idx_product_brand_price` (ref_brand_id, price)
  
- [x] **단일 인덱스 설계 (전체 조회 + 정렬)**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java` (31-36라인)
  - 좋아요 순: `idx_product_likes` (like_count)
  - 가격순: `idx_product_price` (price)
  - 최신순: `idx_product_created` (created_at)

- [x] **쿼리 패턴과 인덱스 매칭 검증**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java` (104-111라인)
  - 정렬 옵션: `price_asc`, `likes_desc`, `latest` (createdAt DESC)
  - 브랜드 필터 유무에 따른 쿼리 분기 확인: `findByBrandId()` vs `findAll()`

### 2. Redis 캐시 구현
- [x] **Cache Aside 패턴 적용**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/application/catalog/CatalogProductFacade.java`
    - 상품 목록: 46-98라인 (캐시 조회 → DB 조회 → 캐시 저장)
    - 상품 상세: 111-138라인 (캐시 조회 → DB 조회 → 캐시 저장)

- [x] **RedisTemplate 직접 사용**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java`
    - RedisTemplate 주입: 38라인
    - 캐시 조회: 66-82라인 (`getCachedProductList`), 120-136라인 (`getCachedProduct`)
    - 캐시 저장: 96-109라인 (`cacheProductList`), 144-152라인 (`cacheProduct`)

- [x] **캐시 키 설계**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java` (163-169라인)
  - 상품 목록 키: `product:list:brand:{brandId}:sort:{sort}:page:{page}:size:{size}`
  - 상품 상세 키: `product:detail:{productId}`

- [x] **TTL 설정 및 메모리 최적화**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java`
    - TTL 설정: 36라인 (`Duration.ofMinutes(1)`)
    - 첫 3페이지만 캐시: 97-100라인 (`if (page > 2) return;`)

- [x] **예외 처리 및 폴백 전략**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java`
    - 캐시 조회 실패 시 null 반환: 79-81라인, 133-135라인
    - 캐시 저장 실패 시 무시: 106-108라인, 149-151라인

### 3. 좋아요 수 실시간 반영 전략
- [x] **로컬 캐시 델타 관리**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java`
    - 델타 캐시 선언: 48라인 (`ConcurrentHashMap<Long, Long>`)
    - 델타 증가: 189-191라인 (`incrementLikeCountDelta`)
    - 델타 감소: 201-203라인 (`decrementLikeCountDelta`)
    - 델타 적용: 250-270라인 (`applyLikeCountDelta`)

- [x] **좋아요 추가/취소 시 델타 업데이트**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java`
    - 좋아요 추가: 81-84라인 (`incrementLikeCountDelta` 호출)
    - 좋아요 취소: 115-116라인 (`decrementLikeCountDelta` 호출)

- [x] **배치 동기화 후 델타 초기화**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/config/batch/LikeCountSyncBatchConfig.java` (176-188라인)
    - StepExecutionListener로 배치 완료 후 `clearAllLikeCountDelta()` 호출

- [x] **캐시 조회 및 DB 조회 결과에 델타 적용**
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/application/catalog/ProductCacheService.java`
    - 캐시 조회 시: 78라인, 132라인
  - 확인 위치: `apps/commerce-api/src/main/java/com/loopers/application/catalog/CatalogProductFacade.java`
    - DB 조회 결과에도 적용: 98라인, 138라인

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 제품 카탈로그 조회 성능 개선을 위한 캐싱 메커니즘 추가

* **성능 개선**
  * 제품 검색 및 필터링 속도 향상을 위한 데이터베이스 인덱스 최적화
  * 좋아요 개수 업데이트 시 캐시 동기화로 실시간 정확성 강화

* **테스트**
  * 캐싱 기능 검증을 위한 테스트 코드 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->