### PR TITLE
[volume-5] 인덱스 및 Redis 캐시 적용 - 박민호

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,5 +1,6 @@
 package com.loopers.application.order;
 
+import com.loopers.application.product.ProductCacheService;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderItem;
 import com.loopers.domain.order.OrderService;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Component
 public class OrderFacade {
+    private final ProductCacheService productCacheService;
     private final OrderService orderService;
     private final UserService userService;
     private final ProductService productService;
@@ -42,6 +44,7 @@ public class OrderFacade {
         List<OrderItem> orderItemsData = products.stream()
                 .map(product -> {
                     int quantity = itemQuantityMap.get(product.getId());
+                    productCacheService.deleteDetailCache(product.getId());
                     product.decreaseStock(quantity);
                     return OrderItem.create(quantity, product.getPrice(), product.getId(), order.getId());
                 }).toList();

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCacheService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCacheService.java
@@ -1,0 +1,83 @@
+package com.loopers.application.product;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.product.ProductSortType;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ProductCacheService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String PRODUCT_DETAIL_KEY = "product::product-id::%s::detail";
+    private static final String PRODUCT_LIST_KEY = "product::brand-id=%s::sort=%s::page=%s::size=%s::list";
+
+    public void createOrUpdateDetail(final Long productId, final ProductWithBrandInfo value, final Duration ttl) {
+        try {
+            String stringValue = objectMapper.writeValueAsString(value);
+            redisTemplate.opsForValue().set(generateDetailKey(productId), stringValue, ttl);
+        } catch (Exception e) {
+            return;
+        }
+
+    }
+
+    public void createOrUpdateList(
+            final ProductSearchCriteria productSearchCriteria,
+            final List<ProductWithBrandInfo> value,
+            final Duration ttl) {
+        if (productSearchCriteria.page() != 1) {
+            return;
+        }
+        try {
+            String stringValue = objectMapper.writeValueAsString(value);
+            redisTemplate.opsForValue().set(generateListKey(productSearchCriteria.brandId(), productSearchCriteria.productSortType(), productSearchCriteria.page(), productSearchCriteria.size()), stringValue, ttl);
+        } catch (Exception e) {
+            return;
+        }
+    }
+
+    public ProductWithBrandInfo readDetail(final Long productId) {
+        try {
+            String value = redisTemplate.opsForValue()
+                    .get(generateDetailKey(productId));
+            return objectMapper.readValue(value, ProductWithBrandInfo.class);
+
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public List<ProductWithBrandInfo> readList(final ProductSearchCriteria productSearchCriteria) {
+        if (productSearchCriteria.page() != 1) {
+            return null;
+        }
+        try {
+            String value = redisTemplate.opsForValue()
+                    .get(generateListKey(productSearchCriteria.brandId(), productSearchCriteria.productSortType(), productSearchCriteria.page(), productSearchCriteria.size()));
+            return objectMapper.readValue(value, new TypeReference<List<ProductWithBrandInfo>>() {});
+
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public void deleteDetailCache(final Long productId) {
+        redisTemplate.delete(generateDetailKey(productId));
+    }
+
+    private String generateDetailKey(final Long productId) {
+        return PRODUCT_DETAIL_KEY.formatted(productId);
+    }
+
+    private String generateListKey(final Long brandId, ProductSortType sortType, Integer page, Integer size) {
+        return PRODUCT_LIST_KEY.formatted(brandId, sortType, page, size);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -4,12 +4,12 @@ import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandService;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
-import com.loopers.domain.product.ProductSortType;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,14 +20,17 @@ public class ProductFacade {
     private final ProductService productService;
     private final BrandService brandService;
 
-    public ProductWithBrandInfo getProductDetail(Long productId) {
+    public ProductWithBrandInfo getProductDetail(final Long productId) {
         Product product = productService.getProduct(productId);
         Brand brand = brandService.getBrand(product.getBrandId());
         return ProductWithBrandInfo.from(product, brand);
     }
 
-    public List<ProductWithBrandInfo> getProductList(ProductSortType sortType) {
-        List<Product> products = productService.getProductListWithLock(sortType);
+    public List<ProductWithBrandInfo> getProductList(final ProductSearchCriteria productSearchCriteria) {
+        List<Product> products = productService.getProductList(productSearchCriteria.brandId(),
+                productSearchCriteria.productSortType(),
+                PageRequest.of(productSearchCriteria.page() - 1, productSearchCriteria.size())
+                );
 
         Set<Long> brandIds = products.stream()
                 .map(Product::getBrandId)

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -4,8 +4,10 @@ import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandService;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -17,16 +19,33 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Component
 public class ProductFacade {
+    private static final Duration TTL = Duration.ofMinutes(1);
+
+    private final ProductCacheService productCacheService;
     private final ProductService productService;
     private final BrandService brandService;
 
     public ProductWithBrandInfo getProductDetail(final Long productId) {
+        ProductWithBrandInfo cached = productCacheService.readDetail(productId);
+        if (!Objects.isNull(cached)) {
+            return cached;
+        }
+
         Product product = productService.getProduct(productId);
         Brand brand = brandService.getBrand(product.getBrandId());
-        return ProductWithBrandInfo.from(product, brand);
+        ProductWithBrandInfo result = ProductWithBrandInfo.from(product, brand);
+
+        productCacheService.createOrUpdateDetail(productId, result, TTL);
+
+        return result;
     }
 
     public List<ProductWithBrandInfo> getProductList(final ProductSearchCriteria productSearchCriteria) {
+        List<ProductWithBrandInfo> cached = productCacheService.readList(productSearchCriteria);
+        if (!Objects.isNull(cached)) {
+            return cached;
+        }
+
         List<Product> products = productService.getProductList(productSearchCriteria.brandId(),
                 productSearchCriteria.productSortType(),
                 PageRequest.of(productSearchCriteria.page() - 1, productSearchCriteria.size())
@@ -37,10 +56,12 @@ public class ProductFacade {
                 .collect(Collectors.toSet());
 
         Map<Long, Brand> brandMap = getBrandMapByBrandIds(brandIds);
-
-        return products.stream()
+        List<ProductWithBrandInfo> result = products.stream()
                 .map(product -> ProductWithBrandInfo.from(product, brandMap.get(product.getBrandId())))
                 .toList();
+        productCacheService.createOrUpdateList(productSearchCriteria, result, TTL);
+
+        return result;
     }
 
     private Map<Long, Brand> getBrandMapByBrandIds(final Set<Long> brandIds) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductSearchCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductSearchCriteria.java
@@ -1,0 +1,16 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.ProductSortType;
+import java.util.Objects;
+
+public record ProductSearchCriteria(
+        Long brandId,
+        ProductSortType productSortType,
+        Integer page,
+        Integer size
+) {
+    public ProductSearchCriteria {
+        if (Objects.isNull(page)) page = 1;
+        if (Objects.isNull(size)) size = 20;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -8,11 +8,19 @@ import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Getter
-@Table(name = "products")
+@Table(
+        name = "products",
+        indexes = {
+                @Index(name = "idx_brand_id_created_at", columnList = "brandId, createdAt DESC"),
+                @Index(name = "idx_brand_id_price", columnList = "brandId, price"),
+                @Index(name = "idx_brand_id_like_count", columnList = "brandId, likeCount DESC"),
+        }
+)
 @Entity
 public class Product extends BaseEntity {
 
@@ -25,7 +33,7 @@ public class Product extends BaseEntity {
     @Embedded
     private Stock stock;
 
-    @Column(nullable = false)
+    @Embedded
     private LikeCount likeCount;
 
     @Column(nullable = false)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -2,11 +2,12 @@ package com.loopers.domain.product;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 
 public interface ProductRepository {
     Optional<Product> findByIdWithLock(Long productId);
 
-    List<Product> getProductList(ProductSortType sortType);
+    List<Product> getProductList(Long brandId, ProductSortType sortType, Pageable pageable);
 
     List<Product> findAllByIdInWithLock(List<Long> productIdList);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -4,6 +4,7 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,8 +25,8 @@ public class ProductService {
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[id = " + productId + "] 상품을 찾을 수 없습니다."));
     }
 
-    public List<Product> getProductListWithLock(ProductSortType sortType) {
-        return productRepository.getProductList(sortType);
+    public List<Product> getProductList(final Long brandId, final ProductSortType sortType, final Pageable pageable) {
+        return productRepository.getProductList(brandId, sortType, pageable);
     }
 
     @Transactional

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/LikeCount.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/LikeCount.java
@@ -2,16 +2,22 @@ package com.loopers.domain.product.vo;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode
 @Embeddable
 public class LikeCount {
 
+    @Column(name = "like_count")
     private final int value;
 
-    public LikeCount() { this.value = 0; }
+    public LikeCount() {
+        this.value = 0;
+    }
 
     public LikeCount(int value) {
         if (value < 0) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Stock.java
@@ -2,18 +2,21 @@ package com.loopers.domain.product.vo;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
 @EqualsAndHashCode
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stock {
-    private long quantity;
+    @Column(name = "stock_quantity")
+    private final long quantity;
+
+    public Stock() {
+        quantity = 0;
+    }
 
     public Stock(long quantity) {
         if (quantity < 0) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryRepository.java
@@ -5,9 +5,11 @@ import static com.loopers.domain.product.QProduct.product;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductSortType;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -15,14 +17,24 @@ import org.springframework.stereotype.Component;
 public class ProductQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public List<Product> getProductList(ProductSortType sortType) {
+    public List<Product> getProductList(final Long brandId, final ProductSortType sortType, final Pageable pageable) {
         return queryFactory
                 .selectFrom(product)
+                .where(brandIdEquals(brandId))
                 .orderBy(sortCondition(sortType))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
     }
 
-    private OrderSpecifier<?> sortCondition(ProductSortType sortType) {
+    private BooleanExpression brandIdEquals(Long brandId) {
+        if (brandId == null) {
+            return null;
+        }
+        return product.brandId.eq(brandId);
+    }
+
+    private OrderSpecifier<?> sortCondition(final ProductSortType sortType) {
         if (sortType == ProductSortType.LATEST) {
             return product.createdAt.desc();
         }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.loopers.domain.product.ProductSortType;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -20,8 +21,8 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public List<Product> getProductList(final ProductSortType sortType) {
-        return productQueryRepository.getProductList(sortType);
+    public List<Product> getProductList(final Long brandId, final ProductSortType sortType,  final Pageable pageable) {
+        return productQueryRepository.getProductList(brandId, sortType, pageable);
     }
 
     @Override

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -65,9 +65,10 @@ class ProductFacadeIntegrationTest {
             productJpaRepository.save(Product.create("testA", 1000, new Stock(2), brand.getId()));
             productJpaRepository.save(Product.create("testB", 2000, new Stock(2), brand.getId()));
             ProductSortType productSortType = ProductSortType.LATEST;
+            ProductSearchCriteria productSearchCriteria = new ProductSearchCriteria(1L, productSortType, 1, 20);
 
             // act
-            List<ProductWithBrandInfo> products = productFacade.getProductList(productSortType);
+            List<ProductWithBrandInfo> products = productFacade.getProductList(productSearchCriteria);
 
             assertThat(products).hasSize(2)
                     .extracting(ProductWithBrandInfo::name)
@@ -81,9 +82,10 @@ class ProductFacadeIntegrationTest {
             productJpaRepository.save(Product.create("testA", 1000, new Stock(2), brand.getId()));
             productJpaRepository.save(Product.create("testB", 2000, new Stock(2), brand.getId()));
             ProductSortType productSortType = ProductSortType.PRICE_ASC;
+            ProductSearchCriteria productSearchCriteria = new ProductSearchCriteria(1L, productSortType, 1, 20);
 
             // act
-            List<ProductWithBrandInfo> products = productFacade.getProductList(productSortType);
+            List<ProductWithBrandInfo> products = productFacade.getProductList(productSearchCriteria);
 
             assertThat(products).hasSize(2)
                     .extracting(ProductWithBrandInfo::price)
@@ -99,9 +101,10 @@ class ProductFacadeIntegrationTest {
             testB.likeCountIncrease(30);
             productJpaRepository.save(testB);
             ProductSortType productSortType = ProductSortType.LIKES_DESC;
+            ProductSearchCriteria productSearchCriteria = new ProductSearchCriteria(1L, productSortType, 1, 20);
 
             // act
-            List<ProductWithBrandInfo> products = productFacade.getProductList(productSortType);
+            List<ProductWithBrandInfo> products = productFacade.getProductList(productSearchCriteria);
 
             assertThat(products).hasSize(2)
                     .extracting(ProductWithBrandInfo::name)

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -111,5 +111,29 @@ class ProductFacadeIntegrationTest {
                     .containsExactly("testB", "testA");
         }
 
+        @Test
+        void 상품_리스트_page1_두번째_조회는_DB조회없이_캐시에서_가져온다() {
+            // arrange
+            Brand brand = brandJpaRepository.save(Brand.create("brandTest"));
+            productJpaRepository.save(Product.create("testA", 1000, new Stock(2), brand.getId()));
+            productJpaRepository.save(Product.create("testB", 2000, new Stock(2), brand.getId()));
+
+            ProductSearchCriteria criteria = new ProductSearchCriteria(
+                    brand.getId(), ProductSortType.LATEST, 1, 20
+            );
+
+            List<ProductWithBrandInfo> first = productFacade.getProductList(criteria);
+
+            databaseCleanUp.truncateAllTables();
+            brandJpaRepository.save(Brand.create("brandTest"));
+
+            // act
+            List<ProductWithBrandInfo> second = productFacade.getProductList(criteria);
+
+            // assert
+            assertThat(second).hasSize(2);
+            assertThat(second).extracting(ProductWithBrandInfo::name)
+                    .containsExactlyElementsOf(first.stream().map(ProductWithBrandInfo::name).toList());
+        }
     }
 }

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -37,7 +37,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 
 datasource:
   mysql-jpa:


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->
1. 현재 jpa에서 인덱스를 명시적으로 했는데 
    실무에서는 운영 환경에 ddl-auto를 none으로 설정해서 반영되지 않을 것 같은데
    실무에서는 명시적으로 작성을 하는지 
    아니면 따로 테이블에만 적용하는지가 궁금합니다.

2. 현재 조회 조건이 3개에 대해 각각 복합 인덱스를 3번 설정했는데 이렇게 하는 방식이 맞을까요? 
    지금은 조회 조건이 3개라서 복합 인덱스를 3개 선언했는데
    이런 방식이 최선인지 또는 조회 패턴이나 카디널리티 기준으로 단일/복합 인덱스를 설계하는 것이 더 적절한지 조언 부탁드립니다.

3. 테스트 실행 시 Redis 설정 문제로 인해 docker의 6379 포트를 사용 중일 때만 테스트가 통과하는 이슈가 있습니다.
    Testcontainers로 Redis를 띄우고 있음에도 불구하고
     로컬에서 Redis(6379 포트)가 동작 중일 때만 테스트가 성공하는 문제가 있습니다.
     Testcontainers용 Redis 설정이 제대로 적용되지 않는 것 같은데 혹시 원인을 알 수 있을까요?

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

### 🔖 Index

- [ ]  상품 목록 API에서 brandId 기반 검색, 좋아요 순 정렬 등을 처리했다
- [ ]  조회 필터, 정렬 조건별 유즈케이스를 분석하여 인덱스를 적용하고 전 후 성능비교를 진행했다

### ❤️ Structure

- [ ]  상품 목록/상세 조회 시 좋아요 수를 조회 및 좋아요 순 정렬이 가능하도록 구조 개선을 진행했다
- [ ]  좋아요 적용/해제 진행 시 상품 좋아요 수 또한 정상적으로 동기화되도록 진행하였다

### ⚡ Cache

- [ ]  Redis 캐시를 적용하고 TTL 또는 무효화 전략을 적용했다
- [ ]  캐시 미스 상황에서도 서비스가 정상 동작하도록 처리했다.

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 제품 조회 성능 향상을 위한 캐싱 시스템 도입
  * 브랜드별 제품 필터링 및 페이지네이션 기능 추가
  * 주문 생성 시 제품 정보 자동 갱신

* **Refactor**
  * 제품 조회 로직 최적화 및 데이터베이스 인덱스 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->