### PR TITLE
[volume-5] 인덱스 및 Redis 캐시 적용

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -4,10 +4,13 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
+
 import java.util.TimeZone;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableCaching
 public class CommerceApiApplication {
 
     @PostConstruct

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/ProductLikeQueryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/ProductLikeQueryRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.application.like;
+
+import com.loopers.application.product.ProductLikeSummary;
+import com.loopers.domain.product.ProductSortType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface ProductLikeQueryRepository {
+    Page<ProductLikeSummary> findProductLikes(Long brandId,
+                                              ProductSortType sortType,
+                                              Pageable pageable);
+    Optional<ProductLikeSummary> findProductDetail(Long productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/UserLikeProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/UserLikeProductFacade.java
@@ -22,8 +22,10 @@ public class UserLikeProductFacade {
         UserModel found = userService.getUser(input.userId());
         ProductModel product = productService.getProductDetail(input.productId());
         productService.validateProductDeleteOrStopSelling(product);
-        productLikeService.like(found.getId(), input.productId());
-        product.increaseLikeCount();
+        int resultRow = productLikeService.like(found.getId(), input.productId());
+        if(resultRow == 1) {
+            productService.increaseProductLikeCount(product.getId());
+        }
     }
 
     @Transactional
@@ -31,7 +33,9 @@ public class UserLikeProductFacade {
         UserModel found = userService.getUser(input.userId());
         ProductModel product = productService.getProductDetail(input.productId());
         productService.validateProductDeleteOrStopSelling(product);
-        productLikeService.dislike(found.getId(), product.getId());
-        product.decreaseLikeCount();
+        int resultRow = productLikeService.dislike(found.getId(), product.getId());
+        if(resultRow == 1) {
+            productService.decreaseProductLikeCount(product.getId());
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/UserLikeProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/UserLikeProductFacade.java
@@ -23,6 +23,7 @@ public class UserLikeProductFacade {
         ProductModel product = productService.getProductDetail(input.productId());
         productService.validateProductDeleteOrStopSelling(product);
         productLikeService.like(found.getId(), input.productId());
+        product.increaseLikeCount();
     }
 
     @Transactional
@@ -31,5 +32,6 @@ public class UserLikeProductFacade {
         ProductModel product = productService.getProductDetail(input.productId());
         productService.validateProductDeleteOrStopSelling(product);
         productLikeService.dislike(found.getId(), product.getId());
+        product.decreaseLikeCount();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductLikeSummary.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductLikeSummary.java
@@ -4,9 +4,13 @@ import com.loopers.domain.product.ProductStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.io.Serializable;
+
 @Getter
 @AllArgsConstructor
-public class ProductLikeSummary {
+public class ProductLikeSummary implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private Long productId;
     private String productName;
     private Long brandId;

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductLikeSummary.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductLikeSummary.java
@@ -1,4 +1,4 @@
-package com.loopers.domain.like;
+package com.loopers.application.product;
 
 import com.loopers.domain.product.ProductStatus;
 import lombok.AllArgsConstructor;
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ProductLikeSummaryVO {
+public class ProductLikeSummary {
     private Long productId;
     private String productName;
     private Long brandId;

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -5,6 +5,7 @@ import com.loopers.domain.product.ProductSortType;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -22,8 +23,16 @@ public class ProductQueryService {
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다"));
     }
 
+    @Cacheable(
+            cacheNames = "productLikeSummary",
+            key = "T(String).valueOf(#brandId ?: 'ALL')" +
+                    " + ':' + (#p1 != null ? #p1.name() : 'DEFAULT')" +
+                    " + ':' + (#p2 != null ? #p2.pageNumber : 0)" +
+                    " + ':' + (#p3 != null ? #p3.pageSize : 20)"
+    )
     @Transactional(readOnly = true)
     public Page<ProductLikeSummary> getProductListWithLikeCount(Long brandId, ProductSortType sortType, Pageable pageable) {
         return ProductLikeQuery.findProductLikes(brandId, sortType, pageable);
     }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -2,7 +2,6 @@ package com.loopers.application.product;
 
 import com.loopers.application.like.ProductLikeQueryRepository;
 import com.loopers.domain.product.ProductSortType;
-import com.loopers.infrastructure.productLike.ProductLikeQueryImpl;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -1,0 +1,29 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.ProductSortType;
+import com.loopers.infrastructure.productLike.ProductLikeQueryRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductQueryService {
+    private final ProductLikeQueryRepository productLikeQueryRepository;
+
+
+    @Transactional(readOnly = true)
+    public ProductLikeSummary getProductLikeSummary(Long productId) {
+        return productLikeQueryRepository.findProductDetail(productId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다"));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ProductLikeSummary> getProductListWithLikeCount(Long brandId, ProductSortType sortType, Pageable pageable) {
+        return productLikeQueryRepository.findProductLikes(brandId, sortType, pageable);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -1,7 +1,8 @@
 package com.loopers.application.product;
 
+import com.loopers.application.like.ProductLikeQueryRepository;
 import com.loopers.domain.product.ProductSortType;
-import com.loopers.infrastructure.productLike.ProductLikeQueryRepository;
+import com.loopers.infrastructure.productLike.ProductLikeQueryImpl;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -13,17 +14,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ProductQueryService {
-    private final ProductLikeQueryRepository productLikeQueryRepository;
+    private final ProductLikeQueryRepository ProductLikeQuery;
 
 
     @Transactional(readOnly = true)
     public ProductLikeSummary getProductLikeSummary(Long productId) {
-        return productLikeQueryRepository.findProductDetail(productId)
+        return ProductLikeQuery.findProductDetail(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다"));
     }
 
     @Transactional(readOnly = true)
     public Page<ProductLikeSummary> getProductListWithLikeCount(Long brandId, ProductSortType sortType, Pageable pageable) {
-        return productLikeQueryRepository.findProductLikes(brandId, sortType, pageable);
+        return ProductLikeQuery.findProductLikes(brandId, sortType, pageable);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeRepository.java
@@ -9,4 +9,5 @@ public interface ProductLikeRepository {
     void delete(Long userPkId, Long productId);
     int insertIgnore(Long userPkId, Long productId);
     int countByProductId(Long productId);
+    int deleteByUserAndProduct(Long userId, Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeService.java
@@ -15,8 +15,8 @@ public class ProductLikeService {
     }
 
     @Transactional
-    public void dislike(Long userPkId, Long productId) {
-        productLikeRepository.delete(userPkId, productId);
+    public int dislike(Long userPkId, Long productId) {
+        return productLikeRepository.deleteByUserAndProduct(userPkId, productId);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeService.java
@@ -1,12 +1,6 @@
 package com.loopers.domain.like;
 
-import com.loopers.domain.product.ProductSortType;
-import com.loopers.infrastructure.productLike.ProductLikeQueryRepository;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class ProductLikeService {
     private final ProductLikeRepository productLikeRepository;
-    private final ProductLikeQueryRepository productLikeQueryRepository;
 
     @Transactional
     public int like(Long userPkId, Long productId) {
@@ -24,17 +17,6 @@ public class ProductLikeService {
     @Transactional
     public void dislike(Long userPkId, Long productId) {
         productLikeRepository.delete(userPkId, productId);
-    }
-
-    @Transactional(readOnly = true)
-    public ProductLikeSummaryVO getProductLikeSummary(Long productId) {
-        return productLikeQueryRepository.findProductDetail(productId)
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다"));
-    }
-
-    @Transactional(readOnly = true)
-    public Page<ProductLikeSummaryVO> productLikeSummaryVOPage(ProductSortType sortType, Pageable pageable) {
-        return productLikeQueryRepository.findProductLikes(sortType, pageable);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
@@ -34,6 +34,9 @@ public class ProductModel extends BaseEntity {
     @JoinColumn(name = "brand_id", nullable = false)
     private BrandModel brand;
 
+    @Column(name = "like_count")
+    private Integer likeCount;
+
     protected ProductModel() {}
 
     @Builder
@@ -75,6 +78,15 @@ public class ProductModel extends BaseEntity {
 
     public boolean isStatusOnDeletedOrStopSelling() {
         return status == ProductStatus.DELETE || status == ProductStatus.STOP_SELLING;
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+    public void decreaseLikeCount() {
+        if(this.likeCount > 0) {
+            this.likeCount--;
+        }
     }
 
     private void validateProductCategory(String category) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
@@ -36,7 +36,7 @@ public class ProductModel extends BaseEntity {
     private BrandModel brand;
 
     @Column(name = "like_count")
-    private int likeCount;
+    private long likeCount;
 
     protected ProductModel() {}
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
@@ -9,7 +9,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Setter

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
@@ -9,6 +9,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Setter
@@ -35,7 +36,7 @@ public class ProductModel extends BaseEntity {
     private BrandModel brand;
 
     @Column(name = "like_count")
-    private Integer likeCount;
+    private int likeCount;
 
     protected ProductModel() {}
 
@@ -59,6 +60,7 @@ public class ProductModel extends BaseEntity {
         this.stock = stock;
         this.status = status;
         this.brand = brand;
+        this.likeCount = 0;
     }
 
     public void decreaseStock(Integer stock) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -13,4 +13,6 @@ public interface ProductRepository {
     Optional<ProductModel> findByName(String name);
     boolean existsById(Long id);
     ProductModel save(ProductModel product);
+    int increaseLikeCount(Long productId);
+    int decreaseLikeCount(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -85,6 +85,16 @@ public class ProductService {
         return product.getPrice() * quantity;
     }
 
+    @Transactional
+    public int increaseProductLikeCount(Long productId) {
+        return productRepository.increaseLikeCount(productId);
+    }
+
+    @Transactional
+    public int decreaseProductLikeCount(Long productId) {
+        return productRepository.decreaseLikeCount(productId);
+    }
+
 
     public void validateProductDeleteOrStopSelling(ProductModel product) {
         if(product.isStatusOnDeletedOrStopSelling())

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/db/LargeProductsDataInitializer.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/db/LargeProductsDataInitializer.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.db;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
@@ -18,8 +19,18 @@ import java.sql.Connection;
 public class LargeProductsDataInitializer implements CommandLineRunner {
     private final DataSource dataSource;
 
+    @Value("${spring.jpa.hibernate.ddl-auto:none}")
+    private String ddlAuto;
+
     @Override
     public void run(String... args) throws Exception {
+
+        if(ddlAuto.equals("none")) {
+            log.info("[LargeProductsDataInitializer] skipped because ddl-auto is none");
+            return;
+        }
+
+
         log.info("[LargeProductsDataInitializer] start");
         try (Connection conn = dataSource.getConnection()) {
             ScriptUtils.executeSqlScript(

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/db/LargeProductsDataInitializer.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/db/LargeProductsDataInitializer.java
@@ -32,12 +32,12 @@ public class LargeProductsDataInitializer implements CommandLineRunner {
 
 
         log.info("[LargeProductsDataInitializer] start");
-        try (Connection conn = dataSource.getConnection()) {
-            ScriptUtils.executeSqlScript(
-                    conn,
-                    new ClassPathResource("db/fixtures/large-product-data.sql")
-            );
-        }
+//        try (Connection conn = dataSource.getConnection()) {
+//            ScriptUtils.executeSqlScript(
+//                    conn,
+//                    new ClassPathResource("db/fixtures/large-product-data.sql")
+//            );
+//        }
         log.info("[LargeProductsDataInitializer] done");
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/db/LargeProductsDataInitializer.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/db/LargeProductsDataInitializer.java
@@ -1,0 +1,32 @@
+package com.loopers.infrastructure.db;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+
+@Slf4j
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+public class LargeProductsDataInitializer implements CommandLineRunner {
+    private final DataSource dataSource;
+
+    @Override
+    public void run(String... args) throws Exception {
+        log.info("[LargeProductsDataInitializer] start");
+        try (Connection conn = dataSource.getConnection()) {
+            ScriptUtils.executeSqlScript(
+                    conn,
+                    new ClassPathResource("db/fixtures/large-product-data.sql")
+            );
+        }
+        log.info("[LargeProductsDataInitializer] done");
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,4 +21,12 @@ public interface ProductJpaRepository extends JpaRepository<ProductModel, Long> 
     Optional<ProductModel> findByIdForUpdate(@Param("id") Long id);
     Optional<ProductModel> findById(Long id);
     Optional<ProductModel> findByName(String name);
+
+    @Modifying
+    @Query("update ProductModel p set p.likeCount = p.likeCount + 1 where p.id = :productId")
+    int increaseLikeCount(@Param("productId") Long productId);
+
+    @Modifying
+    @Query("update ProductModel p set p.likeCount = p.likeCount - 1 where p.id = :productId")
+    int decreaseLikeCount(@Param("productId") Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -49,4 +49,15 @@ public class ProductRepositoryImpl implements ProductRepository {
     public Optional<ProductModel> findByIdForUpdate(Long id) {
         return productJpaRepository.findByIdForUpdate(id);
     }
+
+
+    @Override
+    public int increaseLikeCount(Long productId) {
+        return productJpaRepository.increaseLikeCount(productId);
+    }
+
+    @Override
+    public int decreaseLikeCount(Long productId) {
+        return productJpaRepository.decreaseLikeCount(productId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeJpaRepository.java
@@ -22,4 +22,8 @@ public interface ProductLikeJpaRepository extends JpaRepository<ProductLikeModel
     @Query(value = "INSERT IGNORE INTO product_like(user_id, product_id) VALUES (:userId, :productId)",
             nativeQuery = true)
     int insertIgnore(@Param("userId") Long userPkId, @Param("productId") Long productId);
+
+    @Modifying
+    @Query("delete from ProductLikeModel pl where pl.user.id = :userPkId and pl.product.id = :productId")
+    int deleteByUserAndProduct(@Param("userPkId") Long userPkId, @Param("productId") Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeQueryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeQueryImpl.java
@@ -1,5 +1,6 @@
 package com.loopers.infrastructure.productLike;
 
+import com.loopers.application.like.ProductLikeQueryRepository;
 import com.loopers.application.product.ProductLikeSummary;
 import com.loopers.domain.like.QProductLikeModel;
 import com.loopers.domain.product.ProductSortType;
@@ -19,7 +20,7 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class ProductLikeQueryRepository {
+public class ProductLikeQueryImpl implements ProductLikeQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     public Page<ProductLikeSummary> findProductLikes(Long brandId,

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeQueryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeQueryRepository.java
@@ -114,6 +114,8 @@ public class ProductLikeQueryRepository {
         return switch(sortType) {
             case LIKE_ASC -> productLike.id.count().asc();
             case LIKE_DESC -> productLike.id.count().desc();
+            case PRICE_ASC -> productLike.product.price.asc();
+            case PRICE_DESC -> productLike.product.price.desc();
             default -> productLike.id.count().desc();
         };
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeQueryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeQueryRepository.java
@@ -1,11 +1,12 @@
 package com.loopers.infrastructure.productLike;
 
-import com.loopers.domain.like.ProductLikeSummaryVO;
+import com.loopers.application.product.ProductLikeSummary;
 import com.loopers.domain.like.QProductLikeModel;
 import com.loopers.domain.product.ProductSortType;
 import com.loopers.domain.product.QProductModel;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,23 +22,42 @@ import java.util.Optional;
 public class ProductLikeQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public Page<ProductLikeSummaryVO> findProductLikes(ProductSortType sortType,
-                                                       Pageable pageable) {
+    public Page<ProductLikeSummary> findProductLikes(Long brandId,
+                                                     ProductSortType sortType,
+                                                     Pageable pageable) {
 
         QProductModel product = QProductModel.productModel;
         QProductLikeModel productLike = QProductLikeModel.productLikeModel;
 
-        JPAQuery<ProductLikeSummaryVO> query = queryFactory
+        BooleanBuilder condition = new BooleanBuilder();
+        if(brandId != null) {
+            condition.and(product.brand.id.eq(brandId));
+        }
+
+        Long total = queryFactory.select(product.id.countDistinct())
+                .from(product)
+                .leftJoin(productLike).on(productLike.product.eq(product))
+                .where(condition)
+                .fetchOne();
+
+        if (total == null || total == 0) {
+            return Page.empty(pageable);
+        }
+
+        List<ProductLikeSummary> content = queryFactory
                 .select(Projections.constructor(
-                        ProductLikeSummaryVO.class,
+                        ProductLikeSummary.class,
                         product.id,
                         product.name,
+                        product.brand.id,
+                        product.brand.name,
                         product.price,
                         product.status,
-                        productLike.id.count()   // likeCount 집계
+                        productLike.id.count()  // likeCount
                 ))
                 .from(product)
                 .leftJoin(productLike).on(productLike.product.eq(product))
+                .where(condition)
                 .groupBy(
                         product.id,
                         product.name,
@@ -45,25 +65,21 @@ public class ProductLikeQueryRepository {
                         product.brand.name,
                         product.price,
                         product.status
-                );
-
-        applySort(sortType, query, product, productLike);
-
-        List<ProductLikeSummaryVO> content = query
+                )
+                .orderBy(applySort(sortType, productLike))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
-
-        return new PageImpl<>(content, pageable, content.size());
+        return new PageImpl<>(content, pageable, total);
     }
 
-    public Optional<ProductLikeSummaryVO> findProductDetail(Long productId) {
+    public Optional<ProductLikeSummary> findProductDetail(Long productId) {
         QProductModel product = QProductModel.productModel;
         QProductLikeModel productLike = QProductLikeModel.productLikeModel;
 
-        ProductLikeSummaryVO result = queryFactory
+        ProductLikeSummary result = queryFactory
                 .select(Projections.constructor(
-                        ProductLikeSummaryVO.class,
+                        ProductLikeSummary.class,
                         product.id,
                         product.name,
                         product.brand.id,
@@ -90,17 +106,16 @@ public class ProductLikeQueryRepository {
         return Optional.ofNullable(result);
     }
 
-    private void applySort(ProductSortType sortType, JPAQuery<?> query, QProductModel product, QProductLikeModel productLike) {
+    private OrderSpecifier<?> applySort(ProductSortType sortType, QProductLikeModel productLike) {
         if (sortType == null || sortType == ProductSortType.DEFAULT) {
-            query.orderBy(productLike.id.count().desc(), productLike.id.asc());
-            return;
+            return productLike.id.count().desc();
         }
 
-        switch(sortType) {
-            case LIKE_ASC -> query.orderBy(productLike.id.count().asc(), productLike.id.asc());
-            case LIKE_DESC -> query.orderBy(productLike.id.count().desc(), productLike.id.asc());
-            default -> query.orderBy(productLike.id.count().desc(), productLike.id.asc());
-        }
+        return switch(sortType) {
+            case LIKE_ASC -> productLike.id.count().asc();
+            case LIKE_DESC -> productLike.id.count().desc();
+            default -> productLike.id.count().desc();
+        };
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeQueryV2Impl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeQueryV2Impl.java
@@ -1,0 +1,102 @@
+package com.loopers.infrastructure.productLike;
+
+import com.loopers.application.like.ProductLikeQueryRepository;
+import com.loopers.application.product.ProductLikeSummary;
+import com.loopers.domain.product.ProductSortType;
+import com.loopers.domain.product.QProductModel;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Primary
+@Component
+@RequiredArgsConstructor
+public class ProductLikeQueryV2Impl implements ProductLikeQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ProductLikeSummary> findProductLikes(Long brandId, ProductSortType sortType, Pageable pageable) {
+        QProductModel product = QProductModel.productModel;
+
+        BooleanBuilder condition = new BooleanBuilder();
+        if(brandId != null) {
+            condition.and(product.brand.id.eq(brandId));
+        }
+
+        Long total = queryFactory.select(product.id.countDistinct())
+                .from(product)
+                .where(condition)
+                .fetchOne();
+
+        if (total == null || total == 0) {
+            return Page.empty(pageable);
+        }
+
+        List<ProductLikeSummary> content = queryFactory
+                .select(Projections.constructor(
+                        ProductLikeSummary.class,
+                        product.id,
+                        product.name,
+                        product.brand.id,
+                        product.brand.name,
+                        product.price,
+                        product.status,
+                        product.likeCount
+                ))
+                .from(product)
+                .where(condition)
+                .orderBy(applySort(sortType, product))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Optional<ProductLikeSummary> findProductDetail(Long productId) {
+        QProductModel product = QProductModel.productModel;
+
+        ProductLikeSummary result = queryFactory
+                .select(Projections.constructor(
+                        ProductLikeSummary.class,
+                        product.id,
+                        product.name,
+                        product.brand.id,
+                        product.brand.name,
+                        product.price,
+                        product.status,
+                        product.likeCount
+                ))
+                .from(product)
+                .where(
+                        product.id.eq(productId)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    private OrderSpecifier<?> applySort(ProductSortType sortType, QProductModel product) {
+        if (sortType == null || sortType == ProductSortType.DEFAULT) {
+            return product.likeCount.desc();
+        }
+
+        return switch(sortType) {
+            case LIKE_ASC -> product.likeCount.asc();
+            case LIKE_DESC -> product.likeCount.desc();
+            case PRICE_ASC -> product.price.asc();
+            case PRICE_DESC -> product.price.desc();
+            default -> product.likeCount.desc();
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/productLike/ProductLikeRepositoryImpl.java
@@ -42,4 +42,9 @@ public class ProductLikeRepositoryImpl implements ProductLikeRepository {
     public int countByProductId(Long productId) {
         return productLikeJpaRepository.countByProductId(productId);
     }
+
+    @Override
+    public int deleteByUserAndProduct(Long userId, Long productId) {
+        return productLikeJpaRepository.deleteByUserAndProduct(userId, productId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -12,7 +12,7 @@ import org.springframework.data.domain.Pageable;
 public interface ProductV1ApiSpec {
     @Operation(
             summary = "상품 목록 조회",
-            description = "OrderV1Dto.OrderRequest 포맷으로 선조회를 처리합니다."
+            description = "RequestParams 포맷으로 상품 목록 조회를 처리합니다."
     )
     ApiResponse<ProductV1Dto.ProductListResponse<ProductLikeSummary>>  getProducts(
             @Schema(name="", description = "상품 전체 목록 조회 파라미터")
@@ -20,4 +20,14 @@ public interface ProductV1ApiSpec {
             ProductSortType sortType,
             Pageable pageable
     );
+
+    @Operation(
+            summary = "상품 조회",
+            description = "PathVariable로 productId를 받아 상품 조회를 처리합니다.."
+    )
+    ApiResponse<ProductV1Dto.ProductDetailResponse<ProductLikeSummary>>  getProductDetail(
+            @Schema(name="", description = "상품 전체 목록 조회 파라미터")
+            Long productId
+    );
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -1,0 +1,23 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.ProductLikeSummary;
+import com.loopers.domain.product.ProductSortType;
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+
+@Tag(name = "상품 관련 V1 API", description = "상품 API")
+public interface ProductV1ApiSpec {
+    @Operation(
+            summary = "상품 목록 조회",
+            description = "OrderV1Dto.OrderRequest 포맷으로 선조회를 처리합니다."
+    )
+    ApiResponse<ProductV1Dto.ProductListResponse<ProductLikeSummary>>  getProducts(
+            @Schema(name="", description = "상품 전체 목록 조회 파라미터")
+            Long brandId,
+            ProductSortType sortType,
+            Pageable pageable
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class ProductV1Controller implements ProductV1ApiSpec{
     private final ProductQueryService productQueryService;
 
+    @Override
     @GetMapping
     public ApiResponse<ProductV1Dto.ProductListResponse<ProductLikeSummary>> getProducts(@RequestParam(required = false, name = "brandId")
                                                                                              Long brandId,
@@ -24,5 +25,13 @@ public class ProductV1Controller implements ProductV1ApiSpec{
                                             @PageableDefault(size = 20) Pageable pageable) {
         Page<ProductLikeSummary> page = productQueryService.getProductListWithLikeCount(brandId, sortType, pageable);
         return ApiResponse.success(ProductV1Dto.ProductListResponse.of(page, page.stream().toList()));
+    }
+
+    @Override
+    @GetMapping("/{productId}")
+    public ApiResponse<ProductV1Dto.ProductDetailResponse<ProductLikeSummary>> getProductDetail(@PathVariable("productId") Long productId) {
+        ProductLikeSummary productLikeSummary = productQueryService.getProductLikeSummary(productId);
+
+        return ApiResponse.success(ProductV1Dto.ProductDetailResponse.of(productLikeSummary));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.ProductQueryService;
+import com.loopers.application.product.ProductLikeSummary;
+import com.loopers.domain.product.ProductSortType;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/products")
+public class ProductV1Controller implements ProductV1ApiSpec{
+    private final ProductQueryService productQueryService;
+
+    @GetMapping
+    public ApiResponse<ProductV1Dto.ProductListResponse<ProductLikeSummary>> getProducts(@RequestParam(required = false, name = "brandId")
+                                                                                             Long brandId,
+                                            @RequestParam(defaultValue = "DEFAULT", name = "sortType") ProductSortType sortType,
+                                            @PageableDefault(size = 20) Pageable pageable) {
+        Page<ProductLikeSummary> page = productQueryService.getProductListWithLikeCount(brandId, sortType, pageable);
+        return ApiResponse.success(ProductV1Dto.ProductListResponse.of(page, page.stream().toList()));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -26,4 +26,12 @@ public class ProductV1Dto {
         }
 
     }
+
+    public record ProductDetailResponse<T>(
+            T content
+    ){
+        static <T> ProductDetailResponse<T> of(T content) {
+            return new ProductDetailResponse<>(content);
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.api.product;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public class ProductV1Dto {
+
+    public record ProductListResponse<T>(
+            List<T> content,
+            int page,          // 현재 페이지 번호
+            int size,          // 페이지 크기
+            long totalElements,
+            int totalPages,
+            boolean last
+    ) {
+        public static <T> ProductListResponse<T> of(Page<T> page, List<T> content) {
+            return new ProductListResponse<>(
+                    content,
+                    page.getNumber(),
+                    page.getSize(),
+                    page.getTotalElements(),
+                    page.getTotalPages(),
+                    page.isLast()
+            );
+        }
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/cache/CacheConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/cache/CacheConfig.java
@@ -1,0 +1,49 @@
+package com.loopers.support.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class CacheConfig {
+
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    @Bean
+    public RedisCacheManager redisCacheManager() {
+        // 공통 기본 설정
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new JdkSerializationRedisSerializer())
+                )
+                .disableCachingNullValues();
+
+        // 캐시별 개별 설정
+        Map<String, RedisCacheConfiguration> cacheConfigs = new HashMap<>();
+
+        // 상품 목록 + 좋아요 정렬 캐시: TTL 5분
+        cacheConfigs.put(
+                "productLikeSummary",
+                defaultConfig.entryTtl(Duration.ofMinutes(5))
+        );
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(cacheConfigs)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/resources/db/fixtures/large-product-data.sql
+++ b/apps/commerce-api/src/main/resources/db/fixtures/large-product-data.sql
@@ -68,7 +68,7 @@ WHERE n <= 10000;
 
 
 -- 4) Product 1,000,000 개 생성
-INSERT INTO product (name, category, price, status, brand_id, created_at, updated_at)
+INSERT INTO product (name, category, stock, price, status, brand_id, created_at, updated_at)
 SELECT
     CONCAT('Product_', n) AS name,
     CASE
@@ -78,6 +78,7 @@ SELECT
         WHEN RAND() < 0.8 THEN '가전'
         ELSE '기타'
         END AS category,
+    FLOOR(RAND() * 100000)             AS stock,
     FLOOR(RAND() * 100000)             AS price,
     CASE WHEN n % 20 = 0 THEN 'STOP_SELLING' ELSE 'ON_SALE' END AS status,
     ((n - 1) % 10000) + 1              AS brand_id,

--- a/apps/commerce-api/src/main/resources/db/fixtures/large-product-data.sql
+++ b/apps/commerce-api/src/main/resources/db/fixtures/large-product-data.sql
@@ -1,0 +1,80 @@
+-- SET SESSION cte_max_recursion_depth = 100000;
+
+-- 1) numbers 테이블 (유틸)
+CREATE TABLE IF NOT EXISTS numbers (
+    n INT PRIMARY KEY
+);
+INSERT IGNORE INTO numbers (n)
+SELECT
+    a.n + 10 * b.n + 100 * c.n + 1000 * d.n + 1 AS n
+FROM
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) a
+        CROSS JOIN
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) b
+        CROSS JOIN
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) c
+        CROSS JOIN
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d
+WHERE
+    a.n + 10 * b.n + 100 * c.n + 1000 * d.n < 100000;
+
+-- 2) Users 10,000 명 생성
+INSERT INTO users (user_id, user_name, description, email, birth_date, gender, point, created_at, updated_at)
+SELECT
+    CONCAT('User_', n) AS user_id,
+    CONCAT('User_', n) AS user_name,
+    CONCAT('User_Descrption_', n) AS description,
+    CONCAT('user_', n, '@gmail.com') AS email,
+    CONCAT('1997-09-28') AS birth_date,
+    CASE
+        WHEN RAND() < 0.5 THEN 'M'
+        ELSE 'W'
+    END AS gender,
+    FLOOR(RAND() * 100000) AS point,
+    NOW() - INTERVAL (n % 365) DAY AS created_at,
+    NOW() - INTERVAL (n % 365) DAY AS updated_at
+FROM numbers
+WHERE n <= 10000;
+
+-- 3) brand 생성 (1~100)
+INSERT INTO brand (name, description, status, created_at, updated_at)
+SELECT
+    CONCAT('Brand_', n),
+    CONCAT('Description_', n),
+    'REGISTERED',
+    NOW() - INTERVAL (n % 365) DAY AS created_at,
+    NOW() - INTERVAL (n % 365) DAY AS updated_at
+FROM numbers
+WHERE n <= 100;
+
+-- 4) product 100,000개 생성
+INSERT INTO product (name, category, price, status, brand_id, created_at, updated_at)
+SELECT
+    CONCAT('Product_', n) AS name,
+    CASE
+        WHEN RAND() < 0.2 THEN '옷'
+        WHEN RAND() < 0.4 THEN '신발'
+        WHEN RAND() < 0.6 THEN '모자'
+        WHEN RAND() < 0.8 THEN '가전'
+        ELSE '기타'
+        END AS category,
+    FLOOR(RAND() * 100000)    AS price,
+    CASE WHEN n % 20 = 0 THEN 'STOP_SELLING' ELSE 'ON_SALE' END AS status,
+    ((n - 1) % 100) + 1   AS brand_id,
+    NOW() - INTERVAL (n % 365) DAY AS created_at,
+    NOW() - INTERVAL (n % 365) DAY AS updated_at
+FROM numbers
+WHERE n <= 100000;
+
+-- 5) product_like 300,000개 생성
+INSERT INTO product_like (user_id, product_id, created_at)
+SELECT
+    ((n - 1) % 10000) + 1  AS user_id,
+    ((n - 1) % 150) + 1 AS product_id,
+    NOW() - INTERVAL (n % 180) DAY AS created_at
+FROM numbers
+WHERE n <= 300000;

--- a/apps/commerce-api/src/main/resources/db/fixtures/large-product-data.sql
+++ b/apps/commerce-api/src/main/resources/db/fixtures/large-product-data.sql
@@ -1,12 +1,17 @@
--- SET SESSION cte_max_recursion_depth = 100000;
-
--- 1) numbers 테이블 (유틸)
+-- 1) numbers 테이블 (1 ~ 1,000,000까지)
 CREATE TABLE IF NOT EXISTS numbers (
     n INT PRIMARY KEY
 );
+
 INSERT IGNORE INTO numbers (n)
 SELECT
-    a.n + 10 * b.n + 100 * c.n + 1000 * d.n + 1 AS n
+    a.n
+        + 10      * b.n
+        + 100     * c.n
+        + 1000    * d.n
+        + 10000   * e.n
+        + 100000  * f.n
+        + 1       AS n
 FROM
     (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
      UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) a
@@ -19,28 +24,38 @@ FROM
         CROSS JOIN
     (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
      UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d
+        CROSS JOIN
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) e
+        CROSS JOIN
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) f
 WHERE
-    a.n + 10 * b.n + 100 * c.n + 1000 * d.n < 100000;
+    a.n
+        + 10      * b.n
+        + 100     * c.n
+        + 1000    * d.n
+        + 10000   * e.n
+        + 100000  * f.n < 1000000;
 
--- 2) Users 10,000 명 생성
+
+-- 2) Users 100,000 명 생성
 INSERT INTO users (user_id, user_name, description, email, birth_date, gender, point, created_at, updated_at)
 SELECT
-    CONCAT('User_', n) AS user_id,
-    CONCAT('User_', n) AS user_name,
-    CONCAT('User_Descrption_', n) AS description,
-    CONCAT('user_', n, '@gmail.com') AS email,
-    CONCAT('1997-09-28') AS birth_date,
-    CASE
-        WHEN RAND() < 0.5 THEN 'M'
-        ELSE 'W'
-    END AS gender,
-    FLOOR(RAND() * 100000) AS point,
-    NOW() - INTERVAL (n % 365) DAY AS created_at,
-    NOW() - INTERVAL (n % 365) DAY AS updated_at
+    CONCAT('User_', n)                  AS user_id,
+    CONCAT('User_', n)                  AS user_name,
+    CONCAT('User_Descrption_', n)       AS description,
+    CONCAT('user_', n, '@gmail.com')    AS email,
+    '1997-09-28'                        AS birth_date,
+    CASE WHEN RAND() < 0.5 THEN 'M' ELSE 'W' END AS gender,
+    FLOOR(RAND() * 100000)              AS point,
+    NOW() - INTERVAL (n % 365) DAY      AS created_at,
+    NOW() - INTERVAL (n % 365) DAY      AS updated_at
 FROM numbers
-WHERE n <= 10000;
+WHERE n <= 100000;   -- ✅ 10만명
 
--- 3) brand 생성 (1~100)
+
+-- 3) Brand 10,000 개 생성
 INSERT INTO brand (name, description, status, created_at, updated_at)
 SELECT
     CONCAT('Brand_', n),
@@ -49,9 +64,10 @@ SELECT
     NOW() - INTERVAL (n % 365) DAY AS created_at,
     NOW() - INTERVAL (n % 365) DAY AS updated_at
 FROM numbers
-WHERE n <= 100;
+WHERE n <= 10000;
 
--- 4) product 100,000개 생성
+
+-- 4) Product 1,000,000 개 생성
 INSERT INTO product (name, category, price, status, brand_id, created_at, updated_at)
 SELECT
     CONCAT('Product_', n) AS name,
@@ -62,19 +78,42 @@ SELECT
         WHEN RAND() < 0.8 THEN '가전'
         ELSE '기타'
         END AS category,
-    FLOOR(RAND() * 100000)    AS price,
+    FLOOR(RAND() * 100000)             AS price,
     CASE WHEN n % 20 = 0 THEN 'STOP_SELLING' ELSE 'ON_SALE' END AS status,
-    ((n - 1) % 100) + 1   AS brand_id,
-    NOW() - INTERVAL (n % 365) DAY AS created_at,
-    NOW() - INTERVAL (n % 365) DAY AS updated_at
+    ((n - 1) % 10000) + 1              AS brand_id,
+    NOW() - INTERVAL (n % 365) DAY     AS created_at,
+    NOW() - INTERVAL (n % 365) DAY     AS updated_at
 FROM numbers
-WHERE n <= 100000;
+WHERE n <= 1000000;  -- ✅ 100만개
 
--- 5) product_like 300,000개 생성
-INSERT INTO product_like (user_id, product_id, created_at)
+
+-- 5) Product Like 5,000,000 개 생성
+-- numbers(1~1,000,000) × 5 해서 500만개
+--SET @top_hot := 100;         -- 최상위 상품 100개
+--SET @popular_max := 10000;   -- 그 다음 인기 상품 1만개
+--SET @total_products := 1000000;
+
+INSERT IGNORE INTO product_like (user_id, product_id, created_at)
 SELECT
-    ((n - 1) % 10000) + 1  AS user_id,
-    ((n - 1) % 150) + 1 AS product_id,
-    NOW() - INTERVAL (n % 180) DAY AS created_at
-FROM numbers
-WHERE n <= 300000;
+    ((n.n - 1) % 100000) + 1 AS user_id,
+    CASE
+    WHEN RAND() < 0.4 THEN
+    -- 최상위 100개에 40%
+    FLOOR(RAND() * 100) + 1
+    WHEN RAND() < 0.8 THEN
+    -- 다음 1만개(101~10000)에 40%
+    FLOOR(RAND() * (10000 - 100)) + (100 + 1)
+    ELSE
+    -- 나머지에 20%
+    FLOOR(RAND() * (1000000 - 10000)) + (10000 + 1)
+END AS product_id,
+    NOW() - INTERVAL (n.n % 180) DAY AS created_at
+FROM numbers n
+JOIN (
+    SELECT 1 AS k UNION ALL
+    SELECT 2 UNION ALL
+    SELECT 3 UNION ALL
+    SELECT 4 UNION ALL
+    SELECT 5
+) x ON 1 = 1
+WHERE n.n <= 1000000;

--- a/apps/commerce-api/src/test/java/com/loopers/application/ProductQueryServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ProductQueryServiceTest.java
@@ -1,0 +1,142 @@
+package com.loopers.application;
+
+import com.loopers.application.product.ProductQueryService;
+import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.brand.BrandStatus;
+import com.loopers.domain.like.ProductLikeService;
+import com.loopers.application.product.ProductLikeSummary;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductSortType;
+import com.loopers.domain.product.ProductStatus;
+import com.loopers.domain.user.UserModel;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class ProductQueryServiceTest {
+    @Autowired
+    private ProductQueryService productQueryService;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private ProductLikeService productLikeService;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @DisplayName("브랜드ID로 필터 및 좋아요 수 집계가 올바로 동작한다")
+    void findProductLikes_withBrandFilter() {
+        // given
+        BrandModel brand = brandRepository.save(
+                new BrandModel("브랜드A", "설명", BrandStatus.REGISTERED)
+        );
+        ProductModel p1 = productRepository.save(
+                new ProductModel("상품1", "카테고리", 10_000, 100, ProductStatus.ON_SALE, brand)
+        );
+        ProductModel p2 = productRepository.save(
+                new ProductModel("상품2", "카테고리", 20_000, 100, ProductStatus.ON_SALE, brand)
+        );
+
+        UserModel u1 = userRepository.save(new UserModel("user1", "u1", "유저1", "u1@test.com", "1997-01-01", "M", 100_000));
+        UserModel u2 = userRepository.save(new UserModel("user2", "u2", "유저2", "u2@test.com", "1997-01-01", "M", 100_000));
+        UserModel u3 = userRepository.save(new UserModel("user3", "u3", "유저3", "u3@test.com", "1997-01-01", "M", 100_000));
+
+        productLikeService.like(u1.getId(), p1.getId());
+        productLikeService.like(u2.getId(), p1.getId());
+        productLikeService.like(u3.getId(), p2.getId());
+
+        // when
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<ProductLikeSummary> page = productQueryService.getProductListWithLikeCount(
+                brand.getId(),
+                ProductSortType.LIKE_DESC,
+                pageable
+        );
+
+        // then
+        assertThat(page.getContent()).hasSize(2);
+
+        ProductLikeSummary first = page.getContent().get(0);
+        ProductLikeSummary second = page.getContent().get(1);
+
+        // 정렬: 좋아요 수 DESC 이므로 p1(2개) 먼저
+        assertThat(first.getProductId()).isEqualTo(p1.getId());
+        assertThat(first.getLikeCount()).isEqualTo(2L);
+
+        assertThat(second.getProductId()).isEqualTo(p2.getId());
+        assertThat(second.getLikeCount()).isEqualTo(1L);
+
+        // groupBy에 brandId / brandName, price, status까지 들어간 게 잘 매핑되는지도 확인
+        assertThat(first.getBrandId()).isEqualTo(brand.getId());
+        assertThat(first.getBrandName()).isEqualTo(brand.getName());
+        assertThat(first.getPrice()).isEqualTo(p1.getPrice());
+        assertThat(first.getStatus()).isEqualTo(p1.getStatus());
+    }
+
+    @Test
+    @DisplayName("상품 좋아요가 한 건도 없는 상품은 좋아요 개수가 0으로 조회된다")
+    void findProductLikes_withBrandFilterButNoLikes() {
+        // given
+        BrandModel brand = brandRepository.save(
+                new BrandModel("브랜드A", "설명", BrandStatus.REGISTERED)
+        );
+        ProductModel p1 = productRepository.save(
+                new ProductModel("상품1", "카테고리", 10_000, 100, ProductStatus.ON_SALE, brand)
+        );
+        ProductModel p2 = productRepository.save(
+                new ProductModel("상품2", "카테고리", 20_000, 100, ProductStatus.ON_SALE, brand)
+        );
+
+        UserModel u1 = userRepository.save(new UserModel("user1", "u1", "유저1", "u1@test.com", "1997-01-01", "M", 100_000));
+        UserModel u2 = userRepository.save(new UserModel("user2", "u2", "유저2", "u2@test.com", "1997-01-01", "M", 100_000));
+        UserModel u3 = userRepository.save(new UserModel("user3", "u3", "유저3", "u3@test.com", "1997-01-01", "M", 100_000));
+
+        productLikeService.like(u1.getId(), p1.getId());
+
+        // when
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<ProductLikeSummary> page = productQueryService.getProductListWithLikeCount(
+                brand.getId(),
+                ProductSortType.LIKE_DESC,
+                pageable
+        );
+
+        // then
+        assertThat(page.getContent()).hasSize(2);
+
+        ProductLikeSummary first = page.getContent().get(0);
+        ProductLikeSummary second = page.getContent().get(1);
+
+        // p1: likeCount = 1
+        assertThat(first.getProductId()).isEqualTo(p1.getId());
+        assertThat(first.getLikeCount()).isEqualTo(1L);
+
+        // p2: 좋아요 없는 경우 0으로 집계
+        assertThat(second.getProductId()).isEqualTo(p2.getId());
+        assertThat(second.getLikeCount()).isEqualTo(0L);
+
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/ProductQueryServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ProductQueryServiceTest.java
@@ -139,4 +139,40 @@ public class ProductQueryServiceTest {
         assertThat(second.getLikeCount()).isEqualTo(0L);
 
     }
+
+    @Test
+    @DisplayName("특정 상품에 대한 세부 정보를 조회한다")
+    void findProductDetail_withProductId() {
+        // given
+        BrandModel brand = brandRepository.save(
+                new BrandModel("브랜드A", "설명", BrandStatus.REGISTERED)
+        );
+        ProductModel p1 = productRepository.save(
+                new ProductModel("상품1", "카테고리", 10_000, 100, ProductStatus.ON_SALE, brand)
+        );
+        ProductModel p2 = productRepository.save(
+                new ProductModel("상품2", "카테고리", 20_000, 100, ProductStatus.ON_SALE, brand)
+        );
+
+        UserModel u1 = userRepository.save(new UserModel("user1", "u1", "유저1", "u1@test.com", "1997-01-01", "M", 100_000));
+        UserModel u2 = userRepository.save(new UserModel("user2", "u2", "유저2", "u2@test.com", "1997-01-01", "M", 100_000));
+        UserModel u3 = userRepository.save(new UserModel("user3", "u3", "유저3", "u3@test.com", "1997-01-01", "M", 100_000));
+
+        productLikeService.like(u1.getId(), p1.getId());
+        productLikeService.like(u2.getId(), p2.getId());
+        productLikeService.like(u3.getId(), p1.getId());
+
+        // when
+        ProductLikeSummary summary = productQueryService.getProductLikeSummary(p1.getId());
+
+        // then
+        assertThat(summary).isNotNull();
+        assertThat(summary.getProductId()).isEqualTo(p1.getId());
+        assertThat(summary.getProductName()).isEqualTo(p1.getName());
+        assertThat(summary.getBrandId()).isEqualTo(p1.getBrand().getId());
+        assertThat(summary.getBrandName()).isEqualTo(brand.getName());
+        assertThat(summary.getPrice()).isEqualTo(p1.getPrice());
+        assertThat(summary.getStatus()).isEqualTo(p1.getStatus());
+        assertThat(summary.getLikeCount()).isEqualTo(2L);
+    }
 }

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -37,7 +37,9 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
+
+
 
 datasource:
   mysql-jpa:


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
- 상품목록 조회 서비스/API 개선 
- 대량 데이터 테스트를 위한 sql 코드 작성
- 상품목록 조회 성능 이슈 확인 및 분석
- 상품목록 조회에 대한 Redis 캐시 적용 (애노테이션 기반 스프링 AOP 활용)
- 전/후 API p95 성능지표 확인
- TTL 설정 스프링 빈 등록
- Page 결과 캐시 저장시 value 직렬화 방식 현재는 jdk 로. 추후 고민

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

> 금주에는 이상한 회사 이슈(노조 투쟁) 및 그로 인한 감기 이슈가 있어서 과제에 시간을 많이 투자하지 못하였습니다 ㅠㅠ 주말에 보완하겠습니다.

1. 성능 이슈 확인 후 테이블 구조를 변경하고 이전 소스와 비교하는 ASIS/TOBE 테스트를 해보려고 하였는데 깃 별도의 브랜치를 만들고 테스트를 하면 비교가 원할할 것 같다는 생각이 들었습니다! 실무에서는 어떻게 하시는 지 궁금합니다.

2. 상품목록 조회 API 에서 필터들을 여러개 걸면 
- 브랜드ID 전달시 성능 OK
- 브랜드ID 전달 안할 경우 성능 BAD
이런식으로 필터의 유무에 따라 쿼리 성능에도 좀 영향이 있는 것 같았습니다.
동적쿼리 성능에 대한 고민일 것 같은데..  하나의 API에 권장되는 필터 개수 이런게 있을까요?


## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->
### Index
- [x]  상품 목록 API에서 brandId 기반 검색, 좋아요 순 정렬 등을 처리했다
- [x]  조회 필터, 정렬 조건별 유즈케이스를 분석하여 인덱스를 적용하고 전 후 성능비교를 진행했다

### ❤️ Structure
- [x]  상품 목록/상세 조회 시 좋아요 수를 조회 및 좋아요 순 정렬이 가능하도록 구조 개선을 진행했다
- [x]  좋아요 적용/해제 진행 시 상품 좋아요 수 또한 정상적으로 동기화되도록 진행하였다

### ⚡ Cache
- [x]  Redis 캐시를 적용하고 TTL 또는 무효화 전략을 적용했다
- [x]  캐시 미스 상황에서도 서비스가 정상 동작하도록 처리했다.

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 상품 목록 조회 API 추가 (브랜드 필터링, 정렬 옵션 지원)
  * 상품 상세 조회 API 추가
  * 페이지네이션 및 좋아요 수 집계 기능 제공

* **Tests**
  * 상품 조회 서비스 테스트 추가

* **Chores**
  * 대규모 테스트 데이터 초기화 지원 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->