### PR TITLE
[volume-5] 인덱스 및 Redis 캐시 적용

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -4,10 +4,13 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
+
 import java.util.TimeZone;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableCaching
 public class CommerceApiApplication {
 
     @PostConstruct

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -2,6 +2,7 @@ package com.loopers.application.like;
 
 import com.loopers.domain.like.Like;
 import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.user.UserRepository;
 import com.loopers.interfaces.api.like.LikeV1Dto;
@@ -32,7 +33,7 @@ public class LikeFacade {
                 () -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 유저입니다.")
         );
 
-        productRepository.findById(productId).orElseThrow(
+        Product product = productRepository.findById(productId).orElseThrow(
                 () -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다.")
         );
 
@@ -41,6 +42,8 @@ public class LikeFacade {
                 .orElseGet(() -> {
                     Like newLike = request.toEntity();
                     likeRepository.save(newLike);
+
+                    product.addLikeCount();
 
                     return LikeInfo.from(newLike);
                 });

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -8,6 +8,7 @@ import com.loopers.interfaces.api.product.ProductV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +37,7 @@ public class ProductFacade {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "products", key = "'all'")
     public List<ProductInfo> findAllProducts() {
         List<Product> products = productRepository.findAll();
 
@@ -45,6 +47,7 @@ public class ProductFacade {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "product", key = "#id")
     public ProductInfo findProductById(Long id) {
         Product product = productRepository.findById(id).orElseThrow(
                 () -> new CoreException(ErrorType.NOT_FOUND, "찾고자 하는 상품이 존재하지 않습니다.")

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -1,5 +1,6 @@
 package com.loopers.application.product;
 
+import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductRepository;
@@ -17,10 +18,17 @@ import java.util.List;
 public class ProductFacade {
     private final ProductRepository productRepository;
     private final LikeRepository likeRepository;
+    private final BrandRepository brandRepository;
 
 
     @Transactional
     public ProductInfo registerProduct(ProductV1Dto.ProductRequest request) {
+        Long brandId = request.brandId();
+
+        brandRepository.findById(brandId).orElseThrow(
+                () -> new CoreException(ErrorType.NOT_FOUND, "등록하고자 하는 상품의 브랜드가 존재하지 않습니다.")
+        );
+
         Product product = request.toEntity();
         productRepository.save(product);
 
@@ -52,6 +60,7 @@ public class ProductFacade {
 
     @Transactional(readOnly = true)
     public List<ProductInfo> searchProductsByCondition(ProductV1Dto.SearchProductRequest request) {
+        request.filterCondition().conditionValidate();
         request.sortCondition().conditionValidate();
 
         List<Product> products = productRepository.searchProductsByCondition(request);

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -8,10 +8,12 @@ import com.loopers.interfaces.api.product.ProductV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Component
@@ -66,5 +68,20 @@ public class ProductFacade {
         return products.stream()
                 .map(ProductInfo::from)
                 .toList();
+    }
+
+    @Transactional
+    @CacheEvict(value = "product", key = "#request.id()")
+    public ProductInfo changePrice(ProductV1Dto.ChangePriceRequest request) {
+        Long id = request.id();
+        BigDecimal newPrice = request.newPrice();
+
+        Product product = productRepository.findById(id).orElseThrow(
+                () -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다.")
+        );
+
+        Product changedProduct = product.changePrice(newPrice);
+
+        return ProductInfo.from(changedProduct);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -32,7 +32,7 @@ public class ProductFacade {
         Product product = request.toEntity();
         productRepository.save(product);
 
-        return ProductInfo.from(product, 0);
+        return ProductInfo.from(product);
     }
 
     @Transactional(readOnly = true)
@@ -40,10 +40,7 @@ public class ProductFacade {
         List<Product> products = productRepository.findAll();
 
         return products.stream()
-                .map(product -> {
-                    int likeCount = likeRepository.countByProductId(product.getId());
-                    return ProductInfo.from(product, likeCount);
-                })
+                .map(ProductInfo::from)
                 .toList();
     }
 
@@ -53,9 +50,7 @@ public class ProductFacade {
                 () -> new CoreException(ErrorType.NOT_FOUND, "찾고자 하는 상품이 존재하지 않습니다.")
         );
 
-        int likeCount = likeRepository.countByProductId(id);
-
-        return ProductInfo.from(product, likeCount);
+        return ProductInfo.from(product);
     }
 
     @Transactional(readOnly = true)
@@ -66,10 +61,7 @@ public class ProductFacade {
         List<Product> products = productRepository.searchProductsByCondition(request);
 
         return products.stream()
-                .map(product -> {
-                    int likeCount = likeRepository.countByProductId(product.getId());
-                    return ProductInfo.from(product, likeCount);
-                })
+                .map(ProductInfo::from)
                 .toList();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
@@ -5,14 +5,15 @@ import com.loopers.domain.product.Product;
 import java.math.BigDecimal;
 
 public record ProductInfo(Long id, Long brandId, String name, BigDecimal price, int stock, int likeCount) {
-    public static ProductInfo from(Product product, int likeCount) {
+    public static ProductInfo from(Product product) {
         return new ProductInfo(
-            product.getId(),
-            product.getBrandId(),
-            product.getName(),
-            product.getPrice(),
-            product.getStock(),
-            likeCount
+                product.getId(),
+                product.getBrandId(),
+                product.getName(),
+                product.getPrice(),
+                product.getStock(),
+                product.getLikeCount()
         );
+
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.brand;
+
+import java.util.Optional;
+
+public interface BrandRepository {
+    Optional<Brand> findById(Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -29,12 +29,16 @@ public class Product extends BaseEntity {
     @Column(name = "stock", nullable = false)
     private int stock;
 
+    @Column(name = "like_count", nullable = false)
+    private int likeCount;
 
-    public Product(Long brandId, String name, BigDecimal price, int stock) {
+
+    public Product(Long brandId, String name, BigDecimal price, int stock, int likeCount) {
         this.brandId = brandId;
         this.name = name;
         this.price = price;
         this.stock = stock;
+        this.likeCount = likeCount;
     }
 
     public Product changePrice(BigDecimal newPrice) {
@@ -42,7 +46,7 @@ public class Product extends BaseEntity {
         return this;
     }
 
-    public Product decreaseStock(int amount) {
+    public void decreaseStock(int amount) {
         if (amount <= 0) {
             throw new CoreException(ErrorType.BAD_REQUEST, "재고 감소량은 0보다 커야 합니다.");
         }
@@ -51,11 +55,14 @@ public class Product extends BaseEntity {
         }
         this.stock -= amount;
 
-        return this;
     }
 
     public boolean isInStock(int quantity) {
         return this.stock >= quantity;
+    }
+
+    public int addLikeCount() {
+        return this.likeCount++;
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BrandJpaRepository extends JpaRepository<Brand, Long> {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class BrandRepositoryImpl implements BrandRepository {
+    private final BrandJpaRepository brandJpaRepository;
+
+    @Override
+    public Optional<Brand> findById(Long id) {
+        return brandJpaRepository.findById(id);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -41,7 +41,7 @@ public class ProductRepositoryImpl implements ProductRepository {
 
     @Override
     public List<Product> searchProductsByCondition(ProductV1Dto.SearchProductRequest request) {
-        System.out.println("sortBy = " + request.sortCondition().sortBy());
+
         boolean isAsc = request.sortCondition().order().equals("asc");
 
         JPAQuery<Product> query = queryFactory
@@ -49,6 +49,10 @@ public class ProductRepositoryImpl implements ProductRepository {
                 .leftJoin(like)
                 .on(product.id.eq(like.productId))
                 .groupBy(product.id);
+
+        switch (request.filterCondition().filterBy()) {
+            case "brandId" -> query.where(product.brandId.eq(request.filterCondition().filterValue()));
+        }
 
 
         switch (request.sortCondition().sortBy()) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -9,14 +9,18 @@ import java.util.List;
 @Tag(name = "Product V1 API", description = "Product API 입니다.")
 public interface ProductV1ApiSpec {
     @Operation(summary = "상품 등록")
-    ApiResponse<ProductV1Dto.ProductResponse> registerProduct (ProductV1Dto.ProductRequest request);
+    ApiResponse<ProductV1Dto.ProductResponse> registerProduct(ProductV1Dto.ProductRequest request);
 
     @Operation(summary = "상품 목록 조회")
-    ApiResponse<List<ProductV1Dto.ProductResponse>> findAllProducts ();
+    ApiResponse<List<ProductV1Dto.ProductResponse>> findAllProducts();
 
     @Operation(summary = "상품 상세 조회")
-    ApiResponse<ProductV1Dto.ProductResponse> findProductById (Long id);
+    ApiResponse<ProductV1Dto.ProductResponse> findProductById(Long id);
 
     @Operation(summary = "상품 정렬 조회")
-    ApiResponse<List<ProductV1Dto.ProductResponse>> findProductsBySortCondition (ProductV1Dto.SearchProductRequest request);
+    ApiResponse<List<ProductV1Dto.ProductResponse>> findProductsBySortCondition(ProductV1Dto.SearchProductRequest request);
+
+    @Operation(summary = "상품 가격 변경")
+    ApiResponse<ProductV1Dto.ProductResponse> changePrice(ProductV1Dto.ChangePriceRequest request);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -60,4 +60,14 @@ public class ProductV1Controller implements ProductV1ApiSpec {
 
         return ApiResponse.success(responses);
     }
+
+    @PostMapping("/change")
+    @Override
+    public ApiResponse<ProductV1Dto.ProductResponse> changePrice(@RequestBody ProductV1Dto.ChangePriceRequest request) {
+        ProductInfo info = productFacade.changePrice(request);
+
+        ProductV1Dto.ProductResponse response = ProductV1Dto.ProductResponse.from(info);
+
+        return ApiResponse.success(response);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -32,7 +32,16 @@ public class ProductV1Dto {
         }
     }
 
-    public record SearchProductRequest(SortCondition sortCondition) {
+    public record SearchProductRequest(FilterCondition filterCondition, SortCondition sortCondition) {
+        public record FilterCondition(String filterBy, Long filterValue) {
+            public void conditionValidate() {
+                if (!filterBy.equals("brandId")) {
+                    throw new CoreException(ErrorType.BAD_REQUEST, "유효하지 않은 필터 조건입니다.");
+                }
+            }
+
+        }
+
         public record SortCondition(String sortBy, String order) {
             public void conditionValidate() {
                 if (!sortBy.equals("price") && !sortBy.equals("likeCount") && !sortBy.equals("createdAt")) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -54,4 +54,7 @@ public class ProductV1Dto {
             }
         }
     }
+
+    public record ChangePriceRequest(Long id, BigDecimal newPrice) {
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -27,7 +27,8 @@ public class ProductV1Dto {
                     brandId,
                     name,
                     price,
-                    stock
+                    stock,
+                    0
             );
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeConcurrencyIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeConcurrencyIntegrationTest.java
@@ -52,7 +52,8 @@ public class LikeConcurrencyIntegrationTest {
                         1L,
                         "테스트 상품",
                         BigDecimal.valueOf(10000),
-                        100
+                        100,
+                        0
                 )
         );
 

--- a/modules/redis/build.gradle.kts
+++ b/modules/redis/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     api("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
 
     testFixturesImplementation("com.redis:testcontainers-redis")
 }


### PR DESCRIPTION
## 📌 Summary
### 1. 인덱스 설정
- brandId와 price에 대해 복합 인덱스 설정 -> (brandId, price)
- 인덱스 적용 전과 후의 성능 비교

**🎯 성능 비교**

👨‍💻 비교 시나리오
- 상품 더미 데이터 10만개를 INSERT 후에 10만개에 대한 조회 진행
- Selectivity는 대략 10% 수준

**인덱스 적용 전** | **인덱스 적용 후**
-- | --
평균 70ms | 평균 30ms


<!-- notionvc: dc0813c2-e17b-46e8-be19-3ee398c1c6cb -->
---
### 2. 비정규화
**기존 방식**
- 좋아요 시에 ProductLike 내에 productId, userId를 컬럼으로 가지는 row 생성하는 구조

**변경한 방식**
- 비정규화를 진행하여 Product 내 likeCount 컬럼을 정의하고 좋아요 시에 likeCount 컬럼 값을 변경(멱등성 유지)

**🎯성능 비교**

👨‍💻 비교 시나리오
- 2만 건의 좋아요를 가지는 Product를 기준으로 비교 진행

**비정규화 진행 전** | **비정규화 진행 후**
-- | --
평균 42s | 평균 403ms


<!-- notionvc: dc0813c2-e17b-46e8-be19-3ee398c1c6cb -->
---
### 3. 레디스 학습 및 적용
Redis에 대한 이론적이 학습을 짧게 수행하고 캐시 전략과 무효화 전략에 대해 고민하면서 캐싱을 적용했습니다. 

루퍼스 과정이 마무리 되면 다시 다른 것들을 포함해서 레디스도 학습해보려고 하는데요! 

어제 멘토링 때 추천해주셨던 서적 말고 레디스를 공부할 때 중점적으로 해보면 좋을 **학습 및 고민 포인트**가 있을까요?

## 💬 Review Points
### 1. 레디스에 영구적으로 캐싱해두는 데이터가 있나요?

엄밀히 말하면 인메모리 DB이기에 “영구”는 아니겠지만, 스냅샷을 RDB에 저장해두고 서버를 재시작할 때 스냅샷을 기반으로 다시 레디스에 데이터를 저장하는 방법이 있다는 것을 보았는데요!

실무에서 이렇게 캐싱을 해두는 데이터가 있나요? 어제 멘토링 때 레디스를 성능 개선 방법 중 가장 나중에 고려해야할 방법으로 말씀하신 걸로 이해를 하고 있습니다. 그래서 더더욱 TTL을 두지 않고 영구적인 것처럼 캐싱을 해두는 데이터가 있을까 궁금합니다!

---
### 2. 실무에서 좋아요 개수에 대한 컬럼은 어디에서 관리를 하나요?
좋아요를 비정규화하여 product에서 likeCount를 컬럼으로 가지고 있는 상태입니다. 과제가 상품 목록 및 상세 조회를 캐싱하는 것이기에 해당 데이터에 대해서 캐싱을 해두었는데요

상품의 가격 정보가 바뀌었을 때 무효화 전략으로 상세 조회 및 목록 조회에 대한 캐싱 데이터를 삭제하도록 했습니다. 

좋아요는 빈번하게 일어나는 것이기에 likeCount에 대해서는 캐싱하지 않는 방향으로 진행하도록 하려는데요. 찾아보니 캐싱을 하지 않더라도 Redis에서 likeCount를 직접 수정하고 추후에 DB를 동기화해주는 방식이 있던데 실무에서 통상적으로 채택되는 정책은 무엇인가요?

어차피 비정규화를 했으니 Redis에서 관리하지 않고, 필요 시에 바로 DB에서 조회를 해와도 큰 성능 차이가 없을 거 같다고 생각하는데 멘토님은 어떻게 생각하시나요?

---
### 👨‍💻 이슈 사항
상품 목록 조회에 대해 캐싱을 하고 상품 목록 조회 API를 호출하면 최초는 조회가 됩니다.

하지만 그 이후에 캐싱된 데이터를 조회해야 하는데 에러가 생겨서 해결해 보는 중입니다 ! 

## ✅ Checklist
### 🔖 Index

- [x]  상품 목록 API에서 brandId 기반 검색, 좋아요 순 정렬 등을 처리했다
- [x]  조회 필터, 정렬 조건별 유즈케이스를 분석하여 인덱스를 적용하고 전 후 성능비교를 진행했다

### ❤️ Structure

- [x]  상품 목록/상세 조회 시 좋아요 수를 조회 및 좋아요 순 정렬이 가능하도록 구조 개선을 진행했다
- [x]  좋아요 적용/해제 진행 시 상품 좋아요 수 또한 정상적으로 동기화되도록 진행하였다

### ⚡ Cache

- [x]  Redis 캐시를 적용하고 TTL 또는 무효화 전략을 적용했다
- [ ]  캐시 미스 상황에서도 서비스가 정상 동작하도록 처리했다.

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 상품 가격 변경 API 추가
  * 브랜드별 상품 필터링 기능 추가
  * 상품 좋아요 수 추적 및 증가 기능
  * 상품 검색 결과 캐싱 기능 활성화

* **개선 사항**
  * 상품 등록 시 브랜드 존재 여부 검증
  * 가격 변경 시 캐시 자동 갱신
  * 검색 필터 및 정렬 조건 검증 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->