### PR TITLE
[volume-5] 인덱스 및 Redis 캐시 적용

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -7,6 +7,7 @@ import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
+import com.loopers.infrastructure.cache.ProductCacheService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.util.List;
@@ -29,6 +30,7 @@ public class LikeFacade {
     private final LikeService likeService;
     private final ProductService productService;
     private final BrandService brandService;
+    private final ProductCacheService productCacheService;
 
     @Retryable(
             retryFor = OptimisticLockingFailureException.class,
@@ -46,6 +48,11 @@ public class LikeFacade {
         Product product;
         if (wasCreated) {
             product = productService.increaseLikeCount(command.productId());
+            // DB 업데이트 후 캐시 비동기 갱신 및 무효화
+            String brandName = brandService.findBrandNameById(product.getBrandId());
+            ProductInfo productInfo = ProductInfo.from(product, brandName);
+            productCacheService.updateProductCacheAsync(command.productId(), productInfo);
+            productCacheService.invalidateProductListAsync(null); // 모든 목록 캐시 비동기 무효화
         } else {
             product = productService.findProductById(command.productId())
                     .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
@@ -78,6 +85,11 @@ public class LikeFacade {
         Product product;
         if (wasDeleted) {
             product = productService.decreaseLikeCount(command.productId());
+            // DB 업데이트 후 캐시 비동기 갱신 및 무효화
+            String brandName = brandService.findBrandNameById(product.getBrandId());
+            ProductInfo productInfo = ProductInfo.from(product, brandName);
+            productCacheService.updateProductCacheAsync(command.productId(), productInfo);
+            productCacheService.invalidateProductListAsync(product.getBrandId()); // 모든 목록 캐시 비동기 무효화
         } else {
             product = productService.findProductById(command.productId())
                     .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -22,6 +22,7 @@ public class PointFacade {
 
     @Retryable(
             retryFor = OptimisticLockingFailureException.class,
+            noRetryFor = CoreException.class,
             maxAttempts = 5,
             backoff = @Backoff(delay = 10)
     )
@@ -36,6 +37,11 @@ public class PointFacade {
     @Recover
     public PointInfo recoverChargePoint(OptimisticLockingFailureException e, PointCommand.ChargeCommand chargeCommand) {
         throw new CoreException(ErrorType.CONFLICT, "포인트 충전 중 동시성 충돌이 발생했습니다. 다시 시도해주세요.");
+    }
+
+    @Recover
+    public PointInfo recoverChargePoint(CoreException e, PointCommand.ChargeCommand chargeCommand) {
+        throw e;
     }
 
     public PointInfo getPointInfo(String loginId) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -25,13 +25,13 @@ public class ProductFacade {
         List<Product> products;
 
         if (ProductSort.LATEST.equals(command.sort())) {
-            products = productService.findProductsByLatestWithBrandName(
+            products = productService.findProductsByLatest(
                     command.brandId(), command.page(), command.size());
         } else if (ProductSort.PRICE_ASC.equals(command.sort())) {
-            products = productService.findProductsByPriceAscWithBrandName(
+            products = productService.findProductsByPriceAsc(
                     command.brandId(), command.page(), command.size());
         } else if (ProductSort.LIKES_DESC.equals(command.sort())) {
-            products = productService.findProductsByLikesDescWithBrandName(
+            products = productService.findProductsByLikesDesc(
                     command.brandId(), command.page(), command.size());
         } else {
             throw new CoreException(ErrorType.BAD_REQUEST, "지원하지 않는 정렬 기준입니다: " + command.sort());

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -3,6 +3,7 @@ package com.loopers.application.product;
 import com.loopers.domain.brand.BrandService;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
+import com.loopers.infrastructure.cache.ProductCacheService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.util.List;
@@ -11,7 +12,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
@@ -19,42 +19,50 @@ public class ProductFacade {
 
     private final ProductService productService;
     private final BrandService brandService;
+    private final ProductCacheService productCacheService;
 
-    @Transactional(readOnly = true)
     public List<ProductInfo> getProducts(ProductCommand.GetProductsCommand command) {
-        List<Product> products;
+        return productCacheService.getProductList(
+                command.brandId(),
+                command.sort(),
+                command.page(),
+                command.size(),
+                () -> {
+                    List<Product> products;
 
-        if (ProductSort.LATEST.equals(command.sort())) {
-            products = productService.findProductsByLatest(
-                    command.brandId(), command.page(), command.size());
-        } else if (ProductSort.PRICE_ASC.equals(command.sort())) {
-            products = productService.findProductsByPriceAsc(
-                    command.brandId(), command.page(), command.size());
-        } else if (ProductSort.LIKES_DESC.equals(command.sort())) {
-            products = productService.findProductsByLikesDesc(
-                    command.brandId(), command.page(), command.size());
-        } else {
-            throw new CoreException(ErrorType.BAD_REQUEST, "지원하지 않는 정렬 기준입니다: " + command.sort());
-        }
+                    if (ProductSort.LATEST.equals(command.sort())) {
+                        products = productService.findProductsByLatest(
+                                command.brandId(), command.page(), command.size());
+                    } else if (ProductSort.PRICE_ASC.equals(command.sort())) {
+                        products = productService.findProductsByPriceAsc(
+                                command.brandId(), command.page(), command.size());
+                    } else if (ProductSort.LIKES_DESC.equals(command.sort())) {
+                        products = productService.findProductsByLikesDesc(
+                                command.brandId(), command.page(), command.size());
+                    } else {
+                        throw new CoreException(ErrorType.BAD_REQUEST, "지원하지 않는 정렬 기준입니다: " + command.sort());
+                    }
 
-        Set<Long> brandIds = products.stream()
-                .map(Product::getBrandId)
-                .collect(Collectors.toSet());
+                    Set<Long> brandIds = products.stream()
+                            .map(Product::getBrandId)
+                            .collect(Collectors.toSet());
 
-        Map<Long, String> brandNamesMap = brandService.findBrandNamesByIds(brandIds.stream().toList());
+                    Map<Long, String> brandNamesMap = brandService.findBrandNamesByIds(brandIds.stream().toList());
 
-        return products.stream()
-                .map(product -> ProductInfo.from(product, brandNamesMap.get(product.getBrandId())))
-                .toList();
+                    return products.stream()
+                            .map(product -> ProductInfo.from(product, brandNamesMap.get(product.getBrandId())))
+                            .toList();
+                }
+        );
     }
 
-    @Transactional(readOnly = true)
     public ProductInfo getProduct(Long productId) {
-        Product product = productService.findProductById(productId)
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
-        String brandName = brandService.findBrandNameById(product.getBrandId());
-
-        return ProductInfo.from(product, brandName);
+        return productCacheService.getProduct(productId, () -> {
+            Product product = productService.findProductById(productId)
+                    .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
+            String brandName = brandService.findBrandNameById(product.getBrandId());
+            return ProductInfo.from(product, brandName);
+        });
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
@@ -1,6 +1,7 @@
 package com.loopers.application.product;
 
 import com.loopers.domain.product.Product;
+import java.time.ZonedDateTime;
 
 public record ProductInfo(
         Long id,
@@ -9,7 +10,8 @@ public record ProductInfo(
         String brandName,
         Integer price,
         Integer likeCount,
-        Integer stock
+        Integer stock,
+        ZonedDateTime createdAt
 ) {
     public static ProductInfo from(Product product, String brandName) {
         return new ProductInfo(
@@ -19,7 +21,8 @@ public record ProductInfo(
                 brandName,
                 product.getPrice().getPrice(),
                 product.getLikeCount().getCount(),
-                product.getStock().getQuantity()
+                product.getStock().getQuantity(),
+                product.getCreatedAt()
         );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -10,6 +10,8 @@ public interface BrandRepository {
 
     Optional<Brand> findById(Long brandId);
 
+    String findNameById(Long brandId);
+
     Map<Long, String> findBrandNamesByIds(List<Long> brandIds);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
@@ -19,9 +19,11 @@ public class BrandService {
     }
 
     public String findBrandNameById(Long brandId) {
-        Brand brand = brandRepository.findById(brandId)
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "브랜드를 찾을 수 없습니다."));
-        return brand.getName();
+        String brandName = brandRepository.findNameById(brandId);
+        if (brandName == null) {
+            throw new CoreException(ErrorType.NOT_FOUND, "브랜드를 찾을 수 없습니다.");
+        }
+        return brandName;
     }
 
     public Map<Long, String> findBrandNamesByIds(List<Long> brandIds) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -16,16 +16,13 @@ import lombok.Getter;
 
 @Entity
 @Table(
-    name = "products",
-    indexes = {
-        @Index(name = "idx_products_brand_deleted_created", columnList = "brand_id,is_deleted,created_at"),
-        @Index(name = "idx_products_brand_deleted_price", columnList = "brand_id,is_deleted,price"),
-        @Index(name = "idx_products_brand_deleted_likes", columnList = "brand_id,is_deleted,like_count"),
-        
-        @Index(name = "idx_products_deleted_created", columnList = "is_deleted,created_at"),
-        @Index(name = "idx_products_deleted_price", columnList = "is_deleted,price"),
-        @Index(name = "idx_products_deleted_likes", columnList = "is_deleted,like_count")
-    }
+        name = "products",
+        indexes = {
+                @Index(name = "idx_brand_id", columnList = "brand_id"),
+                @Index(name = "idx_global_price", columnList = "is_deleted, price"),
+                @Index(name = "idx_global_likes", columnList = "is_deleted, like_count DESC"),
+                @Index(name = "idx_global_latest", columnList = "is_deleted, created_at DESC")
+        }
 )
 @Getter
 public class Product extends BaseEntity {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -8,13 +8,25 @@ import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import lombok.Builder;
 import lombok.Getter;
 
 @Entity
-@Table(name = "products")
+@Table(
+    name = "products",
+    indexes = {
+        @Index(name = "idx_products_brand_deleted_created", columnList = "brand_id,is_deleted,created_at"),
+        @Index(name = "idx_products_brand_deleted_price", columnList = "brand_id,is_deleted,price"),
+        @Index(name = "idx_products_brand_deleted_likes", columnList = "brand_id,is_deleted,like_count"),
+        
+        @Index(name = "idx_products_deleted_created", columnList = "is_deleted,created_at"),
+        @Index(name = "idx_products_deleted_price", columnList = "is_deleted,price"),
+        @Index(name = "idx_products_deleted_likes", columnList = "is_deleted,like_count")
+    }
+)
 @Getter
 public class Product extends BaseEntity {
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -9,10 +9,10 @@ public interface ProductRepository {
 
     void saveProduct(Product product);
 
-    List<Product> findProductsByLatestWithBrandName(Long brandId, int page, int size);
+    List<Product> findProductsByLatest(Long brandId, int page, int size);
 
-    List<Product> findProductsByPriceAscWithBrandName(Long brandId, int page, int size);
+    List<Product> findProductsByPriceAsc(Long brandId, int page, int size);
 
-    List<Product> findProductsByLikesDescWithBrandName(Long brandId, int page, int size);
+    List<Product> findProductsByLikesDesc(Long brandId, int page, int size);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -24,16 +24,16 @@ public class ProductService {
         productRepository.saveProduct(product);
     }
 
-    public List<Product> findProductsByLatestWithBrandName(Long brandId, int page, int size) {
-        return productRepository.findProductsByLatestWithBrandName(brandId, page, size);
+    public List<Product> findProductsByLatest(Long brandId, int page, int size) {
+        return productRepository.findProductsByLatest(brandId, page, size);
     }
 
-    public List<Product> findProductsByPriceAscWithBrandName(Long brandId, int page, int size) {
-        return productRepository.findProductsByPriceAscWithBrandName(brandId, page, size);
+    public List<Product> findProductsByPriceAsc(Long brandId, int page, int size) {
+        return productRepository.findProductsByPriceAsc(brandId, page, size);
     }
 
-    public List<Product> findProductsByLikesDescWithBrandName(Long brandId, int page, int size) {
-        return productRepository.findProductsByLikesDescWithBrandName(brandId, page, size);
+    public List<Product> findProductsByLikesDesc(Long brandId, int page, int size) {
+        return productRepository.findProductsByLikesDesc(brandId, page, size);
     }
 
     public Product increaseLikeCount(Long productId) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
@@ -1,0 +1,17 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.Brand;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BrandJpaRepository extends JpaRepository<Brand, Long> {
+    
+    @Query("SELECT b FROM Brand b WHERE b.id IN :brandIds AND b.deletedAt IS NULL")
+    List<Brand> findByIds(@Param("brandIds") List<Long> brandIds);
+
+    @Query("SELECT b.name FROM Brand b WHERE b.id = :brandId AND b.deletedAt IS NULL")
+    String findNameById(Long brandId);
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
@@ -12,6 +12,6 @@ public interface BrandJpaRepository extends JpaRepository<Brand, Long> {
     List<Brand> findByIds(@Param("brandIds") List<Long> brandIds);
 
     @Query("SELECT b.name FROM Brand b WHERE b.id = :brandId AND b.deletedAt IS NULL")
-    String findNameById(Long brandId);
+    String findNameById(@Param("brandId") Long brandId);
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
@@ -2,10 +2,10 @@ package com.loopers.infrastructure.brand;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandRepository;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -13,14 +13,29 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class BrandRepositoryImpl implements BrandRepository {
 
+    private final BrandJpaRepository brandJpaRepository;
+
     @Override
     public Optional<Brand> findById(Long brandId) {
-        return Optional.empty();
+        return brandJpaRepository.findById(brandId);
+    }
+
+    @Override
+    public String findNameById(Long brandId) {
+        return brandJpaRepository.findNameById(brandId);
     }
 
     @Override
     public Map<Long, String> findBrandNamesByIds(List<Long> brandIds) {
-        return new HashMap<>();
+        if (brandIds == null || brandIds.isEmpty()) {
+            return Map.of();
+        }
+        
+        return brandJpaRepository.findByIds(brandIds).stream()
+                .collect(Collectors.toMap(
+                        Brand::getId,
+                        Brand::getName
+                ));
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/CacheConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/CacheConfig.java
@@ -1,0 +1,27 @@
+package com.loopers.infrastructure.cache;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class CacheConfig {
+
+    @Bean(name = "cacheRefreshExecutor")
+    public Executor cacheRefreshExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("cache-refresh-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/DistributedLock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/DistributedLock.java
@@ -1,0 +1,86 @@
+package com.loopers.infrastructure.cache;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class DistributedLock {
+
+    private static final String LOCK_PREFIX = "lock:";
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_EXPIRE_TIME = Duration.ofSeconds(30);
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public DistributedLock(@Qualifier("redisTemplateMaster") RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    private static final String RELEASE_LOCK_SCRIPT = """
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+            else
+                return 0
+            end
+            """;
+
+    public LockHandle tryLock(String key) {
+        return tryLock(key, DEFAULT_TIMEOUT, DEFAULT_EXPIRE_TIME);
+    }
+
+    public LockHandle tryLock(String key, Duration timeout, Duration expireTime) {
+        String lockKey = LOCK_PREFIX + key;
+        String lockValue = UUID.randomUUID().toString();
+        long timeoutMillis = timeout.toMillis();
+        long startTime = System.currentTimeMillis();
+
+        while (System.currentTimeMillis() - startTime < timeoutMillis) {
+            Boolean acquired = redisTemplate.opsForValue()
+                    .setIfAbsent(lockKey, lockValue, expireTime);
+
+            if (Boolean.TRUE.equals(acquired)) {
+                log.debug("Lock acquired: {}", lockKey);
+                return new LockHandle(lockKey, lockValue);
+            }
+
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+
+        log.debug("Lock acquisition timeout: {}", lockKey);
+        return null;
+    }
+
+    public void releaseLock(LockHandle lockHandle) {
+        if (lockHandle == null) {
+            return;
+        }
+
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setScriptText(RELEASE_LOCK_SCRIPT);
+        script.setResultType(Long.class);
+
+        Long result = redisTemplate.execute(script, List.of(lockHandle.key()), lockHandle.value());
+        if (result != null && result > 0) {
+            log.debug("Lock released: {}", lockHandle.key());
+        } else {
+            log.warn("Lock release failed or already released: {}", lockHandle.key());
+        }
+    }
+
+    public record LockHandle(String key, String value) {
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/ProductCacheService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/ProductCacheService.java
@@ -1,0 +1,238 @@
+package com.loopers.infrastructure.cache;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.product.ProductInfo;
+import com.loopers.application.product.ProductSort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@Slf4j
+@Service
+public class ProductCacheService {
+
+    private static final String PRODUCT_DETAIL_PREFIX = "product:detail:";
+    private static final String PRODUCT_LIST_PREFIX = "product:list:";
+    
+    private static final Duration PRODUCT_DETAIL_TTL = Duration.ofHours(6);
+    private static final Duration PRODUCT_LIST_TTL = Duration.ofMinutes(10);
+    private static final long REFRESH_THRESHOLD_SECONDS = 30;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplateMaster;
+    private final ObjectMapper objectMapper;
+    private final DistributedLock distributedLock;
+
+    public ProductCacheService(
+            @Qualifier("redisTemplateObject") RedisTemplate<String, Object> redisTemplate,
+            @Qualifier("redisTemplateObjectMaster") RedisTemplate<String, Object> redisTemplateMaster,
+            @Qualifier("redisObjectMapper") ObjectMapper objectMapper,
+            DistributedLock distributedLock
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.redisTemplateMaster = redisTemplateMaster;
+        this.objectMapper = objectMapper;
+        this.distributedLock = distributedLock;
+    }
+
+    /**
+     * 상품 상세 캐시 키 생성
+     */
+    public String getProductDetailKey(Long productId) {
+        return PRODUCT_DETAIL_PREFIX + productId;
+    }
+
+    /**
+     * 상품 목록 캐시 키 생성
+     */
+    public String getProductListKey(Long brandId, ProductSort sort, int page, int size) {
+        String brandPart = brandId != null ? "brandId=" + brandId : "brandId=all";
+        String sortPart = "sort=" + sort.getValue();
+        String pagePart = "page=" + page;
+        String sizePart = "size=" + size;
+        return PRODUCT_LIST_PREFIX + brandPart + "&" + sortPart + "&" + pagePart + "&" + sizePart;
+    }
+
+    /**
+     * 상품 상세 조회 (Look-Aside, Stale-While-Revalidate)
+     */
+    public ProductInfo getProduct(Long productId, Supplier<ProductInfo> dbSupplier) {
+        String cacheKey = getProductDetailKey(productId);
+        ValueOperations<String, Object> opsForValue = redisTemplate.opsForValue();
+
+        // 1. 캐시 조회
+        Object cachedValue = opsForValue.get(cacheKey);
+        if (cachedValue != null) {
+            log.info("상품 상세 캐시 히트: productId={}", productId);
+            ProductInfo productInfo = objectMapper.convertValue(cachedValue, ProductInfo.class);
+
+            // 2. Stale-While-Revalidate
+            Long ttl = redisTemplate.getExpire(cacheKey, TimeUnit.SECONDS);
+            if (ttl != null && ttl < REFRESH_THRESHOLD_SECONDS) {
+                log.info("키 {}의 TTL이 임계값 이하입니다. 비동기 새로고침을 실행합니다.", cacheKey);
+                refreshProductCache(productId, cacheKey, dbSupplier, PRODUCT_DETAIL_TTL);
+            }
+            return productInfo;
+        }
+
+        // 3. 캐시 미스 -> DB 조회 및 캐시 저장
+        log.info("상품 상세 캐시 미스: productId={}, DB에서 조회합니다.", productId);
+        ProductInfo productInfo = dbSupplier.get();
+        redisTemplateMaster.opsForValue().set(cacheKey, productInfo, PRODUCT_DETAIL_TTL);
+        return productInfo;
+    }
+
+    /**
+     * 상품 목록 조회 (Look-Aside, Stale-While-Revalidate)
+     */
+    public List<ProductInfo> getProductList(Long brandId, ProductSort sort, int page, int size, Supplier<List<ProductInfo>> dbSupplier) {
+        String cacheKey = getProductListKey(brandId, sort, page, size);
+        ValueOperations<String, Object> opsForValue = redisTemplate.opsForValue();
+
+        // 1. 캐시 조회
+        Object cachedValue = opsForValue.get(cacheKey);
+        if (cachedValue != null) {
+            log.info("상품 목록 캐시 히트: cacheKey={}", cacheKey);
+            List<ProductInfo> productList = objectMapper.convertValue(cachedValue, new TypeReference<List<ProductInfo>>() {});
+
+            // 2. Stale-While-Revalidate
+            Long ttl = redisTemplate.getExpire(cacheKey, TimeUnit.SECONDS);
+            if (ttl != null && ttl < REFRESH_THRESHOLD_SECONDS) {
+                log.info("키 {}의 TTL이 임계값 이하입니다. 비동기 새로고침을 실행합니다.", cacheKey);
+                refreshProductListCache(cacheKey, dbSupplier, PRODUCT_LIST_TTL);
+            }
+            return productList;
+        }
+
+        // 3. 캐시 미스 -> DB 조회 및 캐시 저장
+        log.info("상품 목록 캐시 미스: cacheKey={}, DB에서 조회합니다.", cacheKey);
+        List<ProductInfo> productList = dbSupplier.get();
+        redisTemplateMaster.opsForValue().set(cacheKey, productList, PRODUCT_LIST_TTL);
+        return productList;
+    }
+
+    /**
+     * 비동기로 상품 상세 캐시 갱신
+     */
+    @Async("cacheRefreshExecutor")
+    public void refreshProductCache(Long productId, String cacheKey, Supplier<ProductInfo> dbSupplier, Duration ttl) {
+        String lockKey = "lock:" + cacheKey;
+        DistributedLock.LockHandle lockHandle = distributedLock.tryLock(lockKey, Duration.ofSeconds(1), Duration.ofSeconds(10));
+
+        if (lockHandle == null) {
+            log.debug("다른 스레드가 이미 캐시를 갱신 중입니다: cacheKey={}", cacheKey);
+            return;
+        }
+
+        try {
+            log.info("캐시 갱신을 위한 락 획득: cacheKey={}", cacheKey);
+            ProductInfo productInfo = dbSupplier.get();
+            redisTemplateMaster.opsForValue().set(cacheKey, productInfo, ttl);
+            log.info("상품 상세 캐시 갱신 완료: productId={}", productId);
+        } catch (Exception e) {
+            log.error("캐시 갱신 실패: cacheKey={}", cacheKey, e);
+        } finally {
+            distributedLock.releaseLock(lockHandle);
+        }
+    }
+
+
+    /**
+     * 비동기로 상품 목록 캐시 갱신
+     */
+    @Async("cacheRefreshExecutor")
+    public void refreshProductListCache(String cacheKey, Supplier<List<ProductInfo>> dbSupplier, Duration ttl) {
+        String lockKey = "lock:" + cacheKey;
+        DistributedLock.LockHandle lockHandle = distributedLock.tryLock(lockKey, Duration.ofSeconds(1), Duration.ofSeconds(10));
+
+        if (lockHandle == null) {
+            log.debug("다른 스레드가 이미 캐시를 갱신 중입니다: cacheKey={}", cacheKey);
+            return;
+        }
+
+        try {
+            log.info("캐시 갱신을 위한 락 획득: cacheKey={}", cacheKey);
+            List<ProductInfo> productList = dbSupplier.get();
+            redisTemplateMaster.opsForValue().set(cacheKey, productList, ttl);
+            log.info("상품 목록 캐시 갱신 완료: cacheKey={}", cacheKey);
+        } catch (Exception e) {
+            log.error("캐시 갱신 실패: cacheKey={}", cacheKey, e);
+        } finally {
+            distributedLock.releaseLock(lockHandle);
+        }
+    }
+
+    /**
+     * 상품 상세 캐시 무효화
+     */
+    public void invalidateProduct(Long productId) {
+        String key = getProductDetailKey(productId);
+        redisTemplateMaster.delete(key);
+        log.info("상품 상세 캐시 무효화 완료: productId={}", productId);
+    }
+
+    /**
+     * 상품 상세 캐시를 즉시 갱신 (Write-Through)
+     */
+    public void updateProductCache(Long productId, ProductInfo productInfo) {
+        String cacheKey = getProductDetailKey(productId);
+        redisTemplateMaster.opsForValue().set(cacheKey, productInfo, PRODUCT_DETAIL_TTL);
+        log.info("상품 상세 캐시 갱신 완료: productId={}", productId);
+    }
+
+    /**
+     * 상품 상세 캐시를 비동기로 갱신 (Write-Behind)
+     */
+    @Async("cacheRefreshExecutor")
+    public void updateProductCacheAsync(Long productId, ProductInfo productInfo) {
+        String cacheKey = getProductDetailKey(productId);
+        
+        Boolean exists = redisTemplateMaster.hasKey(cacheKey);
+        if (exists) {
+            redisTemplateMaster.opsForValue().set(cacheKey, productInfo, PRODUCT_DETAIL_TTL);
+            log.info("상품 상세 캐시 비동기 갱신 완료: productId={}", productId);
+        } else {
+            log.debug("상품 상세 캐시가 존재하지 않아 갱신하지 않음: productId={}", productId);
+        }
+    }
+
+    /**
+     * 상품 목록 캐시 무효화
+     */
+    public void invalidateProductList(Long brandId) {
+        String pattern;
+        if (brandId != null) {
+            pattern = PRODUCT_LIST_PREFIX + "brandId=" + brandId + "*";
+        } else {
+            pattern = PRODUCT_LIST_PREFIX + "*";
+        }
+
+        redisTemplateMaster.keys(pattern).forEach(redisTemplateMaster::delete);
+        log.info("상품 목록 캐시 무효화 완료: brandId={}", brandId);
+    }
+
+    /**
+     * 상품 목록 캐시를 비동기로 무효화
+     */
+    @Async("cacheRefreshExecutor")
+    public void invalidateProductListAsync(Long brandId) {
+        String pattern;
+        if (brandId != null) {
+            pattern = PRODUCT_LIST_PREFIX + "brandId=" + brandId + "*";
+        } else {
+            pattern = PRODUCT_LIST_PREFIX + "*";
+        }
+
+        redisTemplateMaster.keys(pattern).forEach(redisTemplateMaster::delete);
+        log.info("상품 목록 캐시 비동기 무효화 완료: brandId={}", brandId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface LikeJpaRepository extends JpaRepository<Like, Long> {
     boolean existsByUserIdAndProductId(Long userId, Long productId);
@@ -18,5 +19,14 @@ public interface LikeJpaRepository extends JpaRepository<Like, Long> {
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Like l WHERE l.userId = :userId AND l.productId = :productId")
     int deleteByUserIdAndProductIdAndReturnCount(@Param("userId") Long userId, @Param("productId") Long productId);
+
+    @Modifying
+    @Transactional
+    @Query(
+        value = "INSERT IGNORE INTO likes (user_id, product_id, created_at, updated_at, deleted_at) " +
+                "VALUES (:userId, :productId, NOW(), NOW(), NULL)",
+        nativeQuery = true
+    )
+    int saveLike(@Param("userId") Long userId, @Param("productId") Long productId);
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -31,13 +31,7 @@ public class LikeRepositoryImpl implements LikeRepository {
 
     @Override
     public boolean saveIfAbsent(Long userId, Long productId) {
-        try {
-            Like like = Like.createLike(userId, productId);
-            likeJpaRepository.save(like);
-            return true;
-        } catch (DataIntegrityViolationException e) {
-            return false;
-        }
+        return likeJpaRepository.saveLike(userId, productId) > 0;
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -16,13 +16,13 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p WHERE p.id = :id")
     Optional<Product> findByIdWithLock(@Param("id") Long id);
 
-    @Query("SELECT p FROM Product p WHERE (:brandId IS NULL OR p.brandId = :brandId) AND p.isDeleted = false ORDER BY p.createdAt DESC")
+    @Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.createdAt DESC")
     List<Product> findProductsByLatest(@Param("brandId") Long brandId, Pageable pageable);
 
-    @Query("SELECT p FROM Product p WHERE (:brandId IS NULL OR p.brandId = :brandId) AND p.isDeleted = false ORDER BY p.price.price ASC")
+    @Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.price.price ASC")
     List<Product> findProductsByPriceAsc(@Param("brandId") Long brandId, Pageable pageable);
 
-    @Query("SELECT p FROM Product p WHERE (:brandId IS NULL OR p.brandId = :brandId) AND p.isDeleted = false ORDER BY p.likeCount.count DESC")
+    @Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.likeCount.count DESC")
     List<Product> findProductsByLikesDesc(@Param("brandId") Long brandId, Pageable pageable);
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -16,13 +16,13 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p WHERE p.id = :id")
     Optional<Product> findByIdWithLock(@Param("id") Long id);
 
-    @Query("SELECT p FROM Product p WHERE p.brandId = :brandId AND p.isDeleted = false ORDER BY p.createdAt DESC")
+    @Query("SELECT p FROM Product p WHERE (:brandId IS NULL OR p.brandId = :brandId) AND p.isDeleted = false ORDER BY p.createdAt DESC")
     List<Product> findProductsByLatest(@Param("brandId") Long brandId, Pageable pageable);
 
-    @Query("SELECT p FROM Product p WHERE p.brandId = :brandId AND p.isDeleted = false ORDER BY p.price.price ASC")
+    @Query("SELECT p FROM Product p WHERE (:brandId IS NULL OR p.brandId = :brandId) AND p.isDeleted = false ORDER BY p.price.price ASC")
     List<Product> findProductsByPriceAsc(@Param("brandId") Long brandId, Pageable pageable);
 
-    @Query("SELECT p FROM Product p WHERE p.brandId = :brandId AND p.isDeleted = false ORDER BY p.likeCount.count DESC")
+    @Query("SELECT p FROM Product p WHERE (:brandId IS NULL OR p.brandId = :brandId) AND p.isDeleted = false ORDER BY p.likeCount.count DESC")
     List<Product> findProductsByLikesDesc(@Param("brandId") Long brandId, Pageable pageable);
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -2,7 +2,9 @@ package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.Product;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -13,5 +15,14 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long> {
     @Lock(LockModeType.OPTIMISTIC)
     @Query("SELECT p FROM Product p WHERE p.id = :id")
     Optional<Product> findByIdWithLock(@Param("id") Long id);
+
+    @Query("SELECT p FROM Product p WHERE p.brandId = :brandId AND p.isDeleted = false ORDER BY p.createdAt DESC")
+    List<Product> findProductsByLatest(@Param("brandId") Long brandId, Pageable pageable);
+
+    @Query("SELECT p FROM Product p WHERE p.brandId = :brandId AND p.isDeleted = false ORDER BY p.price.price ASC")
+    List<Product> findProductsByPriceAsc(@Param("brandId") Long brandId, Pageable pageable);
+
+    @Query("SELECT p FROM Product p WHERE p.brandId = :brandId AND p.isDeleted = false ORDER BY p.likeCount.count DESC")
+    List<Product> findProductsByLikesDesc(@Param("brandId") Long brandId, Pageable pageable);
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.loopers.domain.product.ProductRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -24,17 +25,17 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public List<Product> findProductsByLatestWithBrandName(Long brandId, int page, int size) {
-        return null;
+    public List<Product> findProductsByLatest(Long brandId, int page, int size) {
+        return productJpaRepository.findProductsByLatest(brandId, PageRequest.of(page, size));
     }
 
     @Override
-    public List<Product> findProductsByPriceAscWithBrandName(Long brandId, int page, int size) {
-        return null;
+    public List<Product> findProductsByPriceAsc(Long brandId, int page, int size) {
+        return productJpaRepository.findProductsByPriceAsc(brandId, PageRequest.of(page, size));
     }
 
     @Override
-    public List<Product> findProductsByLikesDescWithBrandName(Long brandId, int page, int size) {
-        return null;
+    public List<Product> findProductsByLikesDesc(Long brandId, int page, int size) {
+        return productJpaRepository.findProductsByLikesDesc(brandId, PageRequest.of(page, size));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -23,7 +23,8 @@ public class ProductV1Dto {
             String brandName,
             Integer price,
             Integer likeCount,
-            Integer stock
+            Integer stock,
+            String createdAt
     ) {
         public static ProductItem from(ProductInfo info) {
             return new ProductItem(
@@ -33,7 +34,8 @@ public class ProductV1Dto {
                     info.brandName(),
                     info.price(),
                     info.likeCount(),
-                    info.stock()
+                    info.stock(),
+                    info.createdAt() != null ? info.createdAt().toString() : null
             );
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -21,10 +21,12 @@ import com.loopers.domain.product.ProductService;
 import com.loopers.domain.product.Stock;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import com.loopers.utils.RedisCleanUp;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,11 +40,19 @@ class ProductFacadeIntegrationTest {
     @Autowired
     private ProductFacade productFacade;
 
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
     @MockitoSpyBean
     private ProductService productService;
 
     @MockitoSpyBean
     private BrandService brandService;
+
+    @BeforeEach
+    void setUp() {
+        redisCleanUp.truncateAll();
+    }
 
     @DisplayName("상품 목록을 조회할 때,")
     @Nested

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -66,7 +66,7 @@ class ProductFacadeIntegrationTest {
             Map<Long, String> brandNamesMap = new HashMap<>();
             brandNamesMap.put(1L, "브랜드1");
 
-            doReturn(products).when(productService).findProductsByLatestWithBrandName(brandId, page, size);
+            doReturn(products).when(productService).findProductsByLatest(brandId, page, size);
             doReturn(brandNamesMap).when(brandService).findBrandNamesByIds(any());
 
             // act
@@ -84,7 +84,7 @@ class ProductFacadeIntegrationTest {
             );
 
             // verify
-            verify(productService, times(1)).findProductsByLatestWithBrandName(brandId, page, size);
+            verify(productService, times(1)).findProductsByLatest(brandId, page, size);
             verify(brandService, times(1)).findBrandNamesByIds(any());
         }
 
@@ -107,7 +107,7 @@ class ProductFacadeIntegrationTest {
             brandNamesMap.put(1L, "브랜드1");
             brandNamesMap.put(2L, "브랜드2");
 
-            doReturn(products).when(productService).findProductsByPriceAscWithBrandName(brandId, page, size);
+            doReturn(products).when(productService).findProductsByPriceAsc(brandId, page, size);
             doReturn(brandNamesMap).when(brandService).findBrandNamesByIds(any());
 
             // act
@@ -123,7 +123,7 @@ class ProductFacadeIntegrationTest {
             );
 
             // verify
-            verify(productService, times(1)).findProductsByPriceAscWithBrandName(brandId, page, size);
+            verify(productService, times(1)).findProductsByPriceAsc(brandId, page, size);
             verify(brandService, times(1)).findBrandNamesByIds(any());
         }
 
@@ -145,7 +145,7 @@ class ProductFacadeIntegrationTest {
             Map<Long, String> brandNamesMap = new HashMap<>();
             brandNamesMap.put(1L, "브랜드1");
 
-            doReturn(products).when(productService).findProductsByLikesDescWithBrandName(brandId, page, size);
+            doReturn(products).when(productService).findProductsByLikesDesc(brandId, page, size);
             doReturn(brandNamesMap).when(brandService).findBrandNamesByIds(any());
 
             // act
@@ -161,7 +161,7 @@ class ProductFacadeIntegrationTest {
             );
 
             // verify
-            verify(productService, times(1)).findProductsByLikesDescWithBrandName(brandId, page, size);
+            verify(productService, times(1)).findProductsByLikesDesc(brandId, page, size);
             verify(brandService, times(1)).findBrandNamesByIds(any());
         }
 
@@ -185,7 +185,7 @@ class ProductFacadeIntegrationTest {
             brandNamesMap.put(1L, "브랜드1");
             brandNamesMap.put(2L, "브랜드2");
 
-            doReturn(products).when(productService).findProductsByLatestWithBrandName(brandId, page, size);
+            doReturn(products).when(productService).findProductsByLatest(brandId, page, size);
             doReturn(brandNamesMap).when(brandService).findBrandNamesByIds(any());
 
             // act
@@ -200,7 +200,7 @@ class ProductFacadeIntegrationTest {
             );
 
             // verify
-            verify(productService, times(1)).findProductsByLatestWithBrandName(brandId, page, size);
+            verify(productService, times(1)).findProductsByLatest(brandId, page, size);
             verify(brandService, times(1)).findBrandNamesByIds(any());
         }
 
@@ -221,7 +221,7 @@ class ProductFacadeIntegrationTest {
             Map<Long, String> brandNamesMap = new HashMap<>();
             brandNamesMap.put(1L, "브랜드1");
 
-            doReturn(products).when(productService).findProductsByLatestWithBrandName(brandId, page, size);
+            doReturn(products).when(productService).findProductsByLatest(brandId, page, size);
             doReturn(brandNamesMap).when(brandService).findBrandNamesByIds(any());
 
             // act
@@ -233,7 +233,7 @@ class ProductFacadeIntegrationTest {
             assertThat(result.get(0).brandName()).isEqualTo("브랜드1");
 
             // verify
-            verify(productService, times(1)).findProductsByLatestWithBrandName(brandId, page, size);
+            verify(productService, times(1)).findProductsByLatest(brandId, page, size);
             verify(brandService, times(1)).findBrandNamesByIds(any());
         }
 
@@ -250,7 +250,7 @@ class ProductFacadeIntegrationTest {
 
             List<Product> products = List.of();
 
-            doReturn(products).when(productService).findProductsByLatestWithBrandName(brandId, page, size);
+            doReturn(products).when(productService).findProductsByLatest(brandId, page, size);
             doReturn(new HashMap<>()).when(brandService).findBrandNamesByIds(any());
 
             // act
@@ -260,7 +260,7 @@ class ProductFacadeIntegrationTest {
             assertThat(result).isEmpty();
 
             // verify
-            verify(productService, times(1)).findProductsByLatestWithBrandName(brandId, page, size);
+            verify(productService, times(1)).findProductsByLatest(brandId, page, size);
             verify(brandService, times(1)).findBrandNamesByIds(any());
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -1,0 +1,309 @@
+package com.loopers.domain.product;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.utils.DatabaseCleanUp;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class ProductServiceIntegrationTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("상품 목록을 조회할 때,")
+    @Nested
+    class FindProducts {
+
+        @DisplayName("최신순 정렬 시 createdAt 내림차순으로 반환된다.")
+        @Test
+        void returnsProductsSortedByLatest() throws Exception {
+            // arrange
+            Long brandId = 1L;
+            int page = 0;
+            int size = 10;
+
+            Product product1 = Product.createProduct(
+                    "상품1", brandId,
+                    Price.createPrice(10000),
+                    LikeCount.createLikeCount(10),
+                    Stock.createStock(100)
+            );
+            productRepository.saveProduct(product1);
+            Thread.sleep(10);
+
+            Product product2 = Product.createProduct(
+                    "상품2", brandId,
+                    Price.createPrice(20000),
+                    LikeCount.createLikeCount(20),
+                    Stock.createStock(200)
+            );
+            productRepository.saveProduct(product2);
+            Thread.sleep(10);
+
+            Product product3 = Product.createProduct(
+                    "상품3", brandId,
+                    Price.createPrice(30000),
+                    LikeCount.createLikeCount(30),
+                    Stock.createStock(300)
+            );
+            productRepository.saveProduct(product3);
+
+            // act
+            List<Product> result = productService.findProductsByLatest(brandId, page, size);
+
+            // assert
+            assertThat(result).hasSize(3);
+            assertAll(
+                    () -> assertThat(result.get(0).getName()).isEqualTo("상품3"),
+                    () -> assertThat(result.get(1).getName()).isEqualTo("상품2"),
+                    () -> assertThat(result.get(2).getName()).isEqualTo("상품1")
+            );
+        }
+
+        @DisplayName("가격 오름차순 정렬 시 price 오름차순으로 반환된다.")
+        @Test
+        void returnsProductsSortedByPriceAsc() throws Exception {
+            // arrange
+            Long brandId = 1L;
+            int page = 0;
+            int size = 10;
+
+            Product product1 = Product.createProduct(
+                    "상품1", brandId,
+                    Price.createPrice(30000),
+                    LikeCount.createLikeCount(10),
+                    Stock.createStock(100)
+            );
+            productRepository.saveProduct(product1);
+
+            Product product2 = Product.createProduct(
+                    "상품2", brandId,
+                    Price.createPrice(10000),
+                    LikeCount.createLikeCount(20),
+                    Stock.createStock(200)
+            );
+            productRepository.saveProduct(product2);
+
+            Product product3 = Product.createProduct(
+                    "상품3", brandId,
+                    Price.createPrice(20000),
+                    LikeCount.createLikeCount(30),
+                    Stock.createStock(300)
+            );
+            productRepository.saveProduct(product3);
+
+            // act
+            List<Product> result = productService.findProductsByPriceAsc(brandId, page, size);
+
+            // assert
+            assertThat(result).hasSize(3);
+            assertAll(
+                    () -> assertThat(result.get(0).getName()).isEqualTo("상품2"),
+                    () -> assertThat(result.get(0).getPrice().getPrice()).isEqualTo(10000),
+                    () -> assertThat(result.get(1).getName()).isEqualTo("상품3"),
+                    () -> assertThat(result.get(1).getPrice().getPrice()).isEqualTo(20000),
+                    () -> assertThat(result.get(2).getName()).isEqualTo("상품1"),
+                    () -> assertThat(result.get(2).getPrice().getPrice()).isEqualTo(30000)
+            );
+        }
+
+        @DisplayName("좋아요 내림차순 정렬 시 likeCount 내림차순으로 반환된다.")
+        @Test
+        void returnsProductsSortedByLikesDesc() throws Exception {
+            // arrange
+            Long brandId = 1L;
+            int page = 0;
+            int size = 10;
+
+            Product product1 = Product.createProduct(
+                    "상품1", brandId,
+                    Price.createPrice(10000),
+                    LikeCount.createLikeCount(30),
+                    Stock.createStock(100)
+            );
+            productRepository.saveProduct(product1);
+
+            Product product2 = Product.createProduct(
+                    "상품2", brandId,
+                    Price.createPrice(20000),
+                    LikeCount.createLikeCount(10),
+                    Stock.createStock(200)
+            );
+            productRepository.saveProduct(product2);
+
+            Product product3 = Product.createProduct(
+                    "상품3", brandId,
+                    Price.createPrice(30000),
+                    LikeCount.createLikeCount(50),
+                    Stock.createStock(300)
+            );
+            productRepository.saveProduct(product3);
+
+            // act
+            List<Product> result = productService.findProductsByLikesDesc(brandId, page, size);
+
+            // assert
+            assertThat(result).hasSize(3);
+            assertAll(
+                    () -> assertThat(result.get(0).getName()).isEqualTo("상품3"),
+                    () -> assertThat(result.get(0).getLikeCount().getCount()).isEqualTo(50),
+                    () -> assertThat(result.get(1).getName()).isEqualTo("상품1"),
+                    () -> assertThat(result.get(1).getLikeCount().getCount()).isEqualTo(30),
+                    () -> assertThat(result.get(2).getName()).isEqualTo("상품2"),
+                    () -> assertThat(result.get(2).getLikeCount().getCount()).isEqualTo(10)
+            );
+        }
+
+        @DisplayName("isDeleted가 true인 상품은 조회되지 않는다.")
+        @Test
+        void excludesDeletedProducts() throws Exception {
+            // arrange
+            Long brandId = 1L;
+            int page = 0;
+            int size = 10;
+
+            Product activeProduct1 = Product.createProduct(
+                    "상품1", brandId,
+                    Price.createPrice(10000),
+                    LikeCount.createLikeCount(10),
+                    Stock.createStock(100)
+            );
+            productRepository.saveProduct(activeProduct1);
+
+            Product activeProduct2 = Product.createProduct(
+                    "상품2", brandId,
+                    Price.createPrice(20000),
+                    LikeCount.createLikeCount(20),
+                    Stock.createStock(200)
+            );
+            productRepository.saveProduct(activeProduct2);
+
+            Product deletedProduct = Product.createProduct(
+                    "삭제된상품", brandId,
+                    Price.createPrice(30000),
+                    LikeCount.createLikeCount(30),
+                    Stock.createStock(300)
+            );
+            productRepository.saveProduct(deletedProduct);
+            setDeleted(deletedProduct, true);
+            productRepository.saveProduct(deletedProduct);
+
+            // act
+            List<Product> result = productService.findProductsByLatest(brandId, page, size);
+
+            // assert
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(Product::getName)
+                    .containsExactlyInAnyOrder("상품1", "상품2");
+            assertThat(result).extracting(Product::getName)
+                    .doesNotContain("삭제된상품");
+        }
+
+        @DisplayName("페이지네이션이 올바르게 동작한다.")
+        @Test
+        void paginationWorksCorrectly() throws Exception {
+            // arrange
+            Long brandId = 1L;
+
+            // 5개의 상품 생성
+            for (int i = 1; i <= 5; i++) {
+                Product product = Product.createProduct(
+                        "상품" + i, brandId,
+                        Price.createPrice(10000 * i),
+                        LikeCount.createLikeCount(10 * i),
+                        Stock.createStock(100 * i)
+                );
+                productRepository.saveProduct(product);
+                Thread.sleep(10);
+            }
+
+            // act
+            List<Product> page1 = productService.findProductsByLatest(brandId, 0, 2);
+            List<Product> page2 = productService.findProductsByLatest(brandId, 1, 2);
+            List<Product> page3 = productService.findProductsByLatest(brandId, 2, 2);
+
+            // assert
+            assertThat(page1).hasSize(2);
+            assertThat(page2).hasSize(2);
+            assertThat(page3).hasSize(1);
+
+            assertThat(page1.get(0).getName()).isEqualTo("상품5");
+            assertThat(page1.get(1).getName()).isEqualTo("상품4");
+            assertThat(page2.get(0).getName()).isEqualTo("상품3");
+            assertThat(page2.get(1).getName()).isEqualTo("상품2");
+            assertThat(page3.get(0).getName()).isEqualTo("상품1");
+        }
+
+        @DisplayName("brandId로 필터링이 올바르게 동작한다.")
+        @Test
+        void filtersByBrandId() throws Exception {
+            // arrange
+            Long brandId1 = 1L;
+            Long brandId2 = 2L;
+            int page = 0;
+            int size = 10;
+
+            Product product1 = Product.createProduct(
+                    "브랜드1상품1", brandId1,
+                    Price.createPrice(10000),
+                    LikeCount.createLikeCount(10),
+                    Stock.createStock(100)
+            );
+            productRepository.saveProduct(product1);
+
+            Product product2 = Product.createProduct(
+                    "브랜드1상품2", brandId1,
+                    Price.createPrice(20000),
+                    LikeCount.createLikeCount(20),
+                    Stock.createStock(200)
+            );
+            productRepository.saveProduct(product2);
+
+            Product product3 = Product.createProduct(
+                    "브랜드2상품1", brandId2,
+                    Price.createPrice(30000),
+                    LikeCount.createLikeCount(30),
+                    Stock.createStock(300)
+            );
+            productRepository.saveProduct(product3);
+
+            // act
+            List<Product> result = productService.findProductsByLatest(brandId1, page, size);
+
+            // assert
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(Product::getBrandId)
+                    .containsOnly(brandId1);
+            assertThat(result).extracting(Product::getName)
+                    .containsExactlyInAnyOrder("브랜드1상품1", "브랜드1상품2");
+        }
+    }
+
+    private void setDeleted(Product product, boolean isDeleted) throws Exception {
+        Field field = Product.class.getDeclaredField("isDeleted");
+        field.setAccessible(true);
+        field.setBoolean(product, isDeleted);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/cache/ProductCacheServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/cache/ProductCacheServiceIntegrationTest.java
@@ -1,0 +1,342 @@
+package com.loopers.infrastructure.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.product.ProductInfo;
+import com.loopers.application.product.ProductSort;
+import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ProductCacheServiceIntegrationTest {
+
+    @Autowired
+    private ProductCacheService productCacheService;
+
+    @Autowired
+    @Qualifier("redisTemplateObject")
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    @Qualifier("redisTemplateObjectMaster")
+    private RedisTemplate<String, Object> redisTemplateMaster;
+
+    @Autowired
+    @Qualifier("redisObjectMapper")
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("상품 상세 조회 캐시 테스트")
+    @Nested
+    class ProductDetailCacheTest {
+
+        @DisplayName("캐시 미스 시 DB에서 조회하고 캐시에 저장한다.")
+        @Test
+        void savesToCache_whenCacheMiss() {
+            // arrange
+            Long productId = 1L;
+            ProductInfo expectedProduct = createProductInfo(productId, "상품1", 1L, "브랜드1", 10000, 10, 100);
+
+            // act
+            ProductInfo result = productCacheService.getProduct(productId, () -> expectedProduct);
+
+            // assert
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt")
+                    .isEqualTo(expectedProduct);
+
+            String cacheKey = productCacheService.getProductDetailKey(productId);
+            Object cachedValue = redisTemplate.opsForValue().get(cacheKey);
+            assertThat(cachedValue).isNotNull();
+
+            ProductInfo cachedProduct = objectMapper.convertValue(
+                    cachedValue, ProductInfo.class);
+            assertThat(cachedProduct)
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt")
+                    .isEqualTo(expectedProduct);
+        }
+
+        @DisplayName("캐시 히트 시 DB를 조회하지 않고 캐시에서 반환한다.")
+        @Test
+        void returnsFromCache_whenCacheHit() {
+            // arrange
+            Long productId = 1L;
+            ProductInfo product1 = createProductInfo(productId, "상품1", 1L, "브랜드1", 10000, 10, 100);
+            ProductInfo product2 = createProductInfo(productId, "상품2", 1L, "브랜드1", 20000, 20, 200);
+
+            productCacheService.getProduct(productId, () -> product1);
+
+            // act
+            int[] dbCallCount = {0};
+            ProductInfo result = productCacheService.getProduct(productId, () -> {
+                dbCallCount[0]++;
+                return product2;
+            });
+
+            // assert
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt")
+                    .isEqualTo(product1);
+            assertThat(dbCallCount[0]).isEqualTo(0);
+        }
+
+        @DisplayName("TTL이 임계값 이하일 때 Stale-While-Revalidate가 동작한다.")
+        @Test
+        void triggersStaleWhileRevalidate_whenTtlBelowThreshold() throws InterruptedException {
+            // arrange
+            Long productId = 1L;
+            ProductInfo product1 = createProductInfo(productId, "상품1", 1L, "브랜드1", 10000, 10, 100);
+            ProductInfo product2 = createProductInfo(productId, "상품2", 1L, "브랜드1", 20000, 20, 200);
+
+            String cacheKey = productCacheService.getProductDetailKey(productId);
+            redisTemplateMaster.opsForValue().set(cacheKey, product1, 15, TimeUnit.SECONDS);
+
+            Thread.sleep(6000);
+
+            // act
+            int[] dbCallCount = {0};
+            ProductInfo result = productCacheService.getProduct(productId, () -> {
+                dbCallCount[0]++;
+                return product2;
+            });
+
+            // assert
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt")
+                    .isEqualTo(product1);
+            
+            Thread.sleep(3000);
+
+            assertThat(dbCallCount[0]).isGreaterThanOrEqualTo(0);
+
+            Object cachedValue = redisTemplate.opsForValue().get(cacheKey);
+            assertThat(cachedValue).isNotNull();
+            ProductInfo cachedProduct = objectMapper.convertValue(
+                    cachedValue, ProductInfo.class);
+            assertThat(cachedProduct).isNotNull();
+        }
+
+        @DisplayName("TTL 만료 후 조회 시 DB에서 조회하고 캐시에 저장한다.")
+        @Test
+        void queriesFromDb_whenCacheExpired() throws InterruptedException {
+            // arrange
+            Long productId = 1L;
+            ProductInfo product1 = createProductInfo(productId, "상품1", 1L, "브랜드1", 10000, 10, 100);
+            ProductInfo product2 = createProductInfo(productId, "상품2", 1L, "브랜드1", 20000, 20, 200);
+
+            String cacheKey = productCacheService.getProductDetailKey(productId);
+            redisTemplateMaster.opsForValue().set(cacheKey, product1, 1, TimeUnit.SECONDS);
+
+            Thread.sleep(2000);
+
+            // act
+            int[] dbCallCount = {0};
+            ProductInfo result = productCacheService.getProduct(productId, () -> {
+                dbCallCount[0]++;
+                return product2;
+            });
+
+            // assert
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt")
+                    .isEqualTo(product2);
+            assertThat(dbCallCount[0]).isEqualTo(1);
+
+            Object cachedValue = redisTemplate.opsForValue().get(cacheKey);
+            assertThat(cachedValue).isNotNull();
+            ProductInfo cachedProduct = objectMapper.convertValue(
+                    cachedValue, ProductInfo.class);
+            assertThat(cachedProduct)
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt")
+                    .isEqualTo(product2);
+        }
+    }
+
+    @DisplayName("상품 목록 조회 캐시 테스트")
+    @Nested
+    class ProductListCacheTest {
+
+        @DisplayName("캐시 미스 시 DB에서 조회하고 캐시에 저장한다.")
+        @Test
+        void savesToCache_whenCacheMiss() {
+            // arrange
+            Long brandId = null;
+            ProductSort sort = ProductSort.LATEST;
+            int page = 0;
+            int size = 20;
+            List<ProductInfo> expectedProducts = List.of(
+                    createProductInfo(1L, "상품1", 1L, "브랜드1", 10000, 10, 100),
+                    createProductInfo(2L, "상품2", 1L, "브랜드1", 20000, 20, 200)
+            );
+
+            // act
+            List<ProductInfo> result = productCacheService.getProductList(
+                    brandId, sort, page, size, () -> expectedProducts);
+
+            // assert
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt")
+                    .isEqualTo(expectedProducts);
+
+            String cacheKey = productCacheService.getProductListKey(brandId, sort, page, size);
+            Object cachedValue = redisTemplate.opsForValue().get(cacheKey);
+            assertThat(cachedValue).isNotNull();
+        }
+
+        @DisplayName("캐시 히트 시 DB를 조회하지 않고 캐시에서 반환한다.")
+        @Test
+        void returnsFromCache_whenCacheHit() {
+            // arrange
+            Long brandId = null;
+            ProductSort sort = ProductSort.LATEST;
+            int page = 0;
+            int size = 20;
+            List<ProductInfo> products1 = List.of(
+                    createProductInfo(1L, "상품1", 1L, "브랜드1", 10000, 10, 100)
+            );
+            List<ProductInfo> products2 = List.of(
+                    createProductInfo(2L, "상품2", 1L, "브랜드1", 20000, 20, 200)
+            );
+
+            productCacheService.getProductList(brandId, sort, page, size, () -> products1);
+
+            // act
+            int[] dbCallCount = {0};
+            List<ProductInfo> result = productCacheService.getProductList(
+                    brandId, sort, page, size, () -> {
+                        dbCallCount[0]++;
+                        return products2;
+                    });
+
+            // assert
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt")
+                    .isEqualTo(products1);
+            assertThat(dbCallCount[0]).isEqualTo(0);
+        }
+
+        @DisplayName("다른 정렬 조건은 별도의 캐시 키를 사용한다.")
+        @Test
+        void usesDifferentCacheKeys_forDifferentSorts() {
+            // arrange
+            Long brandId = null;
+            int page = 0;
+            int size = 20;
+            List<ProductInfo> latestProducts = List.of(
+                    createProductInfo(1L, "상품1", 1L, "브랜드1", 10000, 10, 100)
+            );
+            List<ProductInfo> priceAscProducts = List.of(
+                    createProductInfo(2L, "상품2", 1L, "브랜드1", 20000, 20, 200)
+            );
+
+            // act
+            productCacheService.getProductList(brandId, ProductSort.LATEST, page, size, () -> latestProducts);
+            productCacheService.getProductList(brandId, ProductSort.PRICE_ASC, page, size, () -> priceAscProducts);
+
+            // assert
+            String latestKey = productCacheService.getProductListKey(brandId, ProductSort.LATEST, page, size);
+            String priceAscKey = productCacheService.getProductListKey(brandId, ProductSort.PRICE_ASC, page, size);
+
+            assertThat(redisTemplate.hasKey(latestKey)).isTrue();
+            assertThat(redisTemplate.hasKey(priceAscKey)).isTrue();
+            assertThat(latestKey).isNotEqualTo(priceAscKey);
+        }
+
+        @DisplayName("브랜드 필터링은 별도의 캐시 키를 사용한다.")
+        @Test
+        void usesDifferentCacheKeys_forDifferentBrands() {
+            // arrange
+            int page = 0;
+            int size = 20;
+            List<ProductInfo> allBrandProducts = List.of(
+                    createProductInfo(1L, "상품1", 1L, "브랜드1", 10000, 10, 100)
+            );
+            List<ProductInfo> brand1Products = List.of(
+                    createProductInfo(2L, "상품2", 1L, "브랜드1", 20000, 20, 200)
+            );
+
+            // act
+            productCacheService.getProductList(null, ProductSort.LATEST, page, size, () -> allBrandProducts);
+            productCacheService.getProductList(1L, ProductSort.LATEST, page, size, () -> brand1Products);
+
+            // assert
+            String allBrandKey = productCacheService.getProductListKey(null, ProductSort.LATEST, page, size);
+            String brand1Key = productCacheService.getProductListKey(1L, ProductSort.LATEST, page, size);
+
+            assertThat(redisTemplate.hasKey(allBrandKey)).isTrue();
+            assertThat(redisTemplate.hasKey(brand1Key)).isTrue();
+            assertThat(allBrandKey).isNotEqualTo(brand1Key);
+        }
+    }
+
+    @DisplayName("캐시 무효화 테스트")
+    @Nested
+    class CacheInvalidationTest {
+
+        @DisplayName("상품 상세 캐시를 직접 삭제할 수 있다.")
+        @Test
+        void deletesProductDetailCache() {
+            // arrange
+            Long productId = 1L;
+            ProductInfo product = createProductInfo(productId, "상품1", 1L, "브랜드1", 10000, 10, 100);
+            productCacheService.getProduct(productId, () -> product);
+
+            String cacheKey = productCacheService.getProductDetailKey(productId);
+            assertThat(redisTemplate.hasKey(cacheKey)).isTrue();
+
+            // act
+            redisTemplateMaster.delete(cacheKey);
+
+            // assert
+            assertThat(redisTemplateMaster.hasKey(cacheKey)).isFalse();
+        }
+    }
+
+    private ProductInfo createProductInfo(
+            Long id, String name, Long brandId, String brandName,
+            Integer price, Integer likeCount, Integer stock) {
+        return new ProductInfo(
+                id,
+                name,
+                brandId,
+                brandName,
+                price,
+                likeCount,
+                stock,
+                ZonedDateTime.now()
+        );
+    }
+}
+

--- a/insert_test_data.sql
+++ b/insert_test_data.sql
@@ -1,0 +1,205 @@
+-- ============================================================================
+-- 성능 테스트를 위한 대량 데이터 삽입 스크립트
+-- ============================================================================
+-- 
+-- 이 스크립트는 다음을 생성합니다:
+-- 1. 100개의 브랜드 데이터
+-- 2. 100,000개의 상품 데이터
+--
+-- 데이터 분포:
+-- - brand_id: 1~100 사이 균등 분포 (각 브랜드당 약 1,000개)
+-- - price: 1,000원 ~ 1,000,000원 (저가 10%, 중저가 30%, 중가 40%, 고가 15%, 프리미엄 5%)
+-- - like_count: 0 ~ 100,000 (다양한 분포)
+-- - stock: 0 ~ 10,000 (품절 5%, 다양한 재고 수준)
+-- - is_deleted: false 95%, true 5%
+-- - created_at: 과거 1년간 분포 (최근 데이터가 더 많음)
+--
+-- ============================================================================
+
+-- 1. 브랜드 데이터 생성 (100개)
+-- 다양한 브랜드를 생성하여 brandId 필터링 테스트에 활용
+INSERT INTO brands (name, description, created_at, updated_at, deleted_at)
+SELECT 
+    CONCAT('Brand_', LPAD(n, 3, '0')) as name,
+    CONCAT('Description for Brand ', n) as description,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM 
+        (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+        (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+        (SELECT @row := 0) r
+    LIMIT 100
+) numbers;
+
+-- 2. 상품 데이터 생성 (100,000개)
+-- 각 컬럼의 값이 다양하게 분포하도록 설정
+INSERT INTO products (
+    name, 
+    brand_id, 
+    price, 
+    like_count, 
+    stock, 
+    version, 
+    is_deleted, 
+    created_at, 
+    updated_at, 
+    deleted_at
+)
+SELECT 
+    CONCAT('Product_', LPAD(n, 6, '0')) as name,
+    -- brandId: 1~100 사이 균등 분포 (각 브랜드당 약 1,000개씩)
+    ((n - 1) % 100) + 1 as brand_id,
+    -- price: 1,000원 ~ 1,000,000원 사이 다양하게 분포
+    -- 가격대별로 분포: 저가(10%), 중저가(30%), 중가(40%), 고가(15%), 프리미엄(5%)
+    -- n % 100을 사용하여 균등 분포 보장
+    CASE 
+        WHEN n % 100 < 10 THEN FLOOR(1000 + (n * 7) % 9000)                    -- 1,000 ~ 10,000 (10%)
+        WHEN n % 100 < 40 THEN FLOOR(10000 + (n * 11) % 40000)                  -- 10,000 ~ 50,000 (30%)
+        WHEN n % 100 < 80 THEN FLOOR(50000 + (n * 13) % 200000)                 -- 50,000 ~ 250,000 (40%)
+        WHEN n % 100 < 95 THEN FLOOR(250000 + (n * 17) % 500000)                -- 250,000 ~ 750,000 (15%)
+        ELSE FLOOR(750000 + (n * 19) % 250000)                                   -- 750,000 ~ 1,000,000 (5%)
+    END as price,
+    -- like_count: 0 ~ 100,000 사이 다양하게 분포
+    -- 좋아요 수는 정규분포와 유사하게, 대부분은 중간값에 집중
+    CASE 
+        WHEN n % 100 < 20 THEN (n * 3) % 100                            -- 0 ~ 100 (20%)
+        WHEN n % 100 < 50 THEN 100 + (n * 5) % 900                      -- 100 ~ 1,000 (30%)
+        WHEN n % 100 < 80 THEN 1000 + (n * 7) % 9000                    -- 1,000 ~ 10,000 (30%)
+        WHEN n % 100 < 95 THEN 10000 + (n * 11) % 40000                  -- 10,000 ~ 50,000 (15%)
+        ELSE 50000 + (n * 13) % 50000                                     -- 50,000 ~ 100,000 (5%)
+    END as like_count,
+    -- stock: 0 ~ 10,000 사이 다양하게 분포
+    -- 재고는 대부분 양수, 일부는 0 (품절)
+    CASE 
+        WHEN n % 100 < 5 THEN 0                                              -- 품절 (5%)
+        WHEN n % 100 < 30 THEN 1 + (n * 2) % 99                          -- 1 ~ 100 (25%)
+        WHEN n % 100 < 70 THEN 100 + (n * 3) % 900                      -- 100 ~ 1,000 (40%)
+        WHEN n % 100 < 95 THEN 1000 + (n * 5) % 4000                    -- 1,000 ~ 5,000 (25%)
+        ELSE 5000 + (n * 7) % 5000                                       -- 5,000 ~ 10,000 (5%)
+    END as stock,
+    0 as version,
+    -- is_deleted: 대부분 false, 약 5%는 true
+    CASE WHEN n % 100 < 5 THEN 1 ELSE 0 END as is_deleted,
+    -- created_at: 과거 1년간 분포 (최신순 정렬 테스트를 위해)
+    -- 최근 데이터가 더 많도록 분포 (최근 3개월: 50%, 3~6개월: 30%, 6~12개월: 20%)
+    CASE 
+        WHEN n % 100 < 50 THEN DATE_SUB(NOW(), INTERVAL (n * 2) % 90 DAY)      -- 최근 3개월 (50%)
+        WHEN n % 100 < 80 THEN DATE_SUB(NOW(), INTERVAL (90 + (n * 3) % 90) DAY) -- 3~6개월 (30%)
+        ELSE DATE_SUB(NOW(), INTERVAL (180 + (n * 5) % 185) DAY)                  -- 6~12개월 (20%)
+    END as created_at,
+    DATE_SUB(NOW(), INTERVAL (n * 7) % 365 DAY) as updated_at,
+    -- deleted_at: is_deleted가 true인 경우에만 설정
+    CASE 
+        WHEN n % 100 < 5 THEN DATE_SUB(NOW(), INTERVAL (n * 11) % 30 DAY)
+        ELSE NULL
+    END as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM 
+        (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+        (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+        (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+        (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t4,
+        (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t5,
+        (SELECT @row := 0) r
+    LIMIT 100000
+) numbers;
+
+-- 3. 인덱스 확인 및 생성 (성능 최적화)
+-- brand_id, is_deleted, created_at, price, like_count에 대한 인덱스가 있는지 확인
+-- 필요시 다음 인덱스들을 생성 (이미 존재하면 에러 발생하므로 주의)
+
+-- brand_id와 is_deleted 복합 인덱스 (브랜드 필터링 + 삭제 여부 필터링)
+-- CREATE INDEX idx_products_brand_deleted ON products(brand_id, is_deleted);
+
+-- created_at 인덱스 (최신순 정렬)
+-- CREATE INDEX idx_products_created_at ON products(created_at DESC);
+
+-- price 인덱스 (가격 정렬)
+-- CREATE INDEX idx_products_price ON products(price);
+
+-- like_count 인덱스 (좋아요 정렬)
+-- CREATE INDEX idx_products_like_count ON products(like_count DESC);
+
+-- brand_id, is_deleted, created_at 복합 인덱스 (최신순 조회 최적화)
+-- CREATE INDEX idx_products_brand_deleted_created ON products(brand_id, is_deleted, created_at DESC);
+
+-- brand_id, is_deleted, price 복합 인덱스 (가격순 조회 최적화)
+-- CREATE INDEX idx_products_brand_deleted_price ON products(brand_id, is_deleted, price);
+
+-- brand_id, is_deleted, like_count 복합 인덱스 (좋아요순 조회 최적화)
+-- CREATE INDEX idx_products_brand_deleted_likes ON products(brand_id, is_deleted, like_count DESC);
+
+-- 4. 데이터 검증 쿼리
+-- 삽입된 데이터 확인
+
+-- 전체 상품 수 확인
+SELECT COUNT(*) as total_products FROM products;
+
+-- is_deleted별 상품 수 확인
+SELECT is_deleted, COUNT(*) as count 
+FROM products 
+GROUP BY is_deleted;
+
+-- 브랜드별 상품 수 확인 (상위 10개)
+SELECT brand_id, COUNT(*) as product_count 
+FROM products 
+WHERE is_deleted = 0 
+GROUP BY brand_id 
+ORDER BY product_count DESC 
+LIMIT 10;
+
+-- 가격 분포 확인
+SELECT 
+    CASE 
+        WHEN price < 10000 THEN '1만원 미만'
+        WHEN price < 50000 THEN '1만원~5만원'
+        WHEN price < 250000 THEN '5만원~25만원'
+        WHEN price < 750000 THEN '25만원~75만원'
+        ELSE '75만원 이상'
+    END as price_range,
+    COUNT(*) as count
+FROM products 
+WHERE is_deleted = 0
+GROUP BY price_range
+ORDER BY MIN(price);
+
+-- 좋아요 수 분포 확인
+SELECT 
+    CASE 
+        WHEN like_count < 100 THEN '0~100'
+        WHEN like_count < 1000 THEN '100~1,000'
+        WHEN like_count < 10000 THEN '1,000~10,000'
+        WHEN like_count < 50000 THEN '10,000~50,000'
+        ELSE '50,000 이상'
+    END as like_range,
+    COUNT(*) as count
+FROM products 
+WHERE is_deleted = 0
+GROUP BY like_range
+ORDER BY MIN(like_count);
+
+-- 최신순 정렬 테스트 (상위 10개)
+SELECT id, name, brand_id, price, like_count, created_at 
+FROM products 
+WHERE brand_id = 1 AND is_deleted = 0 
+ORDER BY created_at DESC 
+LIMIT 10;
+
+-- 가격 오름차순 정렬 테스트 (상위 10개)
+SELECT id, name, brand_id, price, like_count 
+FROM products 
+WHERE brand_id = 1 AND is_deleted = 0 
+ORDER BY price ASC 
+LIMIT 10;
+
+-- 좋아요 내림차순 정렬 테스트 (상위 10개)
+SELECT id, name, brand_id, price, like_count 
+FROM products 
+WHERE brand_id = 1 AND is_deleted = 0 
+ORDER BY like_count DESC 
+LIMIT 10;
+

--- a/k6_product_list.js
+++ b/k6_product_list.js
@@ -12,6 +12,7 @@ import { Rate, Trend } from 'k6/metrics';
 // 3. 좋아요 내림차순 정렬 조회 (LIKES_DESC)
 // 4. 브랜드 필터링 조회
 // 5. 페이지네이션 테스트
+// 6. 좋아요 등록
 //
 // 실행 방법:
 // 
@@ -21,16 +22,11 @@ import { Rate, Trend } from 'k6/metrics';
 // 스트레스 테스트:
 // TEST_MODE=stress k6 run k6_product_list.js
 //
-// 옵션 예시:
-// k6 run --vus 50 --duration 30s k6_product_list.js
-// TEST_MODE=stress k6 run k6_product_list.js
-//
 // ============================================================================
 
 // 테스트 모드 설정 (기본: load, 스트레스: stress)
 const TEST_MODE = __ENV.TEST_MODE || 'load';
 
-// 커스텀 메트릭
 const errorRate = new Rate('errors');
 const responseTimeLatest = new Trend('response_time_latest');
 const responseTimePriceAsc = new Trend('response_time_price_asc');
@@ -38,47 +34,39 @@ const responseTimeLikesDesc = new Trend('response_time_likes_desc');
 const responseTimeBrandFilter = new Trend('response_time_brand_filter');
 const responseTimePagination = new Trend('response_time_pagination');
 
-// 테스트 설정 (모드에 따라 다름)
 function getTestOptions() {
     if (TEST_MODE === 'stress') {
-        // 스트레스 테스트 설정: 시스템의 한계점을 찾기 위한 높은 부하
+        // 스트레스 테스트 설정
         return {
             stages: [
-                // 빠른 ramp-up으로 시스템에 부하 가하기
-                { duration: '1m', target: 100 },   // 1분 동안 100명으로 증가
-                { duration: '2m', target: 200 },   // 2분 동안 200명으로 증가
-                { duration: '3m', target: 300 },   // 3분 동안 300명으로 증가
-                { duration: '5m', target: 500 },  // 5분 동안 500명으로 증가 (최대 부하)
-                { duration: '5m', target: 500 },  // 5분 동안 500명 유지 (최대 부하 지속)
-                { duration: '2m', target: 300 },   // 2분 동안 300명으로 감소
-                { duration: '1m', target: 100 },   // 1분 동안 100명으로 감소
-                { duration: '1m', target: 0 },     // 1분 동안 0명으로 감소
+                { duration: '1m', target: 100 },
+                { duration: '2m', target: 200 },
+                { duration: '3m', target: 300 },
+                { duration: '5m', target: 500 },
+                { duration: '5m', target: 500 },
+                { duration: '2m', target: 300 },
+                { duration: '1m', target: 100 },
+                { duration: '1m', target: 0 },
             ],
             thresholds: {
-                // 스트레스 테스트는 한계점을 찾는 것이므로 더 관대한 임계값
-                // 하지만 여전히 모니터링은 필요
-                http_req_duration: ['p(95)<2000', 'p(99)<5000'],  // 스트레스 상황에서는 더 느릴 수 있음
-                errors: ['rate<0.10'],  // 스트레스 상황에서는 10%까지 허용
-                http_req_failed: ['rate<0.20'],  // 스트레스 상황에서는 20%까지 허용
+                http_req_duration: ['p(95)<2000', 'p(99)<5000'],
+                errors: ['rate<0.10'],
+                http_req_failed: ['rate<0.20'],
             },
         };
     } else {
         // 기본 부하 테스트 설정
         return {
             stages: [
-                // Ramp-up: 점진적으로 부하 증가
-                { duration: '30s', target: 50 },   // 30초 동안 50명의 가상 사용자로 증가
-                { duration: '1m', target: 100 },   // 1분 동안 100명으로 증가
-                { duration: '2m', target: 100 },   // 2분 동안 100명 유지
-                { duration: '30s', target: 50 },    // 30초 동안 50명으로 감소
-                { duration: '30s', target: 0 },   // 30초 동안 0명으로 감소
+                { duration: '30s', target: 50 },
+                { duration: '1m', target: 100 },
+                { duration: '2m', target: 100 },
+                { duration: '30s', target: 50 },
+                { duration: '30s', target: 0 },
             ],
             thresholds: {
-                // 전체 요청의 95%가 500ms 이내에 완료되어야 함
                 http_req_duration: ['p(95)<500', 'p(99)<1000'],
-                // 에러율이 1% 미만이어야 함
                 errors: ['rate<0.01'],
-                // HTTP 상태 코드가 200인 비율이 95% 이상이어야 함
                 http_req_failed: ['rate<0.05'],
             },
         };
@@ -87,21 +75,24 @@ function getTestOptions() {
 
 export const options = getTestOptions();
 
-// 기본 URL 설정
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 const API_BASE = `${BASE_URL}/api/v1/products`;
+const LIKE_API_BASE = `${BASE_URL}/api/v1/like/products`;
 
-// 브랜드 ID 목록 (1~100 사이 랜덤 선택)
 function getRandomBrandId() {
     return Math.floor(Math.random() * 100) + 1;
 }
 
-// 랜덤 페이지 번호 (0~9)
 function getRandomPage() {
     return Math.floor(Math.random() * 10);
 }
 
-// 쿼리 파라미터를 URL 문자열로 변환
+function getRandomUserId() {
+    const users = ['user1', 'user2'];
+    return users[Math.floor(Math.random() * users.length)];
+}
+
+
 function buildQueryString(params) {
     const parts = [];
     for (const key in params) {
@@ -123,20 +114,17 @@ function getProducts(params, metric) {
     });
     
     const duration = Date.now() - startTime;
-    
-    // 메트릭 기록
+
     if (metric) {
         metric.add(duration);
     }
-    
-    // 응답 검증
+
     const checks = {
         'status is 200': (r) => r.status === 200,
         'response has data': (r) => {
             try {
                 const body = JSON.parse(r.body);
-                // ApiResponse 구조: { meta: { result: 'SUCCESS' }, data: { products: [...] } }
-                return body.meta && 
+                return body.meta &&
                        body.meta.result === 'SUCCESS' && 
                        body.data && 
                        body.data.products && 
@@ -149,9 +137,8 @@ function getProducts(params, metric) {
     };
     
     const success = check(response, checks);
-    
-    // 실패 시 상세 정보 로깅 (처음 몇 개만)
-    if (!success && Math.random() < 0.01) { // 1% 확률로만 로깅하여 로그 과다 방지
+
+    if (!success && (response.status >= 500 || Math.random() < 0.01)) {
         try {
             const body = JSON.parse(response.body);
             console.error(`Request failed - URL: ${url}`);
@@ -167,13 +154,60 @@ function getProducts(params, metric) {
     return { response, success, duration };
 }
 
+// 좋아요 등록 헬퍼 함수
+function recordLike(productId, loginId) {
+    const url = `${LIKE_API_BASE}/${productId}`;
+    
+    const response = http.post(url, null, {
+        headers: {
+            'X-USER-ID': loginId,
+            'Content-Type': 'application/json',
+        },
+        tags: { name: 'like_record' },
+    });
+
+    const checks = {
+        'status is 200 or 404': (r) => r.status === 200 || r.status === 404,
+        'response has data': (r) => {
+            try {
+                const body = JSON.parse(r.body);
+                if (r.status === 404) {
+                    return true;
+                }
+                return body.meta && body.meta.result === 'SUCCESS';
+            } catch (e) {
+                return false;
+            }
+        },
+    };
+    
+    const success = check(response, checks);
+
+    if (!success && response.status >= 500) {
+        try {
+            const body = JSON.parse(response.body);
+            console.error(`Like record failed - URL: ${url}, Status: ${response.status}`);
+            console.error(`Response body: ${JSON.stringify(body).substring(0, 200)}`);
+        } catch (e) {
+            console.error(`Like record failed - URL: ${url}, Status: ${response.status}, Body parse error`);
+        }
+    }
+    
+    errorRate.add(!success);
+    
+    return { response, success };
+}
+
 // ============================================================================
 // 테스트 시나리오
 // ============================================================================
 
 export default function () {
-    // 스트레스 테스트 모드에서는 sleep 시간을 줄여 더 빠르게 요청
     const sleepTime = TEST_MODE === 'stress' ? 0.1 : 1;
+
+    const loginId = getRandomUserId();
+
+    const iteration = __ITER || 0;
     
     // 시나리오 1: 최신순 정렬 조회 (LATEST)
     const latestParams = {
@@ -183,11 +217,7 @@ export default function () {
     };
     const latestResult = getProducts(latestParams, responseTimeLatest);
     
-    if (!latestResult.success) {
-        console.error('Latest sort failed:', latestResult.response.status);
-    }
-    
-    sleep(sleepTime); // 요청 간 대기 (스트레스 모드: 0.1초, 일반 모드: 1초)
+    sleep(sleepTime);
     
     // 시나리오 2: 가격 오름차순 정렬 조회 (PRICE_ASC)
     const priceAscParams = {
@@ -196,10 +226,6 @@ export default function () {
         size: 20,
     };
     const priceAscResult = getProducts(priceAscParams, responseTimePriceAsc);
-    
-    if (!priceAscResult.success) {
-        console.error('Price ASC sort failed:', priceAscResult.response.status);
-    }
     
     sleep(sleepTime);
     
@@ -211,10 +237,6 @@ export default function () {
     };
     const likesDescResult = getProducts(likesDescParams, responseTimeLikesDesc);
     
-    if (!likesDescResult.success) {
-        console.error('Likes DESC sort failed:', likesDescResult.response.status);
-    }
-    
     sleep(sleepTime);
     
     // 시나리오 4: 브랜드 필터링 조회
@@ -225,14 +247,11 @@ export default function () {
         size: 20,
     };
     const brandFilterResult = getProducts(brandFilterParams, responseTimeBrandFilter);
-    
-    if (!brandFilterResult.success) {
-        console.error('Brand filter failed:', brandFilterResult.response.status);
-    }
+
     
     sleep(sleepTime);
     
-    // 시나리오 5: 페이지네이션 테스트 (다양한 페이지 크기)
+    // 시나리오 5: 페이지네이션 테스트
     const pageSizes = [10, 20, 50];
     const randomPageSize = pageSizes[Math.floor(Math.random() * pageSizes.length)];
     
@@ -242,10 +261,7 @@ export default function () {
         size: randomPageSize,
     };
     const paginationResult = getProducts(paginationParams, responseTimePagination);
-    
-    if (!paginationResult.success) {
-        console.error('Pagination failed:', paginationResult.response.status);
-    }
+
     
     sleep(sleepTime);
     
@@ -265,21 +281,18 @@ export default function () {
             check(brandValidationResult.response, {
                 'brand filter validation': () => {
                     if (body.data && body.data.products && body.data.products.length > 0) {
-                        // 모든 상품이 같은 브랜드인지 확인
                         return body.data.products.every(product => product.brandId === brandId);
                     }
-                    return true; // 빈 결과도 유효
+                    return true;
                 },
             });
         } catch (e) {
-            // JSON 파싱 실패는 무시
         }
     }
     
     sleep(sleepTime);
     
-    // 시나리오 7: 정렬 순서 검증 테스트
-    // 최신순 정렬 검증
+    // 시나리오 7: 최신순 정렬 검증
     const latestValidationParams = { sort: 'latest', page: 0, size: 10 };
     const latestValidationResult = getProducts(latestValidationParams, responseTimeLatest);
     
@@ -294,13 +307,12 @@ export default function () {
                 });
             }
         } catch (e) {
-            // JSON 파싱 실패는 무시
         }
     }
     
     sleep(sleepTime);
     
-    // 가격 오름차순 정렬 검증
+    // 시나리오 8: 가격 오름차순 정렬 검증
     const priceAscValidationParams = { sort: 'price_asc', page: 0, size: 10 };
     const priceAscValidationResult = getProducts(priceAscValidationParams, responseTimePriceAsc);
     
@@ -315,13 +327,12 @@ export default function () {
                 });
             }
         } catch (e) {
-            // JSON 파싱 실패는 무시
         }
     }
     
     sleep(sleepTime);
     
-    // 좋아요 내림차순 정렬 검증
+    // 시나리오 9: 좋아요 내림차순 정렬 검증
     const likesDescValidationParams = { sort: 'likes_desc', page: 0, size: 10 };
     const likesDescValidationResult = getProducts(likesDescValidationParams, responseTimeLikesDesc);
     
@@ -336,9 +347,14 @@ export default function () {
                 });
             }
         } catch (e) {
-            // JSON 파싱 실패는 무시
         }
     }
+    
+    sleep(sleepTime);
+    
+    // 시나리오 10: 유저 좋아요 등록
+    const productId = iteration + 1;
+    recordLike(productId, loginId);
     
     sleep(sleepTime);
 }
@@ -348,7 +364,6 @@ export default function () {
 // ============================================================================
 
 export function setup() {
-    // 테스트 시작 전 초기 설정
     console.log(`Starting k6 test against: ${BASE_URL}`);
     console.log(`API endpoint: ${API_BASE}`);
     console.log(`Test mode: ${TEST_MODE}`);
@@ -362,6 +377,35 @@ export function setup() {
         console.log('📊 LOAD TEST MODE: Normal performance testing');
         console.log('   - Max VUs: 100');
         console.log('   - Standard thresholds');
+    }
+    
+    // 테스트용 사용자 생성 (user1, user2)
+    const USER_API_BASE = `${BASE_URL}/api/v1/users`;
+    
+    for (let i = 1; i <= 2; i++) {
+        const loginId = `user${i}`;
+        const email = `user${i}@test.com`;
+        const birthDate = '2000-01-01';
+        const gender = 'M';
+        
+        const signupRequest = {
+            loginId: loginId,
+            email: email,
+            birthDate: birthDate,
+            gender: gender
+        };
+        
+        const response = http.post(USER_API_BASE, JSON.stringify(signupRequest), {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        
+        if (response.status === 200 || response.status === 409) {
+            console.log(`User ${loginId} ready (status: ${response.status})`);
+        } else {
+            console.warn(`Failed to create user ${loginId}: ${response.status}`);
+        }
     }
     
     return {

--- a/k6_product_list.js
+++ b/k6_product_list.js
@@ -1,0 +1,370 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+// ============================================================================
+// k6 성능 테스트 스크립트 - 상품 목록 조회 API
+// ============================================================================
+// 
+// 테스트 시나리오:
+// 1. 최신순 정렬 조회 (LATEST)
+// 2. 가격 오름차순 정렬 조회 (PRICE_ASC)
+// 3. 좋아요 내림차순 정렬 조회 (LIKES_DESC)
+// 4. 브랜드 필터링 조회
+// 5. 페이지네이션 테스트
+//
+// 실행 방법:
+// 
+// 기본 부하 테스트:
+// k6 run k6_product_list.js
+//
+// 스트레스 테스트:
+// TEST_MODE=stress k6 run k6_product_list.js
+//
+// 옵션 예시:
+// k6 run --vus 50 --duration 30s k6_product_list.js
+// TEST_MODE=stress k6 run k6_product_list.js
+//
+// ============================================================================
+
+// 테스트 모드 설정 (기본: load, 스트레스: stress)
+const TEST_MODE = __ENV.TEST_MODE || 'load';
+
+// 커스텀 메트릭
+const errorRate = new Rate('errors');
+const responseTimeLatest = new Trend('response_time_latest');
+const responseTimePriceAsc = new Trend('response_time_price_asc');
+const responseTimeLikesDesc = new Trend('response_time_likes_desc');
+const responseTimeBrandFilter = new Trend('response_time_brand_filter');
+const responseTimePagination = new Trend('response_time_pagination');
+
+// 테스트 설정 (모드에 따라 다름)
+function getTestOptions() {
+    if (TEST_MODE === 'stress') {
+        // 스트레스 테스트 설정: 시스템의 한계점을 찾기 위한 높은 부하
+        return {
+            stages: [
+                // 빠른 ramp-up으로 시스템에 부하 가하기
+                { duration: '1m', target: 100 },   // 1분 동안 100명으로 증가
+                { duration: '2m', target: 200 },   // 2분 동안 200명으로 증가
+                { duration: '3m', target: 300 },   // 3분 동안 300명으로 증가
+                { duration: '5m', target: 500 },  // 5분 동안 500명으로 증가 (최대 부하)
+                { duration: '5m', target: 500 },  // 5분 동안 500명 유지 (최대 부하 지속)
+                { duration: '2m', target: 300 },   // 2분 동안 300명으로 감소
+                { duration: '1m', target: 100 },   // 1분 동안 100명으로 감소
+                { duration: '1m', target: 0 },     // 1분 동안 0명으로 감소
+            ],
+            thresholds: {
+                // 스트레스 테스트는 한계점을 찾는 것이므로 더 관대한 임계값
+                // 하지만 여전히 모니터링은 필요
+                http_req_duration: ['p(95)<2000', 'p(99)<5000'],  // 스트레스 상황에서는 더 느릴 수 있음
+                errors: ['rate<0.10'],  // 스트레스 상황에서는 10%까지 허용
+                http_req_failed: ['rate<0.20'],  // 스트레스 상황에서는 20%까지 허용
+            },
+        };
+    } else {
+        // 기본 부하 테스트 설정
+        return {
+            stages: [
+                // Ramp-up: 점진적으로 부하 증가
+                { duration: '30s', target: 50 },   // 30초 동안 50명의 가상 사용자로 증가
+                { duration: '1m', target: 100 },   // 1분 동안 100명으로 증가
+                { duration: '2m', target: 100 },   // 2분 동안 100명 유지
+                { duration: '30s', target: 50 },    // 30초 동안 50명으로 감소
+                { duration: '30s', target: 0 },   // 30초 동안 0명으로 감소
+            ],
+            thresholds: {
+                // 전체 요청의 95%가 500ms 이내에 완료되어야 함
+                http_req_duration: ['p(95)<500', 'p(99)<1000'],
+                // 에러율이 1% 미만이어야 함
+                errors: ['rate<0.01'],
+                // HTTP 상태 코드가 200인 비율이 95% 이상이어야 함
+                http_req_failed: ['rate<0.05'],
+            },
+        };
+    }
+}
+
+export const options = getTestOptions();
+
+// 기본 URL 설정
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const API_BASE = `${BASE_URL}/api/v1/products`;
+
+// 브랜드 ID 목록 (1~100 사이 랜덤 선택)
+function getRandomBrandId() {
+    return Math.floor(Math.random() * 100) + 1;
+}
+
+// 랜덤 페이지 번호 (0~9)
+function getRandomPage() {
+    return Math.floor(Math.random() * 10);
+}
+
+// 쿼리 파라미터를 URL 문자열로 변환
+function buildQueryString(params) {
+    const parts = [];
+    for (const key in params) {
+        if (params[key] !== null && params[key] !== undefined) {
+            parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`);
+        }
+    }
+    return parts.join('&');
+}
+
+// 상품 목록 조회 헬퍼 함수
+function getProducts(params, metric) {
+    const queryString = buildQueryString(params);
+    const url = queryString ? `${API_BASE}?${queryString}` : API_BASE;
+    const startTime = Date.now();
+    
+    const response = http.get(url, {
+        tags: { name: params.sort || 'latest' },
+    });
+    
+    const duration = Date.now() - startTime;
+    
+    // 메트릭 기록
+    if (metric) {
+        metric.add(duration);
+    }
+    
+    // 응답 검증
+    const success = check(response, {
+        'status is 200': (r) => r.status === 200,
+        'response has data': (r) => {
+            try {
+                const body = JSON.parse(r.body);
+                // ApiResponse 구조: { meta: { result: 'SUCCESS' }, data: { products: [...] } }
+                return body.meta && 
+                       body.meta.result === 'SUCCESS' && 
+                       body.data && 
+                       body.data.products && 
+                       Array.isArray(body.data.products);
+            } catch (e) {
+                return false;
+            }
+        },
+        'response time < 1000ms': (r) => r.timings.duration < 1000,
+    });
+    
+    errorRate.add(!success);
+    
+    return { response, success, duration };
+}
+
+// ============================================================================
+// 테스트 시나리오
+// ============================================================================
+
+export default function () {
+    // 스트레스 테스트 모드에서는 sleep 시간을 줄여 더 빠르게 요청
+    // 일반 모드에서도 sleep 시간을 줄여 더 많은 요청 처리
+    const sleepTime = TEST_MODE === 'stress' ? 0.05 : 0.2;
+    
+    // 시나리오 1: 최신순 정렬 조회 (LATEST)
+    const latestParams = {
+        sort: 'latest',
+        page: getRandomPage(),
+        size: 20,
+    };
+    const latestResult = getProducts(latestParams, responseTimeLatest);
+    
+    if (!latestResult.success) {
+        console.error('Latest sort failed:', latestResult.response.status);
+    }
+    
+    sleep(sleepTime); // 요청 간 대기 (스트레스 모드: 0.1초, 일반 모드: 1초)
+    
+    // 시나리오 2: 가격 오름차순 정렬 조회 (PRICE_ASC)
+    const priceAscParams = {
+        sort: 'price_asc',
+        page: getRandomPage(),
+        size: 20,
+    };
+    const priceAscResult = getProducts(priceAscParams, responseTimePriceAsc);
+    
+    if (!priceAscResult.success) {
+        console.error('Price ASC sort failed:', priceAscResult.response.status);
+    }
+    
+    sleep(sleepTime);
+    
+    // 시나리오 3: 좋아요 내림차순 정렬 조회 (LIKES_DESC)
+    const likesDescParams = {
+        sort: 'likes_desc',
+        page: getRandomPage(),
+        size: 20,
+    };
+    const likesDescResult = getProducts(likesDescParams, responseTimeLikesDesc);
+    
+    if (!likesDescResult.success) {
+        console.error('Likes DESC sort failed:', likesDescResult.response.status);
+    }
+    
+    sleep(sleepTime);
+    
+    // 시나리오 4: 브랜드 필터링 조회
+    const brandFilterParams = {
+        brandId: getRandomBrandId(),
+        sort: 'latest',
+        page: 0,
+        size: 20,
+    };
+    const brandFilterResult = getProducts(brandFilterParams, responseTimeBrandFilter);
+    
+    if (!brandFilterResult.success) {
+        console.error('Brand filter failed:', brandFilterResult.response.status);
+    }
+    
+    sleep(sleepTime);
+    
+    // 시나리오 5: 페이지네이션 테스트 (다양한 페이지 크기)
+    const pageSizes = [10, 20, 50];
+    const randomPageSize = pageSizes[Math.floor(Math.random() * pageSizes.length)];
+    
+    const paginationParams = {
+        sort: 'latest',
+        page: getRandomPage(),
+        size: randomPageSize,
+    };
+    const paginationResult = getProducts(paginationParams, responseTimePagination);
+    
+    if (!paginationResult.success) {
+        console.error('Pagination failed:', paginationResult.response.status);
+    }
+    
+    sleep(sleepTime);
+    
+    // 시나리오 6: 브랜드 필터링 검증 테스트
+    const brandId = getRandomBrandId();
+    const brandValidationParams = {
+        brandId: brandId,
+        sort: 'latest',
+        page: 0,
+        size: 20,
+    };
+    const brandValidationResult = getProducts(brandValidationParams, responseTimeBrandFilter);
+    
+    if (brandValidationResult.success) {
+        try {
+            const body = JSON.parse(brandValidationResult.response.body);
+            check(brandValidationResult.response, {
+                'brand filter validation': () => {
+                    if (body.data && body.data.products && body.data.products.length > 0) {
+                        // 모든 상품이 같은 브랜드인지 확인
+                        return body.data.products.every(product => product.brandId === brandId);
+                    }
+                    return true; // 빈 결과도 유효
+                },
+            });
+        } catch (e) {
+            // JSON 파싱 실패는 무시
+        }
+    }
+    
+    sleep(sleepTime);
+    
+    // 시나리오 7: 정렬 순서 검증 테스트
+    // 최신순 정렬 검증
+    const latestValidationParams = { sort: 'latest', page: 0, size: 10 };
+    const latestValidationResult = getProducts(latestValidationParams, responseTimeLatest);
+    
+    if (latestValidationResult.success) {
+        try {
+            const body = JSON.parse(latestValidationResult.response.body);
+            if (body.data && body.data.products && body.data.products.length > 1) {
+                const firstCreatedAt = new Date(body.data.products[0].createdAt);
+                const secondCreatedAt = new Date(body.data.products[1].createdAt);
+                check(latestValidationResult.response, {
+                    'latest sort validation': () => firstCreatedAt >= secondCreatedAt,
+                });
+            }
+        } catch (e) {
+            // JSON 파싱 실패는 무시
+        }
+    }
+    
+    sleep(sleepTime);
+    
+    // 가격 오름차순 정렬 검증
+    const priceAscValidationParams = { sort: 'price_asc', page: 0, size: 10 };
+    const priceAscValidationResult = getProducts(priceAscValidationParams, responseTimePriceAsc);
+    
+    if (priceAscValidationResult.success) {
+        try {
+            const body = JSON.parse(priceAscValidationResult.response.body);
+            if (body.data && body.data.products && body.data.products.length > 1) {
+                const firstPrice = body.data.products[0].price;
+                const secondPrice = body.data.products[1].price;
+                check(priceAscValidationResult.response, {
+                    'price asc sort validation': () => firstPrice <= secondPrice,
+                });
+            }
+        } catch (e) {
+            // JSON 파싱 실패는 무시
+        }
+    }
+    
+    sleep(sleepTime);
+    
+    // 좋아요 내림차순 정렬 검증
+    const likesDescValidationParams = { sort: 'likes_desc', page: 0, size: 10 };
+    const likesDescValidationResult = getProducts(likesDescValidationParams, responseTimeLikesDesc);
+    
+    if (likesDescValidationResult.success) {
+        try {
+            const body = JSON.parse(likesDescValidationResult.response.body);
+            if (body.data && body.data.products && body.data.products.length > 1) {
+                const firstLikes = body.data.products[0].likeCount;
+                const secondLikes = body.data.products[1].likeCount;
+                check(likesDescValidationResult.response, {
+                    'likes desc sort validation': () => firstLikes >= secondLikes,
+                });
+            }
+        } catch (e) {
+            // JSON 파싱 실패는 무시
+        }
+    }
+    
+    sleep(sleepTime);
+}
+
+// ============================================================================
+// 설정 함수 (테스트 시작 전 실행)
+// ============================================================================
+
+export function setup() {
+    // 테스트 시작 전 초기 설정
+    console.log(`Starting k6 test against: ${BASE_URL}`);
+    console.log(`API endpoint: ${API_BASE}`);
+    console.log(`Test mode: ${TEST_MODE}`);
+    
+    if (TEST_MODE === 'stress') {
+        console.log('⚠️  STRESS TEST MODE: Testing system limits with high load');
+        console.log('   - Max VUs: 500');
+        console.log('   - More lenient thresholds');
+        console.log('   - Faster request rate');
+    } else {
+        console.log('📊 LOAD TEST MODE: Normal performance testing');
+        console.log('   - Max VUs: 100');
+        console.log('   - Standard thresholds');
+    }
+    
+    return {
+        baseUrl: BASE_URL,
+        apiBase: API_BASE,
+        testMode: TEST_MODE,
+        startTime: new Date().toISOString(),
+    };
+}
+
+// ============================================================================
+// 정리 함수 (테스트 종료 후 실행)
+// ============================================================================
+
+export function teardown(data) {
+    console.log(`Test completed at: ${new Date().toISOString()}`);
+    console.log(`Test started at: ${data.startTime}`);
+}
+


### PR DESCRIPTION
## 📌 Summary
- 상품 목록 조회 성능 개선 
	- 인덱스
	- Redis 캐시 도입 
		- Cache-Aside 패턴으로 상품 목록/상세 조회 결과를 캐싱
		- TTL 1분 설정으로 자동 만료
		- Stale-While-Revalidate 전략 적용 (TTL 10초 이하 시 비동기 갱신)
		- 좋아요 등록/취소 시 캐시 무효화 제거 (TTL 기반 자동 만료에 의존)
- K6 부하 테스트 스크립트 추가 

## 💬 Review Points
### 1. is_deleted 카디널리티와 인덱스 효율성 


#### 현재 인덱스 구조
```java
@Table(
    name = "products",
    indexes = {
        @Index(name = "idx_brand_id", columnList = "brand_id"),
        @Index(name = "idx_global_price", columnList = "is_deleted, price"),
        @Index(name = "idx_global_likes", columnList = "is_deleted, like_count DESC"),
        @Index(name = "idx_global_latest", columnList = "is_deleted, created_at DESC")
    }
)
```

#### 사용되는 쿼리 
```java
// 최신순 정렬 
@Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.createdAt DESC")
List<Product> findProductsByLatest(@Param("brandId") Long brandId, Pageable pageable);

// 가격순 정렬
@Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.price.price ASC")
List<Product> findProductsByPriceAsc(@Param("brandId") Long brandId, Pageable pageable);

// 좋아요순 정렬
@Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.likeCount.count DESC")
List<Product> findProductsByLikesDesc(@Param("brandId") Long brandId, Pageable pageable);
```

- `is_deleted`는 모든 쿼리에서 필수 조건이지만, 카디널리티가 낮아 인덱스 효율성이 떨어질 수 있다고 생각합니다.
- `is_deleted`가 모든 쿼리에서 공통으로 사용되는 필터 조건이기 때문에 인덱스를 설계할 때 `is_deleted`를 포함했습니다.
- 카디널리티가 낮은 컬럼을 인덱스에 포함도 괜찮을까요?



---

### 2.생성일을 id로 대신할 수 있을까요?
생성일(`created_at`)을 정렬 기준으로 사용하는 대신, PK인 id를 사용할 수 있을까요?
만약 id가 이미 시간 순서를 보장할 수 있다면, `created_at` 인덱스를 삭제해도 되지 않을까해서 질문드립니다. 

```java
// 최신순 정렬 - 현재는 created_at 사용
@Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.createdAt DESC")
List<Product> findProductsByLatest(@Param("brandId") Long brandId, Pageable pageable);
```


---

### 3. 정렬 기준별, 브랜드 필터링 메서드 분리 vs 쿼리 분리
정렬 기준마다 메서드를 따로 만들어야 할지, 아니면 infra 단에서 쿼리로 나눠야 할지 고민입니다.

그리고 brand 필터링 조건이 없는 경우와 있는 경우를 처리할 때, JpaRepository에서 다른 메서드를 써야 할까요? 아니면 그냥 쿼리를 다르게 작성하면 될까요?

#### 현재 접근 방식
- 정렬 기준별로 메서드 분리
- `brandId`가 null이면 전체 조회, 값이 있으면 필터링

#### 현재 구조
```java
// Domain Layer - ProductService
public List<Product> findProductsByLatest(Long brandId, int page, int size) {
    return productRepository.findProductsByLatest(brandId, page, size);
}

public List<Product> findProductsByPriceAsc(Long brandId, int page, int size) {
    return productRepository.findProductsByPriceAsc(brandId, page, size);
}

public List<Product> findProductsByLikesDesc(Long brandId, int page, int size) {
    return productRepository.findProductsByLikesDesc(brandId, page, size);
}
```

```java
// Infrastructure Layer - ProductJpaRepository
@Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.createdAt DESC")
List<Product> findProductsByLatest(@Param("brandId") Long brandId, Pageable pageable);

@Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.price.price ASC")
List<Product> findProductsByPriceAsc(@Param("brandId") Long brandId, Pageable pageable);

@Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.likeCount.count DESC")
List<Product> findProductsByLikesDesc(@Param("brandId") Long brandId, Pageable pageable);
```

---

### 4. 캐시 관련 로그 관리 
- 캐시 도입할 때 캐시 히트/미스, 비동기 갱신 등 중요한 이벤트를 로그로 남기고 있는데, 로그는 얼마나 남겨야 할까요?



## ✅ Checklist
- [x] 불필요한 코드 제거

### 🔖 Index
- [x] 상품 목록 API에서 brandId 기반 검색, 좋아요 순 정렬 등을 처리했다
- [x] 조회 필터, 정렬 조건별 유즈케이스를 분석하여 인덱스를 적용하고 전 후 성능비교를 진행했다

### ❤️ Structure
- [x] 상품 목록/상세 조회 시 좋아요 수를 조회 및 좋아요 순 정렬이 가능하도록 구조 개선을 진행했다
- [x] 좋아요 적용/해제 진행 시 상품 좋아요 수 또한 정상적으로 동기화되도록 진행하였다

### ⚡ Cache
- [x] Redis 캐시를 적용하고 TTL 또는 무효화 전략을 적용했다
- [x] 캐시 미스 상황에서도 서비스가 정상 동작하도록 처리했다.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * Redis 기반 상품 캐싱 기능 추가로 조회 성능 향상
  * 상품 생성일 정보가 API 응답에 추가

* **개선 사항**
  * 상품 정렬 및 필터링 기능 개선
  * 동시 요청 처리 시 에러 처리 강화
  * 데이터베이스 쿼리 성능 최적화

* **API 변경**
  * 상품 조회 관련 메서드명 정리로 API 호출 단순화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->