### PR TITLE
[volume-6] 외부 시스템 장애 및 지연 대응

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -15,6 +15,10 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
 
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3")
+    implementation("io.github.resilience4j:resilience4j-timelimiter")
+
     // querydsl
     annotationProcessor("com.querydsl:querydsl-apt::jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -11,6 +11,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
+    // http-client
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+    implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
+
     // querydsl
     annotationProcessor("com.querydsl:querydsl-apt::jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     // resilience4j
     implementation("io.github.resilience4j:resilience4j-spring-boot3")
     implementation("io.github.resilience4j:resilience4j-timelimiter")
+    implementation ("io.github.resilience4j:resilience4j-micrometer")
 
     // querydsl
     annotationProcessor("com.querydsl:querydsl-apt::jakarta")

--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -5,12 +5,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 import java.util.TimeZone;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
 @EnableCaching
+@EnableFeignClients
 public class CommerceApiApplication {
 
     @PostConstruct

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/UserLikeProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/UserLikeProductFacade.java
@@ -6,6 +6,7 @@ import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.UserModel;
 import com.loopers.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ public class UserLikeProductFacade {
     private final ProductLikeService productLikeService;
     private final ProductService productService;
 
+    @CacheEvict(cacheNames = "productLikeSummary", allEntries = true)
     @Transactional
     public void userLikeProduct(LikeCommand.Like input) {
         UserModel found = userService.getUser(input.userId());
@@ -28,6 +30,7 @@ public class UserLikeProductFacade {
         }
     }
 
+    @CacheEvict(cacheNames = "productLikeSummary", allEntries = true)
     @Transactional
     public void userUnlikeProduct(LikeCommand.Like input) {
         UserModel found = userService.getUser(input.userId());

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.application.payment.PaymentFlowType;
+import com.loopers.application.payment.PaymentInfo;
 import com.loopers.domain.order.OrderItemModel;
 
 import java.util.List;
@@ -13,7 +15,9 @@ public class OrderCommand {
      */
     public record Order (
         String userId,
-        List<OrderLine> orderLineRequests
+        List<OrderLine> orderLineRequests,
+        PaymentFlowType paymentFlowType,
+        PaymentInfo paymentInfo
     ) { }
 
     /**

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
@@ -7,12 +7,12 @@ import java.util.List;
 public class OrderResult {
     public record PreOrderResult(
             String userId,
-            int requiringPoints,
+            long requiringPoints,
             List<OrderCommand.OrderLine> successLines,
             List<OrderCommand.OrderLine> failedLines
     ) {
         public static PreOrderResult of(String userId,
-                                        int successPoint,
+                                        long successPoint,
                                         List<OrderCommand.OrderLine> successLines,
                                         List<OrderCommand.OrderLine> failedLines) {
             return new PreOrderResult(userId, successPoint, successLines, failedLines);
@@ -22,16 +22,16 @@ public class OrderResult {
     public record PlaceOrderResult(
             String userId,
             Long orderId,
-            int normalPrice,
-            int errorPrice,
+            long normalPrice,
+            long errorPrice,
             OrderStatus orderStatus,
             List<OrderCommand.OrderLine> successLines,
             List<OrderCommand.OrderLine> failedLines
     ) {
         public static PlaceOrderResult of(String userId,
                                           Long orderId,
-                                          int normalPrice,
-                                          int errorPrice,
+                                          long normalPrice,
+                                          long errorPrice,
                                         OrderStatus orderStatus,
                                         List<OrderCommand.OrderLine> successLines,
                                         List<OrderCommand.OrderLine> failedLines) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.domain.order.OrderStatus;
+
 import java.util.List;
 
 public class OrderResult {
@@ -22,6 +24,7 @@ public class OrderResult {
             Long orderId,
             int normalPrice,
             int errorPrice,
+            OrderStatus orderStatus,
             List<OrderCommand.OrderLine> successLines,
             List<OrderCommand.OrderLine> failedLines
     ) {
@@ -29,6 +32,7 @@ public class OrderResult {
                                           Long orderId,
                                           int normalPrice,
                                           int errorPrice,
+                                        OrderStatus orderStatus,
                                         List<OrderCommand.OrderLine> successLines,
                                         List<OrderCommand.OrderLine> failedLines) {
             return new PlaceOrderResult(
@@ -36,6 +40,7 @@ public class OrderResult {
                     orderId,
                     normalPrice,
                     errorPrice,
+                    orderStatus,
                     successLines,
                     failedLines);
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/UserOrderProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/UserOrderProductFacade.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.application.payment.PaymentStrategyResolver;
+import com.loopers.application.payment.strategy.PaymentStrategy;
 import com.loopers.domain.order.OrderItemModel;
 import com.loopers.domain.order.OrderItemStatus;
 import com.loopers.domain.order.OrderModel;
@@ -26,6 +28,8 @@ public class UserOrderProductFacade {
     private final ProductService productService;
     private final UserService userService;
 
+    private final PaymentStrategyResolver paymentStrategyResolver;
+
     @Transactional(readOnly = true)
     public OrderResult.PreOrderResult preOrder(OrderCommand.Order orderCommand) {
         UserModel userModel = userService.getUser(orderCommand.userId());
@@ -45,36 +49,24 @@ public class UserOrderProductFacade {
     /**
      * [요구사항] 주문 전체 흐름에 대한 원자성이 보장
      * - 재고가 존재하지 않거나 부족할 경우 주문은 실패
-     * - 주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패
+     * - 주문 시 유저의 결제방식은 결제 전략 패턴을 통해 처리합니다
      * - 쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리
-     * - 주문 성공 시, 모든 처리는 정상 반영
      * @param orderCommand
      */
     @Transactional
     public OrderResult.PlaceOrderResult placeOrder(OrderCommand.Order orderCommand) {
 
         List<OrderItemModel> orderItems = toDomainOrderItem(orderCommand.orderLineRequests());
-        // OrderModel orderModel = orderService.createPendingOrder(userModel, orderItems);
-
         UserModel userModel = userService.getUser(orderCommand.userId());
         StockResult stockResult = decreaseAllStocks(orderItems);
 
-        Integer requiringPoints = stockResult.requiringPrice();
-        // 포인트 부족 시 롤백
-        if(!userModel.hasEnoughPoint(requiringPoints)) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "포인트가 부족합니다. 다시 확인해주세요");
-        }
-
-        userService.decreaseUserPoint(userModel.getId(), requiringPoints);
-
         boolean hasOutOfStockCase = !stockResult.failedLines().isEmpty();
         if(hasOutOfStockCase) {
-            // orderService.updateOrderAsPartialSuccess(orderModel, stockResult.requiringPrice() , stockResult.errorPrice());
             throw new CoreException(ErrorType.BAD_REQUEST, "재고가 부족합니다. 다시 확인해주세요");
         }
 
-        // orderService.updateOrderAsSuccess(orderModel, stockResult.requiringPrice());
-        OrderModel orderModel = orderService.createSuccessOrder(userModel, orderItems, stockResult.requiringPrice());
+        PaymentStrategy paymentStrategy = paymentStrategyResolver.resolve(orderCommand.paymentFlowType());
+        OrderModel orderModel = paymentStrategy.createOrder(userModel, orderItems, stockResult);
 
         return OrderResult.PlaceOrderResult.of(
                 userModel.getUserId(),

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/UserOrderProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/UserOrderProductFacade.java
@@ -5,7 +5,6 @@ import com.loopers.application.payment.strategy.PaymentStrategy;
 import com.loopers.domain.order.OrderItemModel;
 import com.loopers.domain.order.OrderItemStatus;
 import com.loopers.domain.order.OrderModel;
-import com.loopers.domain.order.OrderService;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.UserModel;
@@ -24,7 +23,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class UserOrderProductFacade {
-    private final OrderService orderService;
     private final ProductService productService;
     private final UserService userService;
 
@@ -73,6 +71,7 @@ public class UserOrderProductFacade {
                 orderModel.getId(),
                 stockResult.requiringPrice(),
                 stockResult.errorPrice(),
+                orderModel.getStatus(),
                 stockResult.successLines(),
                 stockResult.failedLines()
         );

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/UserOrderProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/UserOrderProductFacade.java
@@ -162,8 +162,8 @@ public class UserOrderProductFacade {
         return OrderResult.PlaceOrderResult.of(
                 orderModel.getUser().getUserId(),
                 orderModel.getId(),
-                orderModel.getNormalPrice() == null ? 0 : orderModel.getNormalPrice(),
-                orderModel.getErrorPrice() == null ? 0 : orderModel.getErrorPrice(),
+                orderModel.getNormalPrice(),
+                orderModel.getErrorPrice(),
                 orderModel.getStatus(),
                 successLines,
                 failedLines

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFlowType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFlowType.java
@@ -1,0 +1,9 @@
+package com.loopers.application.payment;
+
+/**
+ * 결제 방식에 대한 애플리케이션 정책을 결정합니다
+ */
+public enum PaymentFlowType {
+    POINT_ONLY,
+    PG_ONLY
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentInfo.java
@@ -1,0 +1,6 @@
+package com.loopers.application.payment;
+
+public record PaymentInfo(
+    String cardType,
+    String cardNo
+) { }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentStrategyResolver.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentStrategyResolver.java
@@ -1,0 +1,22 @@
+package com.loopers.application.payment;
+
+import com.loopers.application.payment.strategy.PaymentStrategy;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentStrategyResolver {
+    private final List<PaymentStrategy> strategies;
+
+    public PaymentStrategy resolve(PaymentFlowType paymentFlowType) {
+        return strategies.stream()
+                .filter(s -> s.getType() == paymentFlowType)
+                .findFirst()
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "올바르지 않은 결제 방식입니다."));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/strategy/PaymentStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/strategy/PaymentStrategy.java
@@ -1,0 +1,17 @@
+package com.loopers.application.payment.strategy;
+
+import com.loopers.application.order.StockResult;
+import com.loopers.application.payment.PaymentFlowType;
+import com.loopers.domain.order.OrderItemModel;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.user.UserModel;
+
+import java.util.List;
+
+public interface PaymentStrategy {
+    OrderModel createOrder(UserModel user,
+                           List<OrderItemModel> items,
+                           StockResult stockResult);
+
+    PaymentFlowType getType();
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/strategy/PgPaymentStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/strategy/PgPaymentStrategy.java
@@ -1,0 +1,36 @@
+package com.loopers.application.payment.strategy;
+
+import com.loopers.application.order.StockResult;
+import com.loopers.application.payment.PaymentFlowType;
+import com.loopers.domain.order.OrderItemModel;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.user.UserModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PgPaymentStrategy implements PaymentStrategy {
+    private final OrderService orderService;
+
+    /**
+     * PG사를 통한 결제의 경우 내부 포인트 금액과 상관없이 처리합니다.
+     * PG사의 경우 대외거래가 포함되므로 OrderStatus.PENDING으로 주문정보를 생성합니다.
+     * @param user
+     * @param items
+     * @param stockResult
+     * @return
+     */
+    @Override
+    public OrderModel createOrder(UserModel user, List<OrderItemModel> items, StockResult stockResult) {
+        return orderService.createPendingOrder(user, items);
+    }
+
+    @Override
+    public PaymentFlowType getType() {
+        return PaymentFlowType.PG_ONLY;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/strategy/PointPaymentStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/strategy/PointPaymentStrategy.java
@@ -1,0 +1,47 @@
+package com.loopers.application.payment.strategy;
+
+import com.loopers.application.order.StockResult;
+import com.loopers.application.payment.PaymentFlowType;
+import com.loopers.domain.order.OrderItemModel;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.user.UserModel;
+import com.loopers.domain.user.UserService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PointPaymentStrategy implements PaymentStrategy {
+
+    private final OrderService orderService;
+    private final UserService userService;
+
+    /**
+     * 내부 포인트 결제이고 주문 과정이 정상이면 주문은 바로 성공합니다
+     * @param user
+     * @param items
+     * @param stockResult
+     * @return
+     */
+    @Override
+    public OrderModel createOrder(UserModel user, List<OrderItemModel> items, StockResult stockResult) {
+        int requiringPoints = stockResult.requiringPrice();
+
+        if (!user.hasEnoughPoint(requiringPoints)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트가 부족합니다. 다시 확인해주세요!");
+        }
+        userService.decreaseUserPoint(user.getId(), requiringPoints);
+
+        return orderService.createSuccessOrder(user, items, requiringPoints);
+    }
+
+    @Override
+    public PaymentFlowType getType() {
+        return PaymentFlowType.POINT_ONLY;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemModel.java
@@ -49,6 +49,10 @@ public class OrderItemModel extends BaseEntity {
         this.status = status;
     }
 
+    public OrderItemStatus getStatus() {
+        return status;
+    }
+
     public Integer getPrice() {
         return price;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
@@ -18,9 +18,9 @@ public class OrderModel extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
 
-    private Integer totalPrice;
-    private Integer normalPrice;
-    private Integer errorPrice;
+    private long totalPrice;
+    private long normalPrice;
+    private long errorPrice;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
@@ -48,7 +48,7 @@ public class OrderModel extends BaseEntity {
         return orderModel;
     }
 
-    static OrderModel createSuccess(UserModel userModel, List<OrderItemModel> orderItems, int normalPrice) {
+    static OrderModel createSuccess(UserModel userModel, List<OrderItemModel> orderItems, long normalPrice) {
         OrderModel orderModel = new OrderModel();
         orderModel.user = userModel;
         orderModel.updateToSuccess(normalPrice);
@@ -70,17 +70,17 @@ public class OrderModel extends BaseEntity {
         status = OrderStatus.PENDING;
     }
 
-    void updateToSuccess(int normalPrice) {
+    void updateToSuccess(long normalPrice) {
         status = OrderStatus.SUCCESS;
         this.normalPrice = normalPrice;
     }
 
-    void updateToFailed(int errorPrice) {
+    void updateToFailed(long errorPrice) {
         status = OrderStatus.FAILED;
         this.errorPrice = errorPrice;
     }
 
-    void updateToPartialSuccess(int normalPrice, int errorPrice) {
+    void updateToPartialSuccess(long normalPrice, long errorPrice) {
         status = OrderStatus.PARTIAL_SUCCESS;
         this.normalPrice = normalPrice;
         this.errorPrice = errorPrice;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
@@ -3,6 +3,7 @@ package com.loopers.domain.order;
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.user.UserModel;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +14,7 @@ public class OrderModel extends BaseEntity {
 
     private Integer orderCnt;
 
+    @Getter
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
 
@@ -92,4 +94,5 @@ public class OrderModel extends BaseEntity {
         }
         return totalPrice;
     }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
@@ -10,18 +10,17 @@ import java.util.List;
 
 @Entity
 @Table(name = "orders")
+@Getter
 public class OrderModel extends BaseEntity {
 
     private Integer orderCnt;
 
-    @Getter
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
 
     private Integer totalPrice;
     private Integer normalPrice;
     private Integer errorPrice;
-
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
@@ -87,6 +87,10 @@ public class OrderModel extends BaseEntity {
         this.errorPrice = errorPrice;
     }
 
+    void updateStatus(OrderStatus status) {
+        this.status = status;
+    }
+
     static Integer getTotalPrice(List<OrderItemModel> orderItems) {
         Integer totalPrice = 0;
         for (OrderItemModel orderItem : orderItems) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -1,5 +1,8 @@
 package com.loopers.domain.order;
 
+import java.util.Optional;
+
 public interface OrderRepository {
     OrderModel save(OrderModel order);
+    Optional<OrderModel> findById(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -27,6 +27,13 @@ public class OrderService {
         orderModel.updateToFailed(errorPrice);
     }
 
+    @Transactional
+    public void updateOrderAsFailed(Long orderId) {
+        OrderModel orderModel = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
+        orderModel.updateToFailed(orderModel.getTotalPrice());
+    }
+
     @Transactional(readOnly = true)
     public boolean isPending(Long orderId) {
         OrderModel orderModel = orderRepository.findById(orderId)
@@ -52,5 +59,11 @@ public class OrderService {
     public OrderModel createSuccessOrder(UserModel userModel, List<OrderItemModel> orderItems, int normalPrice) {
         OrderModel orderModel = OrderModel.createSuccess(userModel, orderItems, normalPrice);
         return orderRepository.save(orderModel);
+    }
+
+    @Transactional(readOnly = true)
+    public OrderModel getOrder(Long orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -21,7 +21,7 @@ public class OrderService {
     }
 
     @Transactional
-    public void updateOrderAsFailed(Long orderId, int errorPrice) {
+    public void updateOrderAsFailed(Long orderId, long errorPrice) {
         OrderModel orderModel = orderRepository.findById(orderId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
         orderModel.updateToFailed(errorPrice);
@@ -42,10 +42,10 @@ public class OrderService {
     }
 
     @Transactional
-    public void updateOrderAsSuccess(Long orderId, int normalPrice) {
+    public void updateOrderAsSuccess(Long orderId, long normalPrice) {
         OrderModel orderModel = orderRepository.findById(orderId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
-        orderModel.updateToFailed(normalPrice);
+        orderModel.updateToSuccess(normalPrice);
     }
 
     @Transactional
@@ -56,7 +56,7 @@ public class OrderService {
     }
 
     @Transactional
-    public OrderModel createSuccessOrder(UserModel userModel, List<OrderItemModel> orderItems, int normalPrice) {
+    public OrderModel createSuccessOrder(UserModel userModel, List<OrderItemModel> orderItems, long normalPrice) {
         OrderModel orderModel = OrderModel.createSuccess(userModel, orderItems, normalPrice);
         return orderRepository.save(orderModel);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -1,6 +1,8 @@
 package com.loopers.domain.order;
 
 import com.loopers.domain.user.UserModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,14 +20,35 @@ public class OrderService {
         return orderRepository.save(orderModel);
     }
 
-    public void updateOrderAsPartialSuccess(OrderModel orderModel, int normalPrice, int errorPrice) {
-        orderModel.updateToPartialSuccess(normalPrice, errorPrice);
+    @Transactional
+    public void updateOrderAsFailed(Long orderId, int errorPrice) {
+        OrderModel orderModel = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
+        orderModel.updateToFailed(errorPrice);
     }
 
-    public void updateOrderAsSuccess(OrderModel orderModel, int normalPrice) {
-        orderModel.updateToSuccess(normalPrice);
+    @Transactional(readOnly = true)
+    public boolean isPending(Long orderId) {
+        OrderModel orderModel = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
+        return orderModel.getStatus() == OrderStatus.PENDING;
     }
 
+    @Transactional
+    public void updateOrderAsSuccess(Long orderId, int normalPrice) {
+        OrderModel orderModel = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
+        orderModel.updateToFailed(normalPrice);
+    }
+
+    @Transactional
+    public void updateOrderStatus(Long orderId, OrderStatus status) {
+        OrderModel orderModel = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
+        orderModel.updateStatus(status);
+    }
+
+    @Transactional
     public OrderModel createSuccessOrder(UserModel userModel, List<OrderItemModel> orderItems, int normalPrice) {
         OrderModel orderModel = OrderModel.createSuccess(userModel, orderItems, normalPrice);
         return orderRepository.save(orderModel);

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -4,5 +4,5 @@ import com.loopers.domain.order.OrderModel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderJpaRepository extends JpaRepository<OrderModel, Long> {
-    // TODO
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.loopers.domain.order.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Component
 public class OrderRepositoryImpl implements OrderRepository {
@@ -13,5 +15,10 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Override
     public OrderModel save(OrderModel order) {
         return orderJpaRepository.save(order);
+    }
+
+    @Override
+    public Optional<OrderModel> findById(Long id) {
+        return orderJpaRepository.findById(id);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
@@ -4,6 +4,7 @@ import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "주문 V1 API", description = "유저의 주문을 처리하는 API")
 public interface OrderV1ApiSpec {
@@ -26,4 +27,18 @@ public interface OrderV1ApiSpec {
             @Schema(name="", description = "주문 실행, 재고 및 결제 가능여부 확인 후 주문 처리")
             OrderV1Dto.OrderRequest request
     );
+
+    @Operation(
+            summary = "주문 상세 정보 확인",
+            description = ""
+    )
+    ApiResponse<OrderV1Dto.OrderResponse> getOrderDetails(
+        @PathVariable Long orderId
+    );
+
+    @Operation(
+            summary = "주문 처리중 원거래 결과 확인",
+            description = ""
+    )
+    ApiResponse<?> checkOrderStatus(@PathVariable("orderId") Long orderId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -1,22 +1,23 @@
 package com.loopers.interfaces.api.order;
 
-import com.loopers.application.order.OrderResult;
 import com.loopers.application.order.OrderCommand;
+import com.loopers.application.order.OrderResult;
 import com.loopers.application.order.UserOrderProductFacade;
 import com.loopers.application.payment.PaymentFlowType;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.order.OrderStatus;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.pgVendor.PgPaymentService;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/order")
 public class OrderV1Controller implements OrderV1ApiSpec {
     private final UserOrderProductFacade userOrderProductFacade;
+    private final OrderService orderService;
     private final PgPaymentService pgPaymentService;
 
     @PostMapping("/preOrder")
@@ -44,4 +45,29 @@ public class OrderV1Controller implements OrderV1ApiSpec {
                 placeOrderResult
         ));
     }
+
+    @GetMapping("/{orderId}")
+    @Override
+    public ApiResponse<OrderV1Dto.OrderResponse> getOrderDetails(@PathVariable("orderId") Long orderId) {
+        OrderResult.PlaceOrderResult orderResult = userOrderProductFacade.getOrderResult(orderId);
+        return ApiResponse.success(
+                OrderV1Dto.OrderResponse.fromOrderPlacement(orderResult)
+        );
+    }
+
+    @PutMapping("/{orderId}/payment/pendingRetry")
+    @Override
+    public ApiResponse<?> checkOrderStatus(@PathVariable("orderId") Long orderId) {
+        OrderResult.PlaceOrderResult orderResult = userOrderProductFacade.getOrderResult(orderId);
+        if(orderResult.orderStatus() != OrderStatus.PENDING) {
+            return ApiResponse.fail(ErrorType.BAD_REQUEST.getCode(), "처리중인 주문상품만 입력해주세요");
+        }
+        pgPaymentService.requestPaymentForPendingOrder(orderResult.userId(), orderResult.orderId());
+
+        OrderResult.PlaceOrderResult result = userOrderProductFacade.getOrderResult(orderId);
+        return ApiResponse.success(
+                OrderV1Dto.OrderResponse.fromOrderPlacement(result)
+        );
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -3,7 +3,9 @@ package com.loopers.interfaces.api.order;
 import com.loopers.application.order.OrderResult;
 import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.UserOrderProductFacade;
+import com.loopers.application.payment.PaymentFlowType;
 import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.pgVendor.PgPaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/order")
 public class OrderV1Controller implements OrderV1ApiSpec {
     private final UserOrderProductFacade userOrderProductFacade;
+    private final PgPaymentService pgPaymentService;
 
     @PostMapping("/preOrder")
     @Override
@@ -30,6 +33,12 @@ public class OrderV1Controller implements OrderV1ApiSpec {
         OrderCommand.Order orderCmd = request.toCommand();
         OrderResult.PlaceOrderResult placeOrderResult = userOrderProductFacade.placeOrder(orderCmd);
 
+        /**
+         * PG 결제인 경우
+         */
+        if(request.paymentFlowType().equals(PaymentFlowType.PG_ONLY)) {
+            pgPaymentService.requestPaymentForOrder(placeOrderResult, request);
+        }
 
         return ApiResponse.success(OrderV1Dto.OrderResponse.fromOrderPlacement(
                 placeOrderResult

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -29,6 +29,8 @@ public class OrderV1Controller implements OrderV1ApiSpec {
     public ApiResponse<OrderV1Dto.OrderResponse> placeOrder(@RequestBody OrderV1Dto.OrderRequest request) {
         OrderCommand.Order orderCmd = request.toCommand();
         OrderResult.PlaceOrderResult placeOrderResult = userOrderProductFacade.placeOrder(orderCmd);
+
+
         return ApiResponse.success(OrderV1Dto.OrderResponse.fromOrderPlacement(
                 placeOrderResult
         ));

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -41,8 +41,8 @@ public class OrderV1Dto {
 
     public record OrderResponse(
             String userId, // 이용자ID
-            Integer normalPrice,
-            Integer errorPrice,
+            Long normalPrice,
+            Long errorPrice,
             Long orderId, // 실 주문의 경우에만 값 존재
             String status, // 주문 상태
             int successCount,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -4,6 +4,7 @@ import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.OrderResult;
 import com.loopers.application.payment.PaymentFlowType;
 import com.loopers.application.payment.PaymentInfo;
+import com.loopers.domain.order.OrderModel;
 
 import java.util.List;
 
@@ -107,6 +108,25 @@ public class OrderV1Dto {
             );
         }
 
+        /**
+         * 주문 세부정보로 변환합니다.
+         * @param orderModel
+         * @return
+         */
+        public static OrderResponse getOrderDetail(OrderModel orderModel) {
+            return new OrderResponse(
+                    orderModel.getUser().getUserId(),
+                    orderModel.getNormalPrice(),
+                    orderModel.getErrorPrice(),
+                    orderModel.getId(),
+                    orderModel.getStatus().toString(),
+                    0,
+                    0,
+                    null,
+                    null
+            );
+        }
+
     }
 
     /**
@@ -140,4 +160,7 @@ public class OrderV1Dto {
             return new OrderLineResponse(orderLine.productId(), orderLine.quantity());
         }
     }
+
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -99,7 +99,7 @@ public class OrderV1Dto {
                     placeOrderResult.normalPrice(),  // 실제 사용 포인트
                     placeOrderResult.errorPrice(),
                     placeOrderResult.orderId(),                          // 여기서는 포인트 부족이면 예외로 롤백 처리했다고 가정
-                    "ORDERED",
+                    placeOrderResult.orderStatus().toString(),
                     successLines.size(),
                     failedLines.size(),
                     successLines,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -2,6 +2,8 @@ package com.loopers.interfaces.api.order;
 
 import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.OrderResult;
+import com.loopers.application.payment.PaymentFlowType;
+import com.loopers.application.payment.PaymentInfo;
 
 import java.util.List;
 
@@ -14,7 +16,9 @@ public class OrderV1Dto {
      */
     public record OrderRequest(
             String userId,
-            List<OrderLineRequest> orderLineRequests
+            List<OrderLineRequest> orderLineRequests,
+            PaymentFlowType paymentFlowType,
+            PaymentInfo paymentInfo
     ) {
 
         /**
@@ -25,14 +29,14 @@ public class OrderV1Dto {
             List<OrderCommand.OrderLine> lineCommands = orderLineRequests.stream()
                     .map(OrderLineRequest::toCommand)
                     .toList();
-
             return new OrderCommand.Order(
                     userId,
-                    lineCommands
+                    lineCommands,
+                    paymentFlowType,
+                    paymentInfo
             );
         }
     }
-
 
     public record OrderResponse(
             String userId, // 이용자ID

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgCallbackController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgCallbackController.java
@@ -40,7 +40,7 @@ public class PgCallbackController {
             log.info("OrderId : {}, Order status updated to SUCCESS", orderId);
         } else if("FAILED".equals(status)) {
             orderService.updateOrderStatus(orderId, OrderStatus.FAILED);
-            log.error("OrderId : {}, Order status updated to Failed", orderId);
+            log.error("OrderId : {}, Order status updated to Failed Because {}", orderId, callback.reason());
         } else {
             log.error("OrderId : {}, Callback replied unexpected status: {}", orderId, status);
         }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgCallbackController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgCallbackController.java
@@ -1,0 +1,65 @@
+package com.loopers.interfaces.api.pgVendor;
+
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.order.OrderStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PgCallbackController {
+    private final OrderService orderService;
+
+    @PostMapping("/callback")
+    public ResponseEntity<Map<String, Object>> callback(@RequestBody PgPaymentV1Dto.Response callback) {
+        log.info("callback = {}", callback);
+
+        if(callback.status() == null || callback.status().isBlank()) {
+            return ResponseEntity.badRequest().body(assembleResponse("INVALID"));
+        }
+
+        String status = callback.status();
+        long orderId = Long.parseLong(callback.orderId());
+
+        if(!orderService.isPending(orderId)) {
+            log.error("Order id {} is not pending", orderId);
+            return ResponseEntity.ok(assembleResponse("FAILED"));
+        }
+
+        if ("SUCCESS".equals(status)) {
+            orderService.updateOrderStatus(orderId, OrderStatus.SUCCESS);
+            log.info("OrderId : {}, Order status updated to SUCCESS", orderId);
+        } else if("FAILED".equals(status)) {
+            orderService.updateOrderStatus(orderId, OrderStatus.FAILED);
+            log.error("OrderId : {}, Order status updated to Failed", orderId);
+        } else {
+            log.error("OrderId : {}, Callback replied unexpected status: {}", orderId, status);
+        }
+
+        return ResponseEntity.ok(assembleResponse("SUCCESS"));
+    }
+
+    private Map<String, Object> assembleResponse(String response) {
+        return Map.of(
+                "meta", Map.of(
+                        "result", response
+                )
+        );
+    }
+
+    /*@PostMapping("/callback")
+    public ResponseEntity<String> callbackRaw(HttpServletRequest request) throws Exception {
+        String raw = new String(request.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        log.error("RAW CALLBACK BODY = {}", raw);
+        return ResponseEntity.ok("OK");
+    }*/
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgCallbackController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgCallbackController.java
@@ -36,10 +36,10 @@ public class PgCallbackController {
         }
 
         if ("SUCCESS".equals(status)) {
-            orderService.updateOrderStatus(orderId, OrderStatus.SUCCESS);
+            orderService.updateOrderAsSuccess(orderId, callback.amount());
             log.info("OrderId : {}, Order status updated to SUCCESS", orderId);
         } else if("FAILED".equals(status)) {
-            orderService.updateOrderStatus(orderId, OrderStatus.FAILED);
+            orderService.updateOrderAsFailed(orderId, callback.amount());
             log.error("OrderId : {}, Order status updated to Failed Because {}", orderId, callback.reason());
         } else {
             log.error("OrderId : {}, Callback replied unexpected status: {}", orderId, status);

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgClient.java
@@ -1,0 +1,17 @@
+package com.loopers.interfaces.api.pgVendor;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(
+        name = "pgClient",
+        url = "http://localhost:8082"
+)
+public interface PgClient {
+    @PostMapping("/api/v1/payments")
+    PgPaymentV1Dto.Response requestPayment(
+            @RequestHeader("X-USER-ID") String userId,
+            @RequestBody PgPaymentV1Dto.Request request);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgClient.java
@@ -1,5 +1,6 @@
 package com.loopers.interfaces.api.pgVendor;
 
+import com.loopers.interfaces.api.ApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 )
 public interface PgClient {
     @PostMapping("/api/v1/payments")
-    PgPaymentV1Dto.Response requestPayment(
+    void requestPayment(
             @RequestHeader("X-USER-ID") String userId,
             @RequestBody PgPaymentV1Dto.Request request);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgClient.java
@@ -1,10 +1,7 @@
 package com.loopers.interfaces.api.pgVendor;
 
-import com.loopers.interfaces.api.ApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.*;
 
 @FeignClient(
         name = "pgClient",
@@ -14,5 +11,12 @@ public interface PgClient {
     @PostMapping("/api/v1/payments")
     void requestPayment(
             @RequestHeader("X-USER-ID") String userId,
-            @RequestBody PgPaymentV1Dto.Request request);
+            @RequestBody PgPaymentV1Dto.Request request
+    );
+
+    @GetMapping("/api/v1/payments")
+    void requestPaymentWithOrderId(
+            @RequestHeader("X-USER-ID") String userId,
+            @RequestParam("orderId") String orderId
+    );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgFeignConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgFeignConfig.java
@@ -1,0 +1,18 @@
+package com.loopers.interfaces.api.pgVendor;
+
+import feign.Client;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PgFeignConfig {
+    /**
+     * LoadBalancer 안 타는 기본 Feign Client
+     */
+    @Bean
+    public Client feignClient() {
+        // 첫 번째 인자: SSLSocketFactory (null이면 기본)
+        // 두 번째 인자: HostnameVerifier (null이면 기본)
+        return new Client.Default(null, null);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentRetry.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentRetry.java
@@ -1,0 +1,36 @@
+package com.loopers.interfaces.api.pgVendor;
+
+import com.loopers.domain.order.OrderService;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PgPaymentRetry {
+    private final PgClient pgClient;
+    private final OrderService orderService;
+
+    /**
+     * PG 요청에 대해 Resilience4j Retry 로직
+     * @ref application.yml
+     * @param request
+     * @return
+     */
+    @Retry(name = "pgPayment", fallbackMethod = "pgPaymentFallback")
+    public void requestPaymentWithRetry(String userId, PgPaymentV1Dto.Request request) {
+        pgClient.requestPayment(userId, request);
+    }
+
+    public void pgPaymentFallback(String userId, PgPaymentV1Dto.Request request, Throwable ex) {
+        log.error("[PG PAYMENT] all retries failed. userId={}, orderId={}, cause={}",
+                userId, request.orderId(), ex.toString());
+
+        // long parseOrderId = Long.parseLong(request.orderId());
+        // orderService.updateOrderAsFailed(parseOrderId, request.amount());
+        // 처리중으로 그대로 남깁니다.
+        // 추후 별도의 테이블로 관리할 수도 있겠습니다.
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentRetry.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentRetry.java
@@ -1,5 +1,7 @@
 package com.loopers.interfaces.api.pgVendor;
 
+import com.loopers.domain.order.OrderService;
+import feign.FeignException;
 import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PgPaymentRetry {
     private final PgClient pgClient;
+    private final OrderService orderService;
 
     /**
      * PG 요청에 대해 Resilience4j Retry 로직
@@ -31,4 +34,28 @@ public class PgPaymentRetry {
         // 처리중으로 그대로 남깁니다.
         // 추후 별도의 테이블로 관리할 수도 있겠습니다.
     }
+
+
+    @Retry(name = "pgPayment", fallbackMethod = "pgPaymentOrderStatusFallback")
+    public void requestPaymentForPendingOrder(String userId, String orderId) {
+        log.debug("[PG PAYMENT] called for orderId={}", orderId);
+        pgClient.requestPaymentWithOrderId(userId, orderId);
+    }
+
+    public void pgPaymentOrderStatusFallback(String userId, String orderId, Throwable ex) {
+        log.error("[PG PAYMENT] all retries failed. userId={}, orderId={}, cause={}",
+                userId, orderId, ex.toString());
+
+        // 내부 시스템 원장에만 처리중으로 남고 / PG사 원거래 조회시 거래 건 없음
+        if (ex instanceof FeignException fe) {
+            if (fe.status() == 404) {
+                log.error("[PG PAYMENT] 404 NOT FOUND → 결제 실패로 처리합니다. userId={}, orderId={}", userId, orderId);
+                long parseOrderId = Long.parseLong(orderId);
+                orderService.updateOrderAsFailed(parseOrderId);
+            }
+        }
+
+    }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentRetry.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentRetry.java
@@ -1,6 +1,5 @@
 package com.loopers.interfaces.api.pgVendor;
 
-import com.loopers.domain.order.OrderService;
 import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +10,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PgPaymentRetry {
     private final PgClient pgClient;
-    private final OrderService orderService;
 
     /**
      * PG 요청에 대해 Resilience4j Retry 로직

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentService.java
@@ -1,6 +1,7 @@
 package com.loopers.interfaces.api.pgVendor;
 
 import com.loopers.application.order.OrderResult;
+import com.loopers.domain.order.OrderService;
 import com.loopers.interfaces.api.order.OrderV1Dto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,4 +31,15 @@ public class PgPaymentService {
         );
         pgPaymentRetry.requestPaymentWithRetry(orderResult.userId(), pgRequest);
     }
+
+    /**
+     * 동기 처리 및 Resilience Retry를 AOP로 호출
+     * @param userId
+     * @param orderId
+     */
+    public void requestPaymentForPendingOrder(String userId, Long orderId) {
+        String paddingId = "00000" + orderId.toString();
+        pgPaymentRetry.requestPaymentForPendingOrder(userId, paddingId);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentService.java
@@ -1,9 +1,7 @@
 package com.loopers.interfaces.api.pgVendor;
 
 import com.loopers.application.order.OrderResult;
-import com.loopers.domain.order.OrderService;
 import com.loopers.interfaces.api.order.OrderV1Dto;
-import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentService.java
@@ -1,24 +1,39 @@
 package com.loopers.interfaces.api.pgVendor;
 
 import com.loopers.application.order.OrderResult;
+import com.loopers.domain.order.OrderService;
 import com.loopers.interfaces.api.order.OrderV1Dto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class PgPaymentService {
     private final PgClient pgClient;
+    private final OrderService orderService;
 
-    public PgPaymentV1Dto.Response requestPaymentForOrder(OrderResult.PlaceOrderResult orderResult,
+    /**
+     * 비동기 요청 송신
+     * @param orderResult
+     * @param request
+     * @ref AsyncConfig
+     */
+    @Async("pgExecutor")
+    public void requestPaymentForOrder(OrderResult.PlaceOrderResult orderResult,
                                                           OrderV1Dto.OrderRequest request) {
         PgPaymentV1Dto.Request pgRequest = PgPaymentV1Dto.Request.of(
                 "00000" + orderResult.orderId().toString(),
                 request.paymentInfo(),
                 orderResult.normalPrice(),
-                "http://localhost:8080/"
+                "http://localhost:8080/api/v1/payments/callback"
         );
 
-        return pgClient.requestPayment(orderResult.userId(), pgRequest);
+        try {
+            PgPaymentV1Dto.Response pgRes = pgClient.requestPayment(orderResult.userId(), pgRequest);
+        } catch (Exception e) {
+            // [TODO] PG 요청 자체가 실패한 경우 retry 3번 후 그래도 실패하면 주문 상태를 FAILED 로 갱신
+            orderService.updateOrderAsFailed(orderResult.orderId(), orderResult.errorPrice());
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentService.java
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.pgVendor;
+
+import com.loopers.application.order.OrderResult;
+import com.loopers.interfaces.api.order.OrderV1Dto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PgPaymentService {
+    private final PgClient pgClient;
+
+    public PgPaymentV1Dto.Response requestPaymentForOrder(OrderResult.PlaceOrderResult orderResult,
+                                                          OrderV1Dto.OrderRequest request) {
+        PgPaymentV1Dto.Request pgRequest = PgPaymentV1Dto.Request.of(
+                "00000" + orderResult.orderId().toString(),
+                request.paymentInfo(),
+                orderResult.normalPrice(),
+                "http://localhost:8080/"
+        );
+
+        return pgClient.requestPayment(orderResult.userId(), pgRequest);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentV1Dto.java
@@ -1,11 +1,6 @@
 package com.loopers.interfaces.api.pgVendor;
 
-import com.loopers.application.order.OrderCommand;
-import com.loopers.application.payment.PaymentFlowType;
 import com.loopers.application.payment.PaymentInfo;
-import com.loopers.interfaces.api.order.OrderV1Dto;
-
-import java.util.List;
 
 public class PgPaymentV1Dto {
 
@@ -31,9 +26,15 @@ public class PgPaymentV1Dto {
         }
     }
 
-    public record Response (
+    public record Response(
             String transactionKey,
+            String orderId,
+            String cardType,
+            String cardNo,
+            long amount,
             String status,
             String reason
-    ) { }
+    ) {}
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/pgVendor/PgPaymentV1Dto.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.api.pgVendor;
+
+import com.loopers.application.order.OrderCommand;
+import com.loopers.application.payment.PaymentFlowType;
+import com.loopers.application.payment.PaymentInfo;
+import com.loopers.interfaces.api.order.OrderV1Dto;
+
+import java.util.List;
+
+public class PgPaymentV1Dto {
+
+    public record Request (
+        String orderId,
+        String cardType,
+        String cardNo,
+        long amount,
+        String callbackUrl
+    ) {
+        public static PgPaymentV1Dto.Request of(
+                String orderId,
+                PaymentInfo paymentInfo,
+                long amount,
+                String callbackUrl) {
+            return new PgPaymentV1Dto.Request(
+                    orderId,
+                    paymentInfo.cardType(),
+                    paymentInfo.cardNo(),
+                    amount,
+                    callbackUrl
+            );
+        }
+    }
+
+    public record Response (
+            String transactionKey,
+            String status,
+            String reason
+    ) { }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/async/AsyncConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/async/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.loopers.support.async;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "pgExecutor")
+    public Executor pgExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("pg-async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -44,6 +44,21 @@ cloud:
           url: http://localhost:8082
           connect-timeout: 2000
           read-timeout: 6000
+feign:
+  Logger:
+    Level=FULL:
+
+resilience4j:
+  retry:
+    instances:
+      pgPayment:
+        max-attempts: 3               # 최초시도 + 재시도 2번
+        wait-duration: 1s             # 재시도 간격
+        retry-exceptions:             # 재시도할 예외 지정
+          - feign.RetryableException
+        ignore-exceptions:            # 재시도 하지 않고 실패 처리할 예외
+          - com.loopers.support.error.CoreException
+        fail-after-max-attempts: true
 
 ---
 spring:

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -59,6 +59,24 @@ resilience4j:
         ignore-exceptions:            # 재시도 하지 않고 실패 처리할 예외
           - com.loopers.support.error.CoreException
         fail-after-max-attempts: true
+  circuitbreaker:
+    instances:
+      pgCircuit:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 5       # 최소 호출건수
+        failure-rate-threshold: 65       # 실패율이 60% 넘으면 Open
+        wait-duration-in-open-state: 10s # Open 상태 유지 시간 (Open->Half Open)
+        permitted-number-of-calls-in-half-open-state: 2 # Half-Open 에서 테스트 -> 성공 Closed / 실패 Open
+        slow-call-duration-threshold: 5s # 느린 응답 임계값
+        slow-call-rate-threshold: 50    # 느린 응답 비율
+        record-exceptions:
+          - feign.RetryableException
+          - feign.FeignException.InternalServerError
+          - feign.FeignException.ServiceUnavailable
+        # 내부 에러는 예외
+        ignore-exceptions:
+          - com.loopers.support.error.CoreException
 
 ---
 spring:

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -42,8 +42,8 @@ cloud:
       config:
         pgClient:
           url: http://localhost:8082
-          connect-timeout: 5000
-          read-timeout: 5000
+          connect-timeout: 2000
+          read-timeout: 6000
 
 ---
 spring:

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -77,7 +77,15 @@ resilience4j:
         # 내부 에러는 예외
         ignore-exceptions:
           - com.loopers.support.error.CoreException
-
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health, metrics, circuitbreakers
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 ---
 spring:
   config:

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -23,17 +23,34 @@ spring:
       - redis.yml
       - logging.yml
       - monitoring.yml
+logging:
+  pattern:
+    console: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
 
 springdoc:
   use-fqn: true
   swagger-ui:
     path: /swagger-ui.html
+cloud:
+  loadbalancer:
+    enabled: false
+  openfeign:
+    client:
+      config:
+        pgClient:
+          url: http://localhost:8082
+          connect-timeout: 5000
+          read-timeout: 5000
 
 ---
 spring:
   config:
     activate:
       on-profile: local, test
+
 
 ---
 spring:

--- a/apps/commerce-api/src/test/java/com/loopers/application/OrderConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/OrderConcurrencyTest.java
@@ -3,6 +3,7 @@ package com.loopers.application;
 import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.UserOrderProductFacade;
 import com.loopers.application.order.UserOrderProductRetry;
+import com.loopers.application.payment.PaymentFlowType;
 import com.loopers.domain.brand.BrandModel;
 import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.brand.BrandStatus;
@@ -109,7 +110,9 @@ public class OrderConcurrencyTest {
 
                     OrderCommand.Order command = new OrderCommand.Order(
                             user.getUserId(),
-                            List.of(line)
+                            List.of(line),
+                            PaymentFlowType.POINT_ONLY,
+                            null
                     );
 
                     userOrderProductRetry.placeOrderWithRetry(command);
@@ -185,7 +188,9 @@ public class OrderConcurrencyTest {
 
                     OrderCommand.Order command = new OrderCommand.Order(
                             user1.getUserId(),
-                            List.of(line)
+                            List.of(line),
+                            PaymentFlowType.POINT_ONLY,
+                            null
                     );
 
                     userOrderProductFacade.placeOrder(command);
@@ -286,7 +291,9 @@ public class OrderConcurrencyTest {
 
                     OrderCommand.Order command = new OrderCommand.Order(
                             userId,
-                            List.of(line)
+                            List.of(line),
+                            PaymentFlowType.POINT_ONLY,
+                            null
                     );
 
                     userOrderProductFacade.placeOrder(command);

--- a/apps/commerce-api/src/test/java/com/loopers/application/OrderFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/OrderFacadeTest.java
@@ -3,6 +3,7 @@ package com.loopers.application;
 import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.OrderResult;
 import com.loopers.application.order.UserOrderProductFacade;
+import com.loopers.application.payment.PaymentFlowType;
 import com.loopers.domain.brand.BrandModel;
 import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.brand.BrandStatus;
@@ -89,7 +90,9 @@ public class OrderFacadeTest {
         OrderCommand.OrderLine line = new OrderCommand.OrderLine(resultProduct.getId(), 1);
         OrderCommand.Order order = new OrderCommand.Order(
                 user.getUserId(),
-                List.of(line)
+                List.of(line),
+                PaymentFlowType.POINT_ONLY,
+                null
         );
 
         // when
@@ -122,7 +125,9 @@ public class OrderFacadeTest {
         OrderCommand.OrderLine line = new OrderCommand.OrderLine(resultProduct.getId(), 1);
         OrderCommand.Order order = new OrderCommand.Order(
                 resultUser.getUserId(),
-                List.of(line)
+                List.of(line),
+                PaymentFlowType.POINT_ONLY,
+                null
         );
 
         // when
@@ -157,7 +162,9 @@ public class OrderFacadeTest {
         OrderCommand.OrderLine line = new OrderCommand.OrderLine(resultProduct.getId(), 1);
         OrderCommand.Order order = new OrderCommand.Order(
                 resultUser.getUserId(),
-                List.of(line)
+                List.of(line),
+                PaymentFlowType.POINT_ONLY,
+                null
         );
 
         // when

--- a/apps/commerce-api/src/test/java/com/loopers/application/ProductQueryServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ProductQueryServiceTest.java
@@ -1,11 +1,12 @@
 package com.loopers.application;
 
+import com.loopers.application.like.LikeCommand;
+import com.loopers.application.like.UserLikeProductFacade;
+import com.loopers.application.product.ProductLikeSummary;
 import com.loopers.application.product.ProductQueryService;
 import com.loopers.domain.brand.BrandModel;
 import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.brand.BrandStatus;
-import com.loopers.domain.like.ProductLikeService;
-import com.loopers.application.product.ProductLikeSummary;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.ProductSortType;
@@ -36,7 +37,7 @@ public class ProductQueryServiceTest {
     private BrandRepository brandRepository;
 
     @Autowired
-    private ProductLikeService productLikeService;
+    private UserLikeProductFacade productLikeService;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -64,9 +65,9 @@ public class ProductQueryServiceTest {
         UserModel u2 = userRepository.save(new UserModel("user2", "u2", "유저2", "u2@test.com", "1997-01-01", "M", 100_000));
         UserModel u3 = userRepository.save(new UserModel("user3", "u3", "유저3", "u3@test.com", "1997-01-01", "M", 100_000));
 
-        productLikeService.like(u1.getId(), p1.getId());
-        productLikeService.like(u2.getId(), p1.getId());
-        productLikeService.like(u3.getId(), p2.getId());
+        productLikeService.userLikeProduct(new LikeCommand.Like(u1.getUserId(), p1.getId()));
+        productLikeService.userLikeProduct(new LikeCommand.Like(u2.getUserId(), p1.getId()));
+        productLikeService.userLikeProduct(new LikeCommand.Like(u3.getUserId(), p2.getId()));
 
         // when
         PageRequest pageable = PageRequest.of(0, 10);
@@ -114,7 +115,7 @@ public class ProductQueryServiceTest {
         UserModel u2 = userRepository.save(new UserModel("user2", "u2", "유저2", "u2@test.com", "1997-01-01", "M", 100_000));
         UserModel u3 = userRepository.save(new UserModel("user3", "u3", "유저3", "u3@test.com", "1997-01-01", "M", 100_000));
 
-        productLikeService.like(u1.getId(), p1.getId());
+        productLikeService.userLikeProduct(new LikeCommand.Like(u1.getUserId(), p1.getId()));
 
         // when
         PageRequest pageable = PageRequest.of(0, 10);
@@ -158,9 +159,9 @@ public class ProductQueryServiceTest {
         UserModel u2 = userRepository.save(new UserModel("user2", "u2", "유저2", "u2@test.com", "1997-01-01", "M", 100_000));
         UserModel u3 = userRepository.save(new UserModel("user3", "u3", "유저3", "u3@test.com", "1997-01-01", "M", 100_000));
 
-        productLikeService.like(u1.getId(), p1.getId());
-        productLikeService.like(u2.getId(), p2.getId());
-        productLikeService.like(u3.getId(), p1.getId());
+        productLikeService.userLikeProduct(new LikeCommand.Like(u1.getUserId(), p1.getId()));
+        productLikeService.userLikeProduct(new LikeCommand.Like(u2.getUserId(), p2.getId()));
+        productLikeService.userLikeProduct(new LikeCommand.Like(u3.getUserId(), p1.getId()));
 
         // when
         ProductLikeSummary summary = productQueryService.getProductLikeSummary(p1.getId());

--- a/apps/commerce-api/src/test/java/com/loopers/domain/productLike/ProductLikeServiceMockTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/productLike/ProductLikeServiceMockTest.java
@@ -72,6 +72,6 @@ public class ProductLikeServiceMockTest {
 
         // then
         then(productLikeRepository).should()
-                .delete(userPkId, productId);
+                .deleteByUserAndProduct(userPkId, productId);
     }
 }


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->




## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

- 지난주, 금주 회사/현생 이슈로 기간내 과제 수행에 어려움이 있었습니다.
- 그래도 잠시 점심시간을 빌려 현재까지 구현한 내용 기반으로 제출하였고 야근 후에 보완하였습니다.

1. 시퀀스 다이어그램 설계
- 클라이언트 까지 고려하여 이커머스 서버 - PG간 연동 시퀀스 다이어그램을 그렸습니다.
```mermaid
sequenceDiagram
    participant C as Client
    participant S as Server
    participant S_1 as UserOrderProductFacade
    participant P as PG

    C->>S: POST "/api/v1/placeOrder"
    activate S
        S->>S_1: placeOrder / PG_ONLY
            activate S_1
            S_1-->>S: 주문 '처리중'(orderId 생성)
            deactivate S_1

        S->>P: [외부 연동] - POST "/api/v1/payments"
        S-->>C: HTTP 응답 { orderId, status: PENDING }
    deactivate S

    %% 여기서 C는 규약대로 "처리중입니다" 화면 + 폴링 시작 / 
    loop until status != PENDING
        C->>S : GET "/api/v1/orders/{orderId}"
        activate S
            S->>S_1: getOrder(orderId)
            S_1-->>S: {status ...}
        S-->>C: HTTP response {status ...}
        deactivate S
    end

    %% PG 콜백 도착
    activate P
        P-->>S: [외부 연동] - POST "/api/v1/pg/callback" { paymentKey, result }
    deactivate P

    activate S
        S->>S_1: updateOrderStatusFromPG(orderId, result)
        activate S_1
            S_1-->>S: updated order
        deactivate S_1

        S-->>P: [외부 연동] - response
    deactivate S
```

2. PG 주문 구현 
- 기존 placeOrder 로직에서 전략패턴을 사용하여, placeOrder의 변경은 닫혀있고, 
- PG_ONLY, POINT_ONLY 등에 대한 스프링 빈 주입을 통해 주문을 처리하도록 구현하였습니다.

- PG결제인 경우 인터페이스 계층의 컨트롤러에서 외부와 연동하는 pgPayment 서비스 호출하는 책임이 있다고 봤습니다.
- 컨트롤러단에 결제 방식에 대한 분기를 만들었는데 좀 더 개선해볼 수 있을까요?
```java
@PostMapping("/placeOrder")
@Override
public ApiResponse<OrderV1Dto.OrderResponse> placeOrder(@RequestBody OrderV1Dto.OrderRequest request) {
    OrderCommand.Order orderCmd = request.toCommand();
    OrderResult.PlaceOrderResult placeOrderResult = userOrderProductFacade.placeOrder(orderCmd);

    /**
     * PG 결제인 경우
     */
    if(request.paymentFlowType().equals(PaymentFlowType.PG_ONLY)) {
        pgPaymentService.requestPaymentForOrder(placeOrderResult, request);
    }

    return ApiResponse.success(OrderV1Dto.OrderResponse.fromOrderPlacement(
            placeOrderResult
    ));
}
```

3. FeignClient를 통한 구현
- PG 시뮬레이터의 callback 응답 파싱 규약이 swagger에서 보던 것과 달라 시간을 많이 잡아먹었습니다. 
- 전문 구조의 레거시 환경에 있다보니 HTTP 요청/응답 구조에 조금 애를 먹은 것 같습니다.

(3-1) pg 시뮬레이터 swagger 확인
```json 
{
  "meta": {
    "result": "SUCCESS",
    "errorCode": "string",
    "message": "string"
  },
  "data": {
    "transactionKey": "string",
    "status": "PENDING",
    "reason": "string"
  }
}
```


(3-2) 처음 에러
```md
Cannot invoke "PgPaymentV1Dto$Response$Data.getStatus()" because the return value of "PgPaymentV1Dto$Response.getData()" is null
```


(3-3) RAW CALLBACK BODY를 찍어봄 
```json 
{"transactionKey":"20251205:TR:c09452","orderId":"000003","cardType":"SAMSUNG","cardNo":"1234-5678-1234-1234","amount":1,"status":"SUCCESS","reason":"정상 승인되었습니다."}
```
(3-4) data 부가 실제로는 좀더 필드가 많은 것으로 확인

- 현재는 다음과 같이 설정하였습니다. (처리 지연 1~5s 고려)
```yaml
  openfeign:
    client:
      config:
        pgClient:
          url: http://localhost:8082
          connect-timeout: 2000
          read-timeout: 6000
```

### 제출 마감 후 보완

- PG 호출 실패시 2번 더 재 시도 후 fallback 메소드 호출 / 현재는 에러 로깅만
  - `PgPaymentRetry.java`
  - `PgPaymentService.java`
  - `application.yml`

```yaml
resilience4j:
  retry:
    instances:
      pgPayment:
        max-attempts: 3               # 최초시도 + 재시도 2번
        wait-duration: 1s             # 재시도 간격
        retry-exceptions:             # 재시도할 예외 지정
          - feign.RetryableException
        ignore-exceptions:            # 재시도 하지 않고 실패 처리할 예외
          - com.loopers.support.error.CoreException
        fail-after-max-attempts: true
```

- 결제 상태 확인 API를 통해 처리중(Pending) 주문 건에 대한 PG 원거래 조회를 통해 상태가 업데이트 되도록 하였습니다.
- PG 결제 호출 실패에 따라 PG 원장에는 없어서 404 NOT FOUND 인 경우 실패 
```java

/* OrderV1Controller.java */
@PutMapping("/{orderId}/payment/pendingRetry")
@Override
public ApiResponse<?> checkOrderStatus(@PathVariable("orderId") Long orderId) {
    OrderResult.PlaceOrderResult orderResult = userOrderProductFacade.getOrderResult(orderId);
    if(orderResult.orderStatus() != OrderStatus.PENDING) {
        return ApiResponse.fail(ErrorType.BAD_REQUEST.getCode(), "처리중인 주문상품만 입력해주세요");
    }
    pgPaymentService.requestPaymentForPendingOrder(orderResult.userId(), orderResult.orderId());

    OrderResult.PlaceOrderResult result = userOrderProductFacade.getOrderResult(orderId);
    return ApiResponse.success(
            OrderV1Dto.OrderResponse.fromOrderPlacement(result)
    );
}
```

- 서킷브레이커 설정 및 모니터링 지표 추가 `application.yml`

```yaml
  circuitbreaker:
    instances:
      pgCircuit:
        sliding-window-type: COUNT_BASED
        sliding-window-size: 10
        minimum-number-of-calls: 5       # 최소 호출건수
        failure-rate-threshold: 65       # 실패율이 60% 넘으면 Open
        wait-duration-in-open-state: 10s # Open 상태 유지 시간 (Open->Half Open)
        permitted-number-of-calls-in-half-open-state: 2 # Half-Open 에서 테스트 -> 성공 Closed / 실패 Open
        slow-call-duration-threshold: 5s # 느린 응답 임계값
        slow-call-rate-threshold: 50    # 느린 응답 비율
        record-exceptions:
          - feign.RetryableException
          - feign.FeignException.InternalServerError
          - feign.FeignException.ServiceUnavailable
        # 내부 에러는 예외
        ignore-exceptions:
          - com.loopers.support.error.CoreException
```

- 서킷브레이커/Feign 에러 분기 추가 에러로그 확인하였습니다.

```md
- 서킷브레이커 오픈시
cause=io.github.resilience4j.circuitbreaker.CallNotPermittedException: CircuitBreaker 'pgCircuit' is OPEN and does not permit further calls

- PG 연동 실패
msg=feign.RetryableException: Connection refused executing GET http://localhost:8082/api/v1/payments?orderId=00000129
```
<img width="1576" height="749" alt="image" src="https://github.com/user-attachments/assets/1ee6c307-f0ac-423e-a7f2-c2a6e71c062b" />



## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

- [x]  PG 연동 API는 RestTemplate 혹은 FeignClient 로 외부 시스템을 호출한다.
- [x]  응답 지연에 대해 타임아웃을 설정하고, 실패 시 적절한 예외 처리 로직을 구현한다. 
   (제출 마감 후 보완)  PG 호출 실패시 fallback 메소드 호출 / 현재는 에러 로깅만
- [x]  결제 요청에 대한 실패 응답에 대해 적절한 시스템 연동을 진행한다.
   (제출 마감 후 보완) 재시도 2번 추가 후  fallback 메소드 호출 / 현재는 에러 로깅만
- [x]  콜백 방식 + **결제 상태 확인 API**를 활용해 적절하게 시스템과 결제정보를 연동한다.
  

### **🛡 Resilience 설계**

- [x]  서킷 브레이커 혹은 재시도 정책을 적용하여 장애 확산을 방지한다.
- [x]  외부 시스템 장애 시에도 내부 시스템은 **정상적으로 응답**하도록 보호한다.
- [x]  콜백이 오지 않더라도, 일정 주기 혹은 수동 API 호출로 상태를 복구할 수 있다.
- [x]  PG 에 대한 요청이 타임아웃에 의해 실패되더라도 해당 결제건에 대한 정보를 확인하여 정상적으로 시스템에 반영한다.

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 포인트 전용 및 PG 결제 옵션이 추가되었습니다.
  * 주문 상태 추적 기능이 개선되었습니다.
  * 외부 결제 게이트웨이 통합이 구현되었습니다.

* **개선 사항**
  * 상품 좋아요 기능의 캐시 관리가 최적화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->