### PR TITLE
[volume-6] 외부 시스템 장애 및 지연 대응 

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -11,6 +11,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:2.1.0")
+    implementation("io.github.resilience4j:resilience4j-circuitbreaker:2.1.0")
+    implementation("io.github.resilience4j:resilience4j-retry:2.1.0")
+    implementation("io.github.resilience4j:resilience4j-timelimiter:2.1.0")
+    implementation ("org.springframework.boot:spring-boot-starter-aop")
+
+    // feign
+    implementation ("org.springframework.cloud:spring-cloud-starter-openfeign")
     // querydsl
     annotationProcessor("com.querydsl:querydsl-apt::jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")

--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -4,9 +4,14 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
 import java.util.TimeZone;
 
 @ConfigurationPropertiesScan
+@EnableFeignClients
+@EnableScheduling
 @SpringBootApplication
 public class CommerceApiApplication {
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
@@ -1,0 +1,21 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
+
+import java.util.List;
+
+public record OrderCommand(
+        String userId,
+        List<OrderItemCommand> items,
+        Long couponId,
+        PaymentType paymentType,
+        CardType cardType,
+        String cardNo
+) {
+    public record OrderItemCommand(
+            Long productId,
+            Integer quantity
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -6,8 +6,7 @@ import com.loopers.domain.issuedcoupon.IssuedCoupon;
 import com.loopers.domain.issuedcoupon.IssuedCouponService;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
-import com.loopers.domain.order.OrderStatus;
-import com.loopers.domain.payment.*;
+import com.loopers.domain.payment.PaymentType;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.User;
@@ -30,9 +29,7 @@ public class OrderFacade {
     private final ProductService productService;
     private final CouponService couponService;
     private final IssuedCouponService issuedCouponService;
-    private final PaymentService paymentService;
-    // 외부 결제 API 인터페이스
-    private final PaymentGateway paymentGateway;
+    private final PaymentProcessor paymentProcessor;
 
     @Transactional
     public OrderInfo createOrder(OrderCommand command) {
@@ -59,8 +56,14 @@ public class OrderFacade {
         // 6. 주문 저장 (Payment가 Order를 참조하기 전에 먼저 저장)
         Order savedOrder = orderService.registerOrder(order);
 
-        // 7. 결제 방식별 처리 (Order가 이미 저장된 상태)
-        processPayment(command, user, savedOrder);
+        // 7. 결제 방식별 처리
+        if (command.paymentType() == PaymentType.POINT) {
+            // 포인트 결제는 동기 처리 (트랜잭션 분리 불필요)
+            paymentProcessor.processPointPayment(user, savedOrder);
+        } else if (command.paymentType() == PaymentType.CARD) {
+            // 카드 결제는 별도 트랜잭션으로 분리 (PG 장애 시 Payment만 저장)
+            paymentProcessor.processCardPayment(command, savedOrder.getId());
+        }
 
         // 8. 쿠폰 사용 처리
         if (issuedCoupon != null) {
@@ -85,88 +88,5 @@ public class OrderFacade {
             productQuantities.put(product, item.quantity());
         }
         return productQuantities;
-    }
-
-    /**
-     * 결제 방식별 처리
-     */
-    private void processPayment(OrderCommand command, User user, Order order) {
-        if (command.paymentType() == PaymentType.POINT) {
-            processPointPayment(user, order);
-        } else if (command.paymentType() == PaymentType.CARD) {
-            processCardPayment(command, order);
-        }
-    }
-
-    /**
-     * 포인트 결제 처리 (동기)
-     * 1. Payment 생성 (PENDING)
-     * 2. 포인트 차감
-     * 3. Payment 즉시 완료 (PENDING → SUCCESS)
-     * 4. Payment 저장
-     * 5. 주문 완료 처리
-     */
-    private void processPointPayment(User user, Order order) {
-        // 1. Payment 생성 (PENDING)
-        Payment payment = Payment.createPaymentForPoint(
-                order,
-                order.getTotalPrice(),
-                PaymentType.POINT
-        );
-
-        // 2. 포인트 차감
-        user.usePoint(order.getTotalPrice());
-
-        // 3. Payment 즉시 완료 (PENDING → SUCCESS)
-        payment.completePointPayment();
-
-        // 4. Payment 저장
-        paymentService.save(payment);
-
-        // 5. 주문 완료 처리
-        order.completeOrder();
-    }
-
-    /**
-     * 카드 결제 처리 (비동기 - PG 연동)
-     * 1. Payment 생성
-     * 2. PG 결제 요청
-     * 3. Payment 상태를 PROCESSING으로 변경
-     * 4. 주문 접수 상태로 변경
-     * 5. 콜백으로 최종 결과 처리 (PaymentFacade)
-     */
-    private void processCardPayment(OrderCommand command, Order order) {
-        // 1. Payment 생성
-        Payment payment = Payment.createPaymentForCard(
-                order,
-                order.getTotalPrice(),
-                command.paymentType(),
-                command.cardType(),
-                command.cardNo()
-        );
-
-        // 2. PG 결제 요청 (비동기)
-        String callbackUrl = "http://localhost:8080/api/v1/payments/callback";
-        PaymentResult result = paymentGateway.processPayment(command.userId(), payment, callbackUrl);
-
-        // 3. PG 결제 결과 확인
-        if ("FAIL".equals(result.status())) {
-            // Fallback이 호출된 경우: 결제 대기 상태로 처리
-            // Payment는 이미 PENDING 상태로 생성되었으므로 상태 변경 불필요
-            paymentService.save(payment);
-
-            // 주문은 INIT 상태 유지 (나중에 재시도 가능)
-            throw new CoreException(ErrorType.PAYMENT_REQUEST_FAILED,
-                    "결제 시스템 장애로 인해 주문이 대기 상태입니다. 잠시 후 다시 시도해주세요.");
-        }
-
-        // 4. Payment 상태 → PROCESSING
-        payment.startProcessing(result.transactionId());
-
-        // 5. Payment 저장
-        paymentService.save(payment);
-
-        // 6. 주문 상태 → RECEIVED (접수 완료)
-        order.updateStatus(OrderStatus.RECEIVED);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -6,11 +6,12 @@ import com.loopers.domain.issuedcoupon.IssuedCoupon;
 import com.loopers.domain.issuedcoupon.IssuedCouponService;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
+import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.*;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
-import com.loopers.interfaces.api.order.OrderV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -30,29 +30,52 @@ public class OrderFacade {
     private final ProductService productService;
     private final CouponService couponService;
     private final IssuedCouponService issuedCouponService;
+    private final PaymentService paymentService;
+    // 외부 결제 API 인터페이스
+    private final PaymentGateway paymentGateway;
 
     @Transactional
-    public OrderInfo createOrder(String userId,
-                                 List<OrderV1Dto.OrderRequest.OrderItemRequest> items,
-                                 Long couponId) {
+    public OrderInfo createOrder(OrderCommand command) {
         // 1. User 정보 조회
-        User user = userService.getUser(userId);
+        User user = userService.getUser(command.userId());
 
-        // 2. 쿠폰 처리 (도메인 서비스에서 검증 포함)
+        // 2. 쿠폰 처리
         Coupon coupon = null;
         IssuedCoupon issuedCoupon = null;
-
-        if (couponId != null) {
-            // 쿠폰 유효성 검증 (도메인 서비스에서 처리)
-            coupon = couponService.getValidCoupon(couponId);
-
-            // 사용자가 해당 쿠폰을 발급받았는지 확인 (도메인 서비스에서 검증)
-            issuedCoupon = issuedCouponService.getIssuedCouponByUser(user.getId(), couponId);
+        if (command.couponId() != null) {
+            coupon = couponService.getValidCoupon(command.couponId());
+            issuedCoupon = issuedCouponService.getIssuedCouponByUser(user.getId(), command.couponId());
         }
 
-        // 3. Product 조회 및 Map 생성
+        // 3. 상품 조회 (Pessimistic Lock)
+        Map<Product, Integer> productQuantities = getProductQuantities(command);
+
+        // 4. 주문 생성
+        Order order = Order.createOrder(user, productQuantities, coupon, issuedCoupon);
+
+        // 5. 재고 차감
+        productQuantities.forEach(Product::decreaseStock);
+
+        // 6. 주문 저장 (Payment가 Order를 참조하기 전에 먼저 저장)
+        Order savedOrder = orderService.registerOrder(order);
+
+        // 7. 결제 방식별 처리 (Order가 이미 저장된 상태)
+        processPayment(command, user, savedOrder);
+
+        // 8. 쿠폰 사용 처리
+        if (issuedCoupon != null) {
+            issuedCoupon.useCoupon();
+        }
+
+        return OrderInfo.from(savedOrder);
+    }
+
+    /**
+     * 상품 조회 및 검증
+     */
+    private Map<Product, Integer> getProductQuantities(OrderCommand command) {
         Map<Product, Integer> productQuantities = new HashMap<>();
-        for (OrderV1Dto.OrderRequest.OrderItemRequest item : items) {
+        for (OrderCommand.OrderItemCommand item : command.items()) {
             Product product = productService.getProductWithLock(item.productId());
 
             if (productQuantities.containsKey(product)) {
@@ -61,26 +84,89 @@ public class OrderFacade {
 
             productQuantities.put(product, item.quantity());
         }
+        return productQuantities;
+    }
 
-        // 4. Order 생성 (쿠폰 정보 전달하여 할인 적용)
-        Order order = Order.createOrder(user, productQuantities, coupon);
+    /**
+     * 결제 방식별 처리
+     */
+    private void processPayment(OrderCommand command, User user, Order order) {
+        if (command.paymentType() == PaymentType.POINT) {
+            processPointPayment(user, order);
+        } else if (command.paymentType() == PaymentType.CARD) {
+            processCardPayment(command, order);
+        }
+    }
 
-        // 5. 재고 차감
-        productQuantities.forEach((product, quantity) ->
-            product.decreaseStock(quantity)
+    /**
+     * 포인트 결제 처리 (동기)
+     * 1. Payment 생성 (PENDING)
+     * 2. 포인트 차감
+     * 3. Payment 즉시 완료 (PENDING → SUCCESS)
+     * 4. Payment 저장
+     * 5. 주문 완료 처리
+     */
+    private void processPointPayment(User user, Order order) {
+        // 1. Payment 생성 (PENDING)
+        Payment payment = Payment.createPaymentForPoint(
+                order,
+                order.getTotalPrice(),
+                PaymentType.POINT
         );
 
-        // 6. 포인트 차감 (할인이 적용된 총액)
+        // 2. 포인트 차감
         user.usePoint(order.getTotalPrice());
 
-        // 7. 쿠폰 사용 처리
-        if (issuedCoupon != null) {
-            issuedCoupon.useCoupon();
+        // 3. Payment 즉시 완료 (PENDING → SUCCESS)
+        payment.completePointPayment();
+
+        // 4. Payment 저장
+        paymentService.save(payment);
+
+        // 5. 주문 완료 처리
+        order.completeOrder();
+    }
+
+    /**
+     * 카드 결제 처리 (비동기 - PG 연동)
+     * 1. Payment 생성
+     * 2. PG 결제 요청
+     * 3. Payment 상태를 PROCESSING으로 변경
+     * 4. 주문 접수 상태로 변경
+     * 5. 콜백으로 최종 결과 처리 (PaymentFacade)
+     */
+    private void processCardPayment(OrderCommand command, Order order) {
+        // 1. Payment 생성
+        Payment payment = Payment.createPaymentForCard(
+                order,
+                order.getTotalPrice(),
+                command.paymentType(),
+                command.cardType(),
+                command.cardNo()
+        );
+
+        // 2. PG 결제 요청 (비동기)
+        String callbackUrl = "http://localhost:8080/api/v1/payments/callback";
+        PaymentResult result = paymentGateway.processPayment(command.userId(), payment, callbackUrl);
+
+        // 3. PG 결제 결과 확인
+        if ("FAIL".equals(result.status())) {
+            // Fallback이 호출된 경우: 결제 대기 상태로 처리
+            // Payment는 이미 PENDING 상태로 생성되었으므로 상태 변경 불필요
+            paymentService.save(payment);
+
+            // 주문은 INIT 상태 유지 (나중에 재시도 가능)
+            throw new CoreException(ErrorType.PAYMENT_REQUEST_FAILED,
+                    "결제 시스템 장애로 인해 주문이 대기 상태입니다. 잠시 후 다시 시도해주세요.");
         }
 
-        // 8. Order 저장
-        Order savedOrder = orderService.registerOrder(order);
+        // 4. Payment 상태 → PROCESSING
+        payment.startProcessing(result.transactionId());
 
-        return OrderInfo.from(savedOrder);
+        // 5. Payment 저장
+        paymentService.save(payment);
+
+        // 6. 주문 상태 → RECEIVED (접수 완료)
+        order.updateStatus(OrderStatus.RECEIVED);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/PaymentProcessor.java
@@ -1,0 +1,113 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.*;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 결제 처리를 별도 트랜잭션으로 분리하기 위한 컴포넌트
+ * - PG 장애 시 Payment는 PENDING 상태로 저장되고
+ * - 메인 트랜잭션(주문, 재고)은 롤백되지 않음
+ * - 스케줄러가 나중에 PENDING Payment를 재확인 가능
+ */
+@Component
+@RequiredArgsConstructor
+public class PaymentProcessor {
+
+    @Value("${payment.callback.base-url}")
+    private String callbackBaseUrl;
+
+    private final PaymentService paymentService;
+    private final PaymentGateway paymentGateway;
+    private final com.loopers.infrastructure.order.OrderJpaRepository orderJpaRepository;
+
+    /**
+     * 포인트 결제 처리 (동기, 트랜잭션 분리 없음)
+     * 1. Payment 생성 (PENDING)
+     * 2. 포인트 차감
+     * 3. Payment 즉시 완료 (PENDING → SUCCESS)
+     * 4. Payment 저장
+     * 5. 주문 완료 처리
+     */
+    public void processPointPayment(User user, Order order) {
+        // 1. Payment 생성 (PENDING)
+        Payment payment = Payment.createPaymentForPoint(
+                order,
+                order.getTotalPrice(),
+                PaymentType.POINT
+        );
+
+        // 2. 포인트 차감
+        user.usePoint(order.getTotalPrice());
+
+        // 3. Payment 즉시 완료 (PENDING → SUCCESS)
+        payment.completePointPayment();
+
+        // 4. Payment 저장
+        paymentService.save(payment);
+
+        // 5. 주문 완료 처리
+        order.completeOrder();
+    }
+
+    /**
+     * 카드 결제 처리 (비동기 - PG 연동, 별도 트랜잭션)
+     * 1. Order 재조회 (새 트랜잭션에서 영속 상태로 관리)
+     * 2. Payment 생성
+     * 3. PG 결제 요청
+     * 4. Payment 상태를 PROCESSING으로 변경
+     * 5. 주문 접수 상태로 변경
+     * 6. 콜백으로 최종 결과 처리 (PaymentFacade)
+     *
+     * PG 장애 시 Payment만 저장되고 메인 트랜잭션(주문, 재고)은 롤백
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void processCardPayment(OrderCommand command, Long orderId) {
+        // 1. 새 트랜잭션에서 Order 재조회
+        Order order = orderJpaRepository.findById(orderId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "주문을 찾을 수 없습니다"));
+
+        // 2. Payment 생성
+        Payment payment = Payment.createPaymentForCard(
+                order,
+                order.getTotalPrice(),
+                command.paymentType(),
+                command.cardType(),
+                command.cardNo()
+        );
+
+        // 3. PG 결제 요청 (비동기)
+        String callbackUrl = callbackBaseUrl + "/api/v1/payments/callback";
+        PaymentResult result = paymentGateway.processPayment(command.userId(), payment, callbackUrl);
+
+        // 4. PG 결제 결과 확인
+        if ("FAIL".equals(result.status())) {
+            // Fallback이 호출된 경우: 결제 대기 상태로 처리
+            // Payment는 이미 PENDING 상태로 생성되었으므로 상태 변경 불필요
+            paymentService.save(payment);
+
+            // 주문은 INIT 상태 유지 (나중에 재시도 가능)
+            throw new CoreException(ErrorType.PAYMENT_REQUEST_FAILED,
+                    "결제 시스템 장애로 인해 주문이 대기 상태입니다. 잠시 후 다시 시도해주세요.");
+        }
+
+        // 5. Payment 상태 → PROCESSING
+        payment.startProcessing(result.transactionId());
+
+        // 6. Payment 저장
+        paymentService.save(payment);
+
+        // 7. 주문 상태 → RECEIVED (접수 완료)
+        order.updateStatus(OrderStatus.RECEIVED);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentCallbackInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentCallbackInfo.java
@@ -1,0 +1,11 @@
+package com.loopers.application.payment;
+
+/**
+ * 결제 콜백 처리 Command
+ */
+public record PaymentCallbackInfo(
+        String transactionKey,  // PG 거래 키
+        String status,          // 결제 상태 ("SUCCESS", "FAILED")
+        String reason           // 실패 사유 (실패 시)
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -1,0 +1,104 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentFacade {
+
+    private final PaymentService paymentService;
+
+    /**
+     * PG 콜백 처리
+     */
+    @Transactional
+    public void handlePaymentCallback(PaymentCallbackInfo command) {
+        log.info("Processing payment callback - TransactionKey: {}, Status: {}",
+                command.transactionKey(), command.status());
+
+        // 1. transactionKey로 Payment 조회
+        Payment payment = paymentService.getPaymentByTransactionKey(command.transactionKey());
+
+        // 2. 결제 상태별 처리
+        if ("SUCCESS".equals(command.status())) {
+            handleSuccessPayment(payment);
+        } else if ("FAILED".equals(command.status())) {
+            handleFailedPayment(payment, command.reason());
+        } else {
+            log.warn("Unknown payment status: {}", command.status());
+        }
+    }
+
+    /**
+     * 결제 성공 처리
+     */
+    private void handleSuccessPayment(Payment payment) {
+        log.info("결제 성공 처리 시작 - PaymentId: {}", payment.getPaymentId());
+
+        // 결제 완료 처리 (도메인 로직)
+        payment.completePayment();
+
+        // Order 완료 처리 (도메인 로직)
+        Order order = payment.getOrder();
+        order.completeOrder();
+
+        log.info("결제 성공 처리 완료 - PaymentId: {}, OrderId: {}",
+                payment.getPaymentId(), order.getId());
+    }
+
+    /**
+     * 결제 실패 처리
+     */
+    private void handleFailedPayment(Payment payment, String reason) {
+        log.info("결제 실패 처리 시작 payment - PaymentId: {}, Reason: {}",
+                payment.getPaymentId(), reason);
+
+        // 결제 실패 처리 (도메인 로직)
+        payment.failPayment(reason);
+
+        // Order 취소 처리 (도메인 로직)
+        Order order = payment.getOrder();
+        order.cancelOrder();
+
+        // 보상 트랜잭션: 주문 생성 시 차감된 자원들을 복구
+        executeCompensationTransaction(order);
+
+        log.info("결제 실패 처리 완료 - PaymentId: {}, OrderId: {}",
+                payment.getPaymentId(), order.getId());
+    }
+
+    /**
+     * 보상 트랜잭션 실행
+     * 결제 실패 시 주문 생성 과정에서 차감된 재고, 포인트, 쿠폰을 복구
+     */
+    private void executeCompensationTransaction(Order order) {
+        log.info("보상 트랜잭션 시작 OrderId: {}", order.getId());
+
+        // 1. 재고 복구
+        order.getOrderItems().forEach(orderItem -> {
+            orderItem.getProduct().increaseStock(orderItem.getQuantity());
+            log.info("Stock restored - Product: {}, Quantity: {}",
+                    orderItem.getProduct().getProductName(), orderItem.getQuantity());
+        });
+
+        // 2. 포인트 환불
+        order.getUser().refundPoint(order.getTotalPrice());
+        log.info("Point refunded - UserId: {}, Amount: {}",
+                order.getUser().getUserId(), order.getTotalPrice().getAmount());
+
+        // 3. 쿠폰 복구
+        if (order.getIssuedCoupon() != null) {
+            order.getIssuedCoupon().restoreCoupon();
+            log.info("Coupon restored - IssuedCouponId: {}", order.getIssuedCoupon().getId());
+        }
+
+        log.info("보상 트랜잭션 완료 OrderId: {}", order.getId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -71,10 +71,12 @@ public class PaymentFacade {
 
         // Order 취소 처리 (도메인 로직)
         Order order = payment.getOrder();
-        order.cancelOrder();
 
-        // 보상 트랜잭션: 주문 생성 시 차감된 자원들을 복구
+        // 보상 트랜잭션: 주문 상태 변경 전에 먼저 실행
         executeCompensationTransaction(order);
+
+        // 보상 트랜잭션 완료 후 Order 상태 변경
+        order.cancelOrder();
 
         log.info("결제 실패 처리 완료 - PaymentId: {}, OrderId: {}",
                 payment.getPaymentId(), order.getId());

--- a/apps/commerce-api/src/main/java/com/loopers/config/DataLoader.java
+++ b/apps/commerce-api/src/main/java/com/loopers/config/DataLoader.java
@@ -3,8 +3,11 @@ package com.loopers.config;
 import com.loopers.domain.Money;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
 import com.loopers.infrastructure.brand.BrandJpaRepository;
 import com.loopers.infrastructure.product.ProductJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
@@ -25,6 +28,7 @@ public class DataLoader implements CommandLineRunner {
 
     private final BrandJpaRepository brandRepository;
     private final ProductJpaRepository productRepository;
+    private final UserJpaRepository userRepository;
 
     @Override
     @Transactional
@@ -37,15 +41,43 @@ public class DataLoader implements CommandLineRunner {
 
         log.info("더미 데이터 생성을 시작합니다...");
 
-        // 1. 브랜드 10개 생성
+        // 1. 유저 10개 생성
+        List<User> users = createUsers();
+        log.info("유저 {}개 생성 완료", users.size());
+
+        // 2. 브랜드 10개 생성
         List<Brand> brands = createBrands();
         log.info("브랜드 {}개 생성 완료", brands.size());
 
-        // 2. 상품 50만개 생성 (배치로 처리)
+        // 3. 상품 50만개 생성 (배치로 처리)
         createProducts(brands);
         log.info("상품 생성 완료");
 
         log.info("더미 데이터 생성이 완료되었습니다.");
+    }
+
+    private List<User> createUsers() {
+        List<User> users = new ArrayList<>();
+
+        User user1 = User.createUser("user123", "user123@example.com", "1990-01-01", Gender.MALE);
+        users.add(user1);
+
+        // 나머지 9명의 유저 생성
+        String[] userIds = {"user001", "user002", "user003", "user004", "user005",
+                           "user006", "user007", "user008", "user009"};
+        Gender[] genders = {Gender.MALE, Gender.FEMALE};
+
+        for (int i = 0; i < userIds.length; i++) {
+            String userId = userIds[i];
+            String email = userId + "@example.com";
+            String birthdate = String.format("199%d-%02d-%02d", i % 10, (i % 12) + 1, (i % 28) + 1);
+            Gender gender = genders[i % 2];
+
+            User user = User.createUser(userId, email, birthdate, gender);
+            users.add(user);
+        }
+
+        return userRepository.saveAll(users);
     }
 
     private List<Brand> createBrands() {
@@ -62,7 +94,7 @@ public class DataLoader implements CommandLineRunner {
     }
 
     private void createProducts(List<Brand> brands) {
-        int totalProducts = 500000; // 50만개
+        int totalProducts = 100000; // 50만개
         int batchSize = 1000; // 배치 크기
         Random random = new Random();
 

--- a/apps/commerce-api/src/main/java/com/loopers/config/FeignClientConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/config/FeignClientConfig.java
@@ -1,0 +1,46 @@
+package com.loopers.config;
+
+import feign.Logger;
+import feign.Request;
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignClientConfig {
+
+    @Value("${external.pg-simulator.client-id}")
+    private String pgClientId;
+
+    /**
+     * 연결 및 타임아웃 설정
+     * Connection Timeout : 2초
+     * Read Timeout : 2초
+     * */
+    @Bean
+    public Request.Options options() {
+        return new Request.Options(2000, 2000);
+    }
+
+    /**
+     * 로깅 레벨 설정
+     * */
+    @Bean
+    public Logger.Level feignLoggerLevel() {
+        // 초기 설정은 자세한 내용을 확인하기 위해 FULL로 설정
+        return Logger.Level.FULL;
+    }
+
+    /**
+     * PG 고객사 ID 헤더 추가 Interceptor
+     * 모든 요청에 X-USER-ID 헤더를 자동으로 추가
+     */
+    @Bean
+    public RequestInterceptor pgUserIdInterceptor() {
+        return requestTemplate -> {
+            requestTemplate.header("X-USER-ID", pgClientId);
+        };
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -34,7 +34,7 @@ public class Coupon extends BaseEntity {
     private LocalDate validEndDate;
 
     @Embedded
-    private DiscountPolicy discountPolicy;
+    private Discount discount;
 
     @Column(name = "is_active", nullable = false, columnDefinition = "boolean default true")
     private boolean isActive = true;
@@ -45,10 +45,10 @@ public class Coupon extends BaseEntity {
     private Integer currentIssuanceCount = 0; // 현재까지 발행된 수량
 
     @Builder
-    protected Coupon(String code, String name, String description, LocalDate validStartDate, LocalDate validEndDate, DiscountPolicy discountPolicy) {
+    protected Coupon(String code, String name, String description, LocalDate validStartDate, LocalDate validEndDate, Discount discount) {
         validateCouponCode(code);
         validateCouponName(name);
-        validateDiscountPolicy(discountPolicy);
+        validateDiscount(discount);
         validateCouponDates(validStartDate, validEndDate);
 
         this.code = code;
@@ -56,7 +56,7 @@ public class Coupon extends BaseEntity {
         this.description = description;
         this.validStartDate = validStartDate;
         this.validEndDate = validEndDate;
-        this.discountPolicy = discountPolicy;
+        this.discount = discount;
         this.currentIssuanceCount = 0;
     }
 
@@ -64,7 +64,7 @@ public class Coupon extends BaseEntity {
             String code, String name, String description,
             LocalDate validStartDate, LocalDate validEndDate, DiscountType discountType, int value) {
 
-        DiscountPolicy discountPolicy = new DiscountPolicy(discountType, value);
+        Discount discount = new Discount(discountType, value);
 
         return Coupon.builder()
                 .code(code)
@@ -72,7 +72,7 @@ public class Coupon extends BaseEntity {
                 .description(description)
                 .validStartDate(validStartDate)
                 .validEndDate(validEndDate)
-                .discountPolicy(discountPolicy)
+                .discount(discount)
                 .build();
     }
 
@@ -99,16 +99,16 @@ public class Coupon extends BaseEntity {
         }
     }
 
-    private static void validateDiscountPolicy(DiscountPolicy discountPolicy) {
-        if (discountPolicy == null) {
+    private static void validateDiscount(Discount discount) {
+        if (discount == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "할인 정보는 필수값 입니다");
         }
 
-        if (discountPolicy.getDiscountType() == null) {
+        if (discount.getDiscountType() == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "할인 방식은 필수값 입니다");
         }
 
-        if (discountPolicy.getDiscountValue() <= 0) {
+        if (discount.getDiscountValue() <= 0) {
             throw new CoreException(ErrorType.BAD_REQUEST, "할인률(액)은 0보다 큰 양수여야 합니다");
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Discount.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Discount.java
@@ -4,19 +4,16 @@ import com.loopers.domain.Money;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode
-public class DiscountPolicy {
+public class Discount {
     private DiscountType discountType;
     private int discountValue;
 
     @Builder
-    public DiscountPolicy(DiscountType discountType, int discountValue) {
+    public Discount(DiscountType discountType, int discountValue) {
         this.discountType = discountType;
         this.discountValue = discountValue;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountType.java
@@ -1,14 +1,17 @@
 package com.loopers.domain.coupon;
 
 import com.loopers.domain.Money;
+import com.loopers.domain.coupon.policy.AmountDiscountPolicy;
+import com.loopers.domain.coupon.policy.DiscountPolicy;
+import com.loopers.domain.coupon.policy.RateDiscountPolicy;
 
 public enum DiscountType {
-    RATE(new RateDiscountCalculator()),
-    AMOUNT(new AmountDiscountCalculator());
+    RATE(new RateDiscountPolicy()),
+    AMOUNT(new AmountDiscountPolicy());
 
-    private final DiscountCalculator calculator;
+    private final DiscountPolicy calculator;
 
-    DiscountType(DiscountCalculator calculator) {
+    DiscountType(DiscountPolicy calculator) {
         this.calculator = calculator;
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/policy/AmountDiscountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/policy/AmountDiscountPolicy.java
@@ -1,8 +1,8 @@
-package com.loopers.domain.coupon;
+package com.loopers.domain.coupon.policy;
 
 import com.loopers.domain.Money;
 
-class AmountDiscountCalculator implements DiscountCalculator {
+public class AmountDiscountPolicy implements DiscountPolicy {
     @Override
     public Money calculate(Money originalPrice, int discountValue) {
         // 정액 할인: 고정 금액

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/policy/DiscountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/policy/DiscountPolicy.java
@@ -1,8 +1,8 @@
-package com.loopers.domain.coupon;
+package com.loopers.domain.coupon.policy;
 
 import com.loopers.domain.Money;
 
-public interface DiscountCalculator {
+public interface DiscountPolicy {
     /**
      * 할인 금액을 계산
      * @param originalPrice 원래 금액

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/policy/RateDiscountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/policy/RateDiscountPolicy.java
@@ -1,11 +1,11 @@
-package com.loopers.domain.coupon;
+package com.loopers.domain.coupon.policy;
 
 import com.loopers.domain.Money;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
-class RateDiscountCalculator implements DiscountCalculator {
+public class RateDiscountPolicy implements DiscountPolicy {
     @Override
     public Money calculate(Money originalPrice, int discountValue) {
         // 정률 할인: 원래 금액 * (할인율 / 100)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/issuedcoupon/IssuedCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/issuedcoupon/IssuedCoupon.java
@@ -59,6 +59,19 @@ public class IssuedCoupon extends BaseEntity {
         this.usedAt = LocalDateTime.now();
     }
 
+    /**
+     * 쿠폰 복구 (보상 트랜잭션)
+     * 결제 실패 시 사용된 쿠폰을 다시 사용 가능한 상태로 복구
+     */
+    public void restoreCoupon() {
+        if (this.status != CouponStatus.USED) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용된 쿠폰만 복구할 수 있습니다");
+        }
+
+        this.status = CouponStatus.USABLE;
+        this.usedAt = null;
+    }
+
     private static void validateIssuedCouponFields(User user, Coupon coupon, CouponStatus status) {
         if (user == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "사용자는 필수입니다");

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -107,13 +107,18 @@ public class Order extends BaseEntity {
     }
 
     public void completeOrder() {
-        if (this.status != OrderStatus.RECEIVED && this.status != OrderStatus.PAYMENT_COMPLETE) {
+        if (this.status != OrderStatus.INIT &&
+            this.status != OrderStatus.RECEIVED &&
+            this.status != OrderStatus.PAYMENT_COMPLETE) {
             throw new CoreException(ErrorType.BAD_REQUEST, "주문을 완료할 수 없는 상태입니다");
         }
         this.status = OrderStatus.COMPLETED;
     }
 
     public void cancelOrder() {
+        if (this.status == OrderStatus.CANCELED) {
+            return;  // 이미 취소됨, 멱등성 보장
+        }
         if (this.status == OrderStatus.COMPLETED) {
             throw new CoreException(ErrorType.BAD_REQUEST, "이미 완료된 주문은 취소할 수 없습니다");
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -45,7 +45,7 @@ public class Order extends BaseEntity {
 
         // 쿠폰 할인 적용
         if (coupon != null) {
-            calculatedTotal = coupon.getDiscountPolicy().applyDiscount(calculatedTotal);
+            calculatedTotal = coupon.getDiscount().applyDiscount(calculatedTotal);
         }
 
         // 포인트 부족 검증
@@ -67,7 +67,7 @@ public class Order extends BaseEntity {
 
         // 쿠폰 할인 적용 (최종 totalPrice에 반영)
         if (coupon != null) {
-            this.totalPrice = coupon.getDiscountPolicy().applyDiscount(this.totalPrice);
+            this.totalPrice = coupon.getDiscount().applyDiscount(this.totalPrice);
         }
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardType.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment;
+
+public enum CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -1,0 +1,203 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.Money;
+import com.loopers.domain.order.Order;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@Table(name = "payment")
+@Getter
+public class Payment {
+
+    @Id
+    @Column(name = "payment_id", nullable = false, updatable = false, length = 36)
+    private String paymentId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", referencedColumnName = "id")
+    private Order order;
+
+    @Column(name = "pg_transaction_id", unique = true)
+    private String pgTransactionId; // PG사에서 발급한 승인 번호
+
+    @Embedded
+    @Column(name = "amount", nullable = false)
+    private Money amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PaymentStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_type", nullable = false)
+    private PaymentType paymentType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "card_type")
+    private CardType cardType;
+
+    @Column(name = "card_no")
+    private String cardNo;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;    // 결제 생성 일시
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;  // 결제 완료 일시
+
+    @Column(name = "status_check_count", nullable = false)
+    private Integer statusCheckCount = 0;  // 상태 확인 횟수
+
+    @Column(name = "last_status_check_at")
+    private LocalDateTime lastStatusCheckAt;  // 마지막 상태 확인 시간
+
+    @PrePersist
+    private void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Payment(String paymentId, Order order, Money amount, PaymentType paymentType, CardType cardType, String cardNo) {
+        validatePaymentType(paymentType, cardType, cardNo);
+
+        this.paymentId = paymentId;
+        this.order = order;
+        this.amount = amount;
+        this.paymentType = paymentType;
+        this.cardType = cardType;
+        this.cardNo = cardNo;
+        this.status = PaymentStatus.PENDING;
+        this.createdAt = LocalDateTime.now();
+        this.statusCheckCount = 0;
+    }
+
+    public static Payment createPaymentForPoint(Order order, Money amount, PaymentType paymentType) {
+        String paymentKey = PaymentKeyGenerator.generateKeyForPoint();
+
+        return Payment.builder()
+                .paymentId(paymentKey)
+                .order(order)
+                .amount(amount)
+                .paymentType(paymentType)
+                .build();
+    }
+
+
+    public static Payment createPaymentForCard(Order order, Money amount, PaymentType paymentType, CardType cardType, String cardNo) {
+
+        String paymentKey = PaymentKeyGenerator.generateKeyForCard();
+
+        return Payment.builder()
+                .paymentId(paymentKey)
+                .order(order)
+                .amount(amount)
+                .paymentType(paymentType)
+                .cardType(cardType)
+                .cardNo(cardNo)
+                .build();
+    }
+
+    public void startProcessing(String pgTransactionId) {
+        if (this.status != PaymentStatus.PENDING) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "결제 처리를 시작할 수 없는 상태입니다");
+        }
+        this.pgTransactionId = pgTransactionId;
+        this.status = PaymentStatus.PROCESSING;
+    }
+
+    /**
+     * 포인트 결제 즉시 완료
+     * PENDING → SUCCESS (동기식 결제)
+     */
+    public void completePointPayment() {
+        if (this.status != PaymentStatus.PENDING) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트 결제를 완료할 수 없는 상태입니다");
+        }
+        this.status = PaymentStatus.SUCCESS;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 카드 결제 완료
+     * PROCESSING → SUCCESS (비동기 콜백)
+     */
+    public void completePayment() {
+        if (this.status != PaymentStatus.PROCESSING) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "결제를 완료할 수 없는 상태입니다");
+        }
+        this.status = PaymentStatus.SUCCESS;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void failPayment(String reason) {
+        if (this.status != PaymentStatus.PROCESSING) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "결제를 실패 처리할 수 없는 상태입니다 : " + reason);
+        }
+        this.status = PaymentStatus.FAILED;
+    }
+
+    /**
+     * 상태 확인 횟수 증가
+     */
+    public void incrementStatusCheckCount() {
+        this.statusCheckCount++;
+        this.lastStatusCheckAt = LocalDateTime.now();
+    }
+
+    /**
+     * 상태 확인이 가능한지 확인
+     * @param maxCheckCount 최대 확인 횟수
+     * @return 확인 가능 여부
+     */
+    public boolean canCheckStatus(int maxCheckCount) {
+        return this.statusCheckCount < maxCheckCount;
+    }
+
+    /**
+     * PROCESSING 상태가 일정 시간 이상 지속되었는지 확인
+     * @param minutes 경과 시간 (분)
+     * @return 경과 여부
+     */
+    public boolean isProcessingOverMinutes(int minutes) {
+        if (this.status != PaymentStatus.PROCESSING) {
+            return false;
+        }
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(minutes);
+
+        // 마지막 상태 확인이 있으면 그 시간 기준, 없으면 생성 시간 기준
+        LocalDateTime baseTime = this.lastStatusCheckAt != null ? this.lastStatusCheckAt : this.createdAt;
+        return baseTime.isBefore(threshold);
+    }
+
+    private void validatePaymentType(PaymentType paymentType, CardType cardType, String cardNo) {
+        if (paymentType == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "결제 방식은 필수값입니다");
+        }
+
+        if (paymentType == PaymentType.CARD) {
+            validateCardNo(cardNo);
+            validateCardType(cardType);
+        }
+    }
+
+    private void validateCardNo(String cardNo) {
+        if (cardNo == null || cardNo.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "카드 번호는 필수값입니다");
+        }
+    }
+
+    private void validateCardType(CardType cardType) {
+        if (cardType == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "카드사 정보는 필수값입니다");
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentGateway.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.payment;
+
+public interface PaymentGateway {
+
+    /**
+     * 외부 결제 시스템을 통해 결제를 처리합니다.
+     *
+     * @param userId 사용자 ID
+     * @param payment 결제 정보
+     * @param callbackUrl 결제 완료 후 콜백 URL
+     * @return 결제 처리 결과
+     */
+    PaymentResult processPayment(String userId, Payment payment, String callbackUrl);
+
+    /**
+     * PG사에 결제 상태를 조회합니다.
+     *
+     * @param pgTransactionId PG 거래 ID
+     * @return 결제 상태 조회 결과
+     */
+    PaymentResult checkPaymentStatus(String pgTransactionId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentKeyGenerator.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentKeyGenerator.java
@@ -15,13 +15,13 @@ public class PaymentKeyGenerator {
 
     public static String generateKeyForPoint() {
         LocalDateTime now = LocalDateTime.now();
-        String uuid = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+        String uuid = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 12);
         return PREFIX_POINT + now.format(FORMATTER) + uuid;
     }
 
     public static String generateKeyForCard() {
         LocalDateTime now = LocalDateTime.now();
-        String uuid = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+        String uuid = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 12);
         return PREFIX_CARD + now.format(FORMATTER) + uuid;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentKeyGenerator.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentKeyGenerator.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.payment;
+
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@NoArgsConstructor
+public class PaymentKeyGenerator {
+    private static final String PREFIX_CARD = "PG_";
+    private static final String PREFIX_POINT = "PO_";
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    public static String generateKeyForPoint() {
+        LocalDateTime now = LocalDateTime.now();
+        String uuid = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+        return PREFIX_POINT + now.format(FORMATTER) + uuid;
+    }
+
+    public static String generateKeyForCard() {
+        LocalDateTime now = LocalDateTime.now();
+        String uuid = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+        return PREFIX_CARD + now.format(FORMATTER) + uuid;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.payment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRepository {
+
+    /**
+     * PG Transaction ID로 Payment 조회
+     *
+     * @param pgTransactionId PG사에서 발급한 거래 키
+     * @return Payment 엔티티 (Optional)
+     */
+    Optional<Payment> findByPgTransactionId(String pgTransactionId);
+
+    /**
+     * Payment 저장
+     *
+     * @param payment Payment 엔티티
+     * @return 저장된 Payment
+     */
+    Payment save(Payment payment);
+
+    /**
+     * PROCESSING 상태인 Payment 목록 조회 (상태 확인 대상)
+     * - PROCESSING 상태
+     * - 마지막 확인 시간이 기준 시간 이전 (또는 확인한 적 없음)
+     * - 최대 확인 횟수 미만
+     *
+     * @param thresholdTime 기준 시간 (이 시간 이전에 마지막으로 확인된 결제만 조회)
+     * @param maxCheckCount 최대 확인 횟수
+     * @return PROCESSING 상태인 Payment 목록
+     */
+    List<Payment> findProcessingPaymentsForStatusCheck(LocalDateTime thresholdTime, int maxCheckCount);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -33,4 +33,6 @@ public interface PaymentRepository {
      * @return PROCESSING 상태인 Payment 목록
      */
     List<Payment> findProcessingPaymentsForStatusCheck(LocalDateTime thresholdTime, int maxCheckCount);
+
+    Optional<Payment> findByPaymentId(String paymentId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentResult.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment;
+
+public record PaymentResult(String transactionId, String status, String message) {
+
+    public boolean isSuccess() {
+        return "SUCCESS".equals(status);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -1,0 +1,35 @@
+package com.loopers.domain.payment;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    /**
+     * Payment 저장
+     */
+    public Payment save(Payment payment) {
+        return paymentRepository.save(payment);
+    }
+
+    /**
+     * TransactionKey로 Payment 조회
+     *
+     * @param transactionKey PG 거래 키
+     * @return Payment 엔티티
+     * @throws CoreException 결제 정보를 찾을 수 없는 경우
+     */
+    public Payment getPaymentByTransactionKey(String transactionKey) {
+        return paymentRepository.findByPgTransactionId(transactionKey)
+                .orElseThrow(() -> new CoreException(
+                        ErrorType.NOT_FOUND,
+                        "결제 정보를 찾을 수 없습니다: " + transactionKey
+                ));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment;
+
+public enum PaymentStatus {
+    PENDING,      // 결제 생성됨 (PG 요청 전)
+    PROCESSING,   // PG에 요청됨 (결제 처리 중)
+    SUCCESS,      // 결제 성공 (콜백으로 확인됨)
+    FAILED        // 결제 실패 (콜백으로 확인됨)
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentType.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment;
+
+public enum PaymentType {
+    CARD,   // 카드 결제
+    POINT,  // 포인트 결제
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -104,4 +104,11 @@ public class User extends BaseEntity {
         validateAmount(amount);
         this.point = this.point.subtract(amount);
     }
+
+    /**
+     * 포인트 환불 (보상 트랜잭션)
+     */
+    public void refundPoint(Money amount) {
+        this.point = this.point.add(amount);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/dto/PaymentExternalDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/dto/PaymentExternalDto.java
@@ -1,0 +1,93 @@
+package com.loopers.infrastructure.external.dto;
+
+import com.loopers.domain.payment.Payment;
+
+public class PaymentExternalDto {
+
+    /**
+     * 결제 정보 Request
+     * */
+    public record PaymentRequest(
+            String orderId,
+            String cardType,
+            String cardNo,
+            Long amount,
+            String callbackUrl
+    ) {
+        public static PaymentRequest from(Payment payment, String callbackUrl) {
+            return new PaymentRequest(
+                    payment.getPaymentId(),
+                    payment.getCardType().name(),
+                    payment.getCardNo(),
+                    payment.getAmount().getAmount().longValue(),
+                    callbackUrl
+            );
+        }
+    }
+
+    /**
+     * 결제 정보 Response (접수 확인 응답)
+     *
+     * - PG에 결제 요청을 보낸 후 즉시 받는 응답
+     * - 실제 결제는 백그라운드에서 비동기로 처리됨
+     * - 최종 결제 결과는 콜백(POST /api/v1/payments/callback)으로 수신
+     */
+    public record PaymentResponse(
+            Meta meta,
+            PaymentData data
+    ) {
+        /**
+         * 결제 요청 성공 여부 확인
+         */
+        public boolean isSuccess() {
+            return "SUCCESS".equals(meta.result());
+        }
+
+        /**
+         * Transaction Key 조회 (성공 시에만 존재)
+         */
+        public String getTransactionKey() {
+            return data != null ? data.transactionKey() : null;
+        }
+
+        /**
+         * 결제 상태 조회 (성공 시에만 존재)
+         */
+        public String getStatus() {
+            return data != null ? data.status() : null;
+        }
+
+        /**
+         * 에러 메시지 조회 (실패 시에만 존재)
+         */
+        public String getErrorMessage() {
+            return meta.message();
+        }
+    }
+
+    /**
+     * Response Meta 정보
+     *
+     * @param result "SUCCESS" 또는 "FAIL"
+     * @param errorCode 에러 코드 (실패 시)
+     * @param message 에러 메시지 (실패 시)
+     */
+    public record Meta(
+            String result,
+            String errorCode,
+            String message
+    ) {
+    }
+
+    /**
+     * Payment Data (성공 시에만 존재)
+     *
+     * @param transactionKey PG사에서 발급한 거래 키
+     * @param status 결제 상태 ("PENDING")
+     */
+    public record PaymentData(
+            String transactionKey,
+            String status
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/feign/PaymentClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/feign/PaymentClient.java
@@ -1,0 +1,40 @@
+package com.loopers.infrastructure.external.feign;
+
+import com.loopers.config.FeignClientConfig;
+import com.loopers.infrastructure.external.dto.PaymentExternalDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * PG 결제 시스템 FeignClient
+ * X-USER-ID 헤더는 FeignClientConfig의 pgClientIdInterceptor에서 자동으로 추가됨
+ */
+@FeignClient(
+        name = "pg-simulator",
+        url = "${external.pg-simulator.url}",
+        configuration = FeignClientConfig.class
+    )
+public interface PaymentClient {
+
+    @PostMapping("/api/v1/payments")
+    PaymentExternalDto.PaymentResponse payment(
+            @RequestBody PaymentExternalDto.PaymentRequest request
+    );
+
+    /**
+     * 결제 정보 확인
+     * */
+    @GetMapping("/api/v1/payments/{transactionId}")
+    PaymentExternalDto.PaymentResponse paymentInfo(
+            @PathVariable String transactionId
+    );
+
+    /**
+     * 주문에 엮인 결제 정보 조회
+     * */
+    @GetMapping("/api/v1/payments?orderId={orderId}")
+    PaymentExternalDto.PaymentResponse[] paymentList(
+            @PathVariable String orderId
+    );
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/feign/PaymentClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/feign/PaymentClient.java
@@ -5,6 +5,8 @@ import com.loopers.infrastructure.external.dto.PaymentExternalDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * PG 결제 시스템 FeignClient
  * X-USER-ID 헤더는 FeignClientConfig의 pgClientIdInterceptor에서 자동으로 추가됨
@@ -32,9 +34,9 @@ public interface PaymentClient {
     /**
      * 주문에 엮인 결제 정보 조회
      * */
-    @GetMapping("/api/v1/payments?orderId={orderId}")
-    PaymentExternalDto.PaymentResponse[] paymentList(
-            @PathVariable String orderId
+    @GetMapping("/api/v1/payments")
+    List<PaymentExternalDto.PaymentResponse> paymentList(
+            @RequestParam("orderId") String orderId
     );
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/FeignPaymentGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/FeignPaymentGateway.java
@@ -1,0 +1,110 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentGateway;
+import com.loopers.domain.payment.PaymentResult;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.infrastructure.external.dto.PaymentExternalDto;
+import com.loopers.infrastructure.external.feign.PaymentClient;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FeignPaymentGateway implements PaymentGateway {
+
+    private final PaymentClient paymentClient;
+
+    @Override
+    @Retry(name = "paymentGateway")
+    @CircuitBreaker(name = "paymentGateway", fallbackMethod = "paymentFallback")
+    public PaymentResult processPayment(String userId, Payment payment, String callbackUrl) {
+        log.debug("결제 요청 - paymentId: {}, userId: {}", payment.getPaymentId(), userId);
+
+        // Infrastructure DTO로 변환
+        PaymentExternalDto.PaymentRequest request = PaymentExternalDto.PaymentRequest.from(payment, callbackUrl);
+
+        // 외부 결제 시스템 호출
+        PaymentExternalDto.PaymentResponse response = paymentClient.payment(request);
+
+        // 실패 응답 처리
+        if (!response.isSuccess()) {
+            throw new CoreException(
+                    ErrorType.PAYMENT_REQUEST_FAILED,
+                    "결제 요청 실패: " + response.getErrorMessage()
+            );
+        }
+
+        // Domain 모델로 변환하여 반환
+        return new PaymentResult(
+                response.getTransactionKey(),  // transactionKey 사용
+                response.getStatus(),          // "PENDING"
+                "결제 요청이 접수되었습니다"
+        );
+    }
+
+    @Override
+    @Retry(name = "paymentGateway")
+    @CircuitBreaker(name = "paymentGateway", fallbackMethod = "checkPaymentStatusFallback")
+    public PaymentResult checkPaymentStatus(String pgTransactionId) {
+        log.debug("결제 상태 조회 - pgTransactionId: {}", pgTransactionId);
+
+        // 외부 결제 시스템에 상태 확인 요청
+        PaymentExternalDto.PaymentResponse response = paymentClient.paymentInfo(pgTransactionId);
+
+        // 실패 응답 처리
+        if (!response.isSuccess()) {
+            throw new CoreException(
+                    ErrorType.PAYMENT_REQUEST_FAILED,
+                    "결제 상태 조회 실패: " + response.getErrorMessage()
+            );
+        }
+
+        // Domain 모델로 변환하여 반환
+        return new PaymentResult(
+                response.getTransactionKey(),
+                response.getStatus(),
+                response.getErrorMessage() != null ? response.getErrorMessage() : "상태 조회 완료"
+        );
+    }
+
+    /**
+     * Payment Fallback 메서드
+     * Circuit이 Open 상태이거나, 재시도 실패 시 호출
+     * */
+    private PaymentResult paymentFallback(String userId, Payment payment, String callbackUrl, Exception ex) {
+        log.error("결제 시스템 장애 발생 - userId: {}, paymentKey: {}, error: {}",
+                userId, payment.getPaymentId(), ex.getMessage(), ex);
+
+        // 방법 1 : 결제 대기 상태 처리 ( 현재 시스템에는 방법 2의 처리가 구현되어 있지 않아 방법 1로 처리함.)
+        return new PaymentResult(
+                null,
+                "FAIL",
+                "결제 시스템 장애로 결제 대기 상태로 변경되었습니다."
+        );
+
+        // 방법 2 : 다른 PG사에 요청을 보낸다.
+    }
+
+    /**
+     * Check Payment Status Fallback 메서드
+     * Circuit이 Open 상태이거나, 재시도 실패 시 호출
+     * */
+    private PaymentResult checkPaymentStatusFallback(String pgTransactionId, Exception ex) {
+        log.error("결제 상태 조회 시스템 장애 발생 - pgTransactionId: {}, error: {}",
+                pgTransactionId, ex.getMessage(), ex);
+
+        // 상태 조회 실패 시 PROCESSING 유지
+        return new PaymentResult(
+                pgTransactionId,
+                "PROCESSING",
+                "결제 시스템 장애로 상태 조회에 실패했습니다."
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -39,4 +39,6 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, String> {
             @Param("thresholdTime") LocalDateTime thresholdTime,
             @Param("maxCheckCount") Integer maxCheckCount
     );
+
+    Optional<Payment> findByPaymentId(String paymentId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -1,0 +1,42 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentJpaRepository extends JpaRepository<Payment, String> {
+
+    /**
+     * PG Transaction ID로 Payment 조회
+     *
+     * @param pgTransactionId PG사에서 발급한 거래 키
+     * @return Payment 엔티티 (Optional)
+     */
+    Optional<Payment> findByPgTransactionId(String pgTransactionId);
+
+    /**
+     * PROCESSING 상태인 결제 중 상태 확인 대상 조회
+     * - PROCESSING 상태
+     * - 마지막 확인 시간이 기준 시간 이전이거나 확인한 적 없음
+     * - 최대 확인 횟수 미만
+     *
+     * @param status 결제 상태
+     * @param thresholdTime 기준 시간
+     * @param maxCheckCount 최대 확인 횟수
+     * @return 상태 확인 대상 Payment 목록
+     */
+    @Query("SELECT p FROM Payment p WHERE p.status = :status " +
+            "AND (p.lastStatusCheckAt < :thresholdTime OR p.lastStatusCheckAt IS NULL) " +
+            "AND p.statusCheckCount < :maxCheckCount")
+    List<Payment> findByStatusAndLastStatusCheckAtBeforeOrLastStatusCheckAtIsNullAndStatusCheckCountLessThan(
+            @Param("status") PaymentStatus status,
+            @Param("thresholdTime") LocalDateTime thresholdTime,
+            @Param("maxCheckCount") Integer maxCheckCount
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentRepository;
+import com.loopers.domain.payment.PaymentStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class PaymentRepositoryImpl implements PaymentRepository {
+    private final PaymentJpaRepository paymentJpaRepository;
+
+    @Override
+    public Optional<Payment> findByPgTransactionId(String pgTransactionId) {
+        return paymentJpaRepository.findByPgTransactionId(pgTransactionId);
+    }
+
+    @Override
+    public Payment save(Payment payment) {
+        return paymentJpaRepository.save(payment);
+    }
+
+    @Override
+    public List<Payment> findProcessingPaymentsForStatusCheck(LocalDateTime thresholdTime, int maxCheckCount) {
+        return paymentJpaRepository.findByStatusAndLastStatusCheckAtBeforeOrLastStatusCheckAtIsNullAndStatusCheckCountLessThan(
+                PaymentStatus.PROCESSING,
+                thresholdTime,
+                maxCheckCount
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -33,4 +33,9 @@ public class PaymentRepositoryImpl implements PaymentRepository {
                 maxCheckCount
         );
     }
+
+    @Override
+    public Optional<Payment> findByPaymentId(String paymentId) {
+        return paymentJpaRepository.findByPaymentId(paymentId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckScheduler.java
@@ -1,0 +1,109 @@
+package com.loopers.infrastructure.scheduler;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentGateway;
+import com.loopers.domain.payment.PaymentRepository;
+import com.loopers.domain.payment.PaymentResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * PROCESSING 상태인 결제에 대해 주기적으로 상태를 확인하는 스케줄러
+ * - 1분 주기로 실행
+ * - 콜백이 오지 않은 결제에 대해 PG사에 상태 확인 요청
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class PaymentStatusCheckScheduler {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentGateway paymentGateway;
+
+    // 최대 확인 횟수 (10회까지 재시도)
+    private static final int MAX_CHECK_COUNT = 10;
+    // 확인 주기 (1분)
+    private static final int CHECK_INTERVAL_MINUTES = 1;
+
+    /**
+     * 1분마다 PROCESSING 상태인 결제 확인
+     */
+    @Scheduled(fixedRate = 60000) // 60초 = 1분
+    @Transactional
+    public void checkProcessingPayments() {
+        log.info("[결제 상태 확인 스케줄러] 결제 상태 확인 시작");
+
+        try {
+            LocalDateTime thresholdTime = LocalDateTime.now().minusMinutes(CHECK_INTERVAL_MINUTES);
+
+            // 확인 대상 결제 조회
+            List<Payment> processingPayments = paymentRepository.findProcessingPaymentsForStatusCheck(
+                    thresholdTime,
+                    MAX_CHECK_COUNT
+            );
+
+            if (processingPayments.isEmpty()) {
+                log.info("[결제 상태 확인 스케줄러] 확인할 처리 중인 결제가 없습니다");
+                return;
+            }
+
+            log.info("[결제 상태 확인 스케줄러] 확인할 처리 중인 결제 {}건 발견",
+                    processingPayments.size());
+
+            // 각 결제에 대해 상태 확인
+            for (Payment payment : processingPayments) {
+                checkPaymentStatus(payment);
+            }
+
+            log.info("[결제 상태 확인 스케줄러] 결제 상태 확인 완료");
+        } catch (Exception e) {
+            log.error("[결제 상태 확인 스케줄러] 결제 상태 확인 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 개별 결제 상태 확인
+     */
+    private void checkPaymentStatus(Payment payment) {
+        try {
+            log.info("[결제 상태 확인 스케줄러] 결제 확인 중: paymentId={}, pgTransactionId={}, checkCount={}",
+                    payment.getPaymentId(), payment.getPgTransactionId(), payment.getStatusCheckCount());
+
+            // PG사에 상태 확인 요청
+            PaymentResult result = paymentGateway.checkPaymentStatus(payment.getPgTransactionId());
+
+            // 확인 횟수 증가
+            payment.incrementStatusCheckCount();
+
+            // 결과에 따라 결제 상태 업데이트
+            if (result.isSuccess()) {
+                payment.completePayment();
+                log.info("[결제 상태 확인 스케줄러] 결제 완료: paymentId={}", payment.getPaymentId());
+            } else if ("FAILED".equals(result.status()) || "FAIL".equals(result.status())) {
+                payment.failPayment(result.message());
+                log.warn("[결제 상태 확인 스케줄러] 결제 실패: paymentId={}, reason={}",
+                        payment.getPaymentId(), result.message());
+            } else {
+                // PROCESSING 상태 유지
+                log.info("[결제 상태 확인 스케줄러] 결제 처리 중: paymentId={}",
+                        payment.getPaymentId());
+            }
+
+            paymentRepository.save(payment);
+
+        } catch (Exception e) {
+            log.error("[결제 상태 확인 스케줄러] 결제 상태 확인 중 오류 발생: paymentId={}",
+                    payment.getPaymentId(), e);
+
+            // 에러 발생 시에도 확인 횟수는 증가
+            payment.incrementStatusCheckCount();
+            paymentRepository.save(payment);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckScheduler.java
@@ -1,14 +1,11 @@
 package com.loopers.infrastructure.scheduler;
 
 import com.loopers.domain.payment.Payment;
-import com.loopers.domain.payment.PaymentGateway;
 import com.loopers.domain.payment.PaymentRepository;
-import com.loopers.domain.payment.PaymentResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +14,7 @@ import java.util.List;
  * PROCESSING 상태인 결제에 대해 주기적으로 상태를 확인하는 스케줄러
  * - 1분 주기로 실행
  * - 콜백이 오지 않은 결제에 대해 PG사에 상태 확인 요청
+ * - 각 결제는 별도 트랜잭션으로 처리되어 부분 실패 시에도 성공한 결제는 커밋됨
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -24,7 +22,7 @@ import java.util.List;
 public class PaymentStatusCheckScheduler {
 
     private final PaymentRepository paymentRepository;
-    private final PaymentGateway paymentGateway;
+    private final PaymentStatusCheckService paymentStatusCheckService;
 
     // 최대 확인 횟수 (10회까지 재시도)
     private static final int MAX_CHECK_COUNT = 10;
@@ -33,9 +31,10 @@ public class PaymentStatusCheckScheduler {
 
     /**
      * 1분마다 PROCESSING 상태인 결제 확인
+     * - 전체 배치에 트랜잭션 적용하지 않음
+     * - 각 결제는 PaymentStatusCheckService에서 독립적인 트랜잭션으로 처리
      */
     @Scheduled(fixedRate = 60000) // 60초 = 1분
-    @Transactional
     public void checkProcessingPayments() {
         log.info("[결제 상태 확인 스케줄러] 결제 상태 확인 시작");
 
@@ -56,54 +55,14 @@ public class PaymentStatusCheckScheduler {
             log.info("[결제 상태 확인 스케줄러] 확인할 처리 중인 결제 {}건 발견",
                     processingPayments.size());
 
-            // 각 결제에 대해 상태 확인
+            // 각 결제를 독립적인 트랜잭션으로 처리
             for (Payment payment : processingPayments) {
-                checkPaymentStatus(payment);
+                paymentStatusCheckService.checkPaymentStatus(payment.getPaymentId());
             }
 
             log.info("[결제 상태 확인 스케줄러] 결제 상태 확인 완료");
         } catch (Exception e) {
             log.error("[결제 상태 확인 스케줄러] 결제 상태 확인 중 오류 발생", e);
-        }
-    }
-
-    /**
-     * 개별 결제 상태 확인
-     */
-    private void checkPaymentStatus(Payment payment) {
-        try {
-            log.info("[결제 상태 확인 스케줄러] 결제 확인 중: paymentId={}, pgTransactionId={}, checkCount={}",
-                    payment.getPaymentId(), payment.getPgTransactionId(), payment.getStatusCheckCount());
-
-            // PG사에 상태 확인 요청
-            PaymentResult result = paymentGateway.checkPaymentStatus(payment.getPgTransactionId());
-
-            // 확인 횟수 증가
-            payment.incrementStatusCheckCount();
-
-            // 결과에 따라 결제 상태 업데이트
-            if (result.isSuccess()) {
-                payment.completePayment();
-                log.info("[결제 상태 확인 스케줄러] 결제 완료: paymentId={}", payment.getPaymentId());
-            } else if ("FAILED".equals(result.status()) || "FAIL".equals(result.status())) {
-                payment.failPayment(result.message());
-                log.warn("[결제 상태 확인 스케줄러] 결제 실패: paymentId={}, reason={}",
-                        payment.getPaymentId(), result.message());
-            } else {
-                // PROCESSING 상태 유지
-                log.info("[결제 상태 확인 스케줄러] 결제 처리 중: paymentId={}",
-                        payment.getPaymentId());
-            }
-
-            paymentRepository.save(payment);
-
-        } catch (Exception e) {
-            log.error("[결제 상태 확인 스케줄러] 결제 상태 확인 중 오류 발생: paymentId={}",
-                    payment.getPaymentId(), e);
-
-            // 에러 발생 시에도 확인 횟수는 증가
-            payment.incrementStatusCheckCount();
-            paymentRepository.save(payment);
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckService.java
@@ -1,0 +1,78 @@
+package com.loopers.infrastructure.scheduler;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentGateway;
+import com.loopers.domain.payment.PaymentRepository;
+import com.loopers.domain.payment.PaymentResult;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 결제 상태 확인 서비스
+ * - 각 결제를 독립적인 트랜잭션으로 처리하여 부분 실패 시에도 성공한 결제는 커밋되도록 함
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentStatusCheckService {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentGateway paymentGateway;
+
+    /**
+     * 개별 결제 상태 확인 (독립적인 트랜잭션)
+     * - REQUIRES_NEW로 각 결제마다 새로운 트랜잭션 생성
+     * - 한 결제 실패가 다른 결제에 영향 없음
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void checkPaymentStatus(String paymentId) {
+        try {
+            Payment payment = paymentRepository.findByPaymentId(paymentId)
+                    .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "결제를 찾을 수 없습니다"));
+
+            log.info("[결제 상태 확인] 결제 확인 중: paymentId={}, pgTransactionId={}, checkCount={}",
+                    payment.getPaymentId(), payment.getPgTransactionId(), payment.getStatusCheckCount());
+
+            // PG사에 상태 확인 요청
+            PaymentResult result = paymentGateway.checkPaymentStatus(payment.getPgTransactionId());
+
+            // 확인 횟수 증가
+            payment.incrementStatusCheckCount();
+
+            // 결과에 따라 결제 상태 업데이트
+            if (result.isSuccess()) {
+                payment.completePayment();
+                log.info("[결제 상태 확인] 결제 완료: paymentId={}", payment.getPaymentId());
+            } else if ("FAILED".equals(result.status()) || "FAIL".equals(result.status())) {
+                payment.failPayment(result.message());
+                log.warn("[결제 상태 확인] 결제 실패: paymentId={}, reason={}",
+                        payment.getPaymentId(), result.message());
+            } else {
+                // PROCESSING 상태 유지
+                log.info("[결제 상태 확인] 결제 처리 중: paymentId={}",
+                        payment.getPaymentId());
+            }
+
+            paymentRepository.save(payment);
+
+        } catch (Exception e) {
+            log.error("[결제 상태 확인] 결제 상태 확인 중 오류 발생: paymentId={}", paymentId, e);
+
+            // 에러 발생 시에도 확인 횟수는 증가
+            try {
+                Payment payment = paymentRepository.findByPaymentId(paymentId).orElse(null);
+                if (payment != null) {
+                    payment.incrementStatusCheckCount();
+                    paymentRepository.save(payment);
+                }
+            } catch (Exception ex) {
+                log.error("[결제 상태 확인] 확인 횟수 증가 중 오류 발생: paymentId={}", paymentId, ex);
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -1,5 +1,6 @@
 package com.loopers.interfaces.api.order;
 
+import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.OrderFacade;
 import com.loopers.application.order.OrderInfo;
 import com.loopers.interfaces.api.ApiResponse;
@@ -7,8 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -21,11 +20,22 @@ public class OrderV1Controller implements OrderV1ApiSpec {
     @PostMapping("/new")
     public ApiResponse<OrderV1Dto.OrderResponse> createOrder(OrderV1Dto.OrderRequest request) {
 
-        List<OrderV1Dto.OrderRequest.OrderItemRequest> items = request.items();
-
-        OrderInfo orderInfo = orderFacade.createOrder(
-                request.userId(), items, request.couponId()
+        // Presentation DTO → Application DTO 변환
+        OrderCommand command = new OrderCommand(
+                request.userId(),
+                request.items().stream()
+                        .map(item -> new OrderCommand.OrderItemCommand(
+                                item.productId(),
+                                item.quantity()
+                        ))
+                        .toList(),
+                request.couponId(),
+                request.paymentType(),
+                request.cardType(),
+                request.cardNo()
         );
+
+        OrderInfo orderInfo = orderFacade.createOrder(command);
 
         OrderV1Dto.OrderResponse response = OrderV1Dto.OrderResponse.from(orderInfo);
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -2,6 +2,8 @@ package com.loopers.interfaces.api.order;
 
 import com.loopers.application.order.OrderInfo;
 import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -11,7 +13,10 @@ public class OrderV1Dto {
     public record OrderRequest(
             String userId,
             List<OrderItemRequest> items,
-            Long couponId
+            Long couponId,
+            PaymentType paymentType,
+            CardType cardType,
+            String cardNo
     ) {
         public record OrderItemRequest(
                 Long productId,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentCallbackController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentCallbackController.java
@@ -1,0 +1,46 @@
+package com.loopers.interfaces.api.payment;
+
+import com.loopers.application.payment.PaymentCallbackInfo;
+import com.loopers.application.payment.PaymentFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentCallbackController {
+
+    private final PaymentFacade paymentFacade;
+
+    /**
+     * PG 결제 콜백 처리
+     *
+     * PG에서 결제 처리 완료 후 최종 결과를 전달받는 엔드포인트
+     */
+    @PostMapping("/callback")
+    public ApiResponse<Void> handleCallback(
+            @RequestBody PaymentCallbackDto.CallbackRequest request
+    ) {
+        log.info("=== Payment Callback Received ===");
+        log.info("TransactionKey: {}", request.transactionKey());
+        log.info("Status: {}", request.status());
+        log.info("OrderId: {}", request.orderId());
+
+        // Presentation Dto → Application Dto 변환
+        PaymentCallbackInfo callbackInfo = new PaymentCallbackInfo(
+                request.transactionKey(),
+                request.status(),
+                request.reason()
+        );
+
+        // Application Layer 호출
+        paymentFacade.handlePaymentCallback(callbackInfo);
+
+        log.info("=== Payment Callback Processed Successfully ===");
+
+        return ApiResponse.success(null);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentCallbackController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentCallbackController.java
@@ -27,7 +27,6 @@ public class PaymentCallbackController {
         log.info("=== Payment Callback Received ===");
         log.info("TransactionKey: {}", request.transactionKey());
         log.info("Status: {}", request.status());
-        log.info("OrderId: {}", request.orderId());
 
         // Presentation Dto → Application Dto 변환
         PaymentCallbackInfo callbackInfo = new PaymentCallbackInfo(

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentCallbackDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentCallbackDto.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.api.payment;
+
+public class PaymentCallbackDto {
+
+    /**
+     * PG에서 전송하는 콜백 요청
+     *
+     * @param transactionKey PG 거래 키 (예: "20251203:TR:1a5877")
+     * @param orderId 주문 ID
+     * @param cardType 카드사
+     * @param cardNo 카드 번호
+     * @param amount 결제 금액
+     * @param status 결제 상태 ("SUCCESS", "FAILED")
+     * @param reason 실패 사유 (실패 시에만 존재)
+     */
+    public record CallbackRequest(
+            String transactionKey,
+            String orderId,
+            String cardType,
+            String cardNo,
+            Long amount,
+            String status,
+            String reason
+    ) {
+        /**
+         * 결제 성공 여부 확인
+         */
+        public boolean isSuccess() {
+            return "SUCCESS".equals(status);
+        }
+
+        /**
+         * 결제 실패 여부 확인
+         */
+        public boolean isFailed() {
+            return "FAILED".equals(status);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -11,7 +11,10 @@ public enum ErrorType {
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "일시적인 오류가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
-    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다.");
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다."),
+
+    /** 결제 에러 */
+    PAYMENT_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT_REQUEST_FAILED", "결제 요청에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -40,6 +40,9 @@ external:
     url: http://localhost:8082
     client-id: "135135"  # 고객사 ID
 
+payment:
+  callback:
+    base-url: http://localhost:8080
 ---
 spring:
   config:

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -35,6 +35,11 @@ spring:
     activate:
       on-profile: local, test
 
+external:
+  pg-simulator:
+    url: http://localhost:8082
+    client-id: "135135"  # 고객사 ID
+
 ---
 spring:
   config:
@@ -56,3 +61,55 @@ spring:
 springdoc:
   api-docs:
     enabled: false
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      paymentGateway:
+        # health indicator 등록
+        register-health-indicator: true
+        # 슬라이딩 윈도우 타입
+        sliding-window-type: COUNT_BASED
+        # 슬라이딩 윈도우 (최근 몇번의 호출을 추적 할지 설정)
+        sliding-window-size: 10
+        # 실패율( % 설정)이 설정한 값 이상이면 Circuit을 Open한다.
+        failure-rate-threshold: 50
+        # 최소 몇번의 호출 후 실패율을 계산할지 설정 (테스트를 위해 5로 설정)
+        minimum-number-of-calls: 5
+        # Circuit이 Half-Open으로 전환되기 전 대기 시간 설정
+        wait-duration-in-open-state: 10s
+        # Half-Open 상태에서 몇번의 테스트 호출을 허용할 것인가 설정
+        permitted-number-of-calls-in-half-open-state: 2
+        # 몇초이상 걸리면 느린 호출로 간주할 것인지 설정
+        slow-call-duration-threshold: 2s
+        # 느린 호출의 비율이 설정한 값( % 설정 ) 이면 Circuit을 Open할지 설정
+        slow-call-rate-threshold: 70
+        # 기록할 예외 (이 예외들은 실패로 카운트)
+        record-exceptions:
+          - feign.FeignException
+          - java.util.concurrent.TimeoutException
+          - java.io.IOException
+        # Circuit Breaker에서 무시할 예외 (실패로 카운트하지 않음)
+        # 비즈니스 로직 예외는 PG 시스템 장애가 아니므로 제외함
+        ignore-exceptions:
+          - com.loopers.support.error.CoreException
+
+  retry:
+    instances:
+      paymentGateway:
+        # 최대 재시도 횟수 (초기 호출 포함 총 3회 시도)
+        max-attempts: 3
+        # 재시도 간격 (1초)
+        wait-duration: 1s
+        # 재시도 간격을 지수적으로 증가시킬지 여부
+        enable-exponential-backoff: true
+        # 지수 백오프 승수 (1초 -> 2초 -> 4초)
+        exponential-backoff-multiplier: 2
+        # 재시도할 예외 타입
+        retry-exceptions:
+          - java.util.concurrent.TimeoutException
+          - feign.RetryableException
+          - java.net.SocketTimeoutException
+        # 재시도하지 않을 예외 타입
+        ignore-exceptions:
+          - com.loopers.support.error.CoreException

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
@@ -22,13 +22,13 @@ class CouponTest {
         @Test
         void createRateCoupon_success() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.RATE)
                     .discountValue(10)
                     .build();
 
             // when
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "테스트를 위해 발급된 코드",
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "테스트를 위해 발급된 코드",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
             // then
@@ -38,7 +38,7 @@ class CouponTest {
                     () -> assertThat(coupon.getDescription()).isEqualTo("테스트를 위해 발급된 코드"),
                     () -> assertThat(coupon.getValidStartDate()).isEqualTo(LocalDate.of(2025, 1, 1)),
                     () -> assertThat(coupon.getValidEndDate()).isEqualTo(LocalDate.of(2025, 12, 31)),
-                    () -> assertThat(coupon.getDiscountPolicy()).isEqualTo(discountPolicy),
+                    () -> assertThat(coupon.getDiscount()).isEqualTo(discount),
                     () -> assertThat(coupon.isActive()).isTrue(),
                     () -> assertThat(coupon.getCurrentIssuanceCount()).isZero()
             );
@@ -48,21 +48,21 @@ class CouponTest {
         @Test
         void createAmountCoupon_success() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.AMOUNT)
                     .discountValue(5000)
                     .build();
 
             // when
-            Coupon coupon = createCoupon(discountPolicy, "AMOUNT5000", "5000원 할인 쿠폰", "정액 할인 쿠폰",
+            Coupon coupon = createCoupon(discount, "AMOUNT5000", "5000원 할인 쿠폰", "정액 할인 쿠폰",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
             // then
             assertAll(
                     () -> assertThat(coupon.getCode()).isEqualTo("AMOUNT5000"),
                     () -> assertThat(coupon.getName()).isEqualTo("5000원 할인 쿠폰"),
-                    () -> assertThat(coupon.getDiscountPolicy().getDiscountType()).isEqualTo(DiscountType.AMOUNT),
-                    () -> assertThat(coupon.getDiscountPolicy().getDiscountValue()).isEqualTo(5000)
+                    () -> assertThat(coupon.getDiscount().getDiscountType()).isEqualTo(DiscountType.AMOUNT),
+                    () -> assertThat(coupon.getDiscount().getDiscountValue()).isEqualTo(5000)
             );
         }
     }
@@ -75,11 +75,11 @@ class CouponTest {
         @Test
         void createCouponWithNullCode_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, null, "테스트 쿠폰", "설명",
+                    createCoupon(discount, null, "테스트 쿠폰", "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -91,11 +91,11 @@ class CouponTest {
         @Test
         void createCouponWithSpecialCharCode_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TEST_CODE123", "테스트 쿠폰", "설명",
+                    createCoupon(discount, "TEST_CODE123", "테스트 쿠폰", "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -107,11 +107,11 @@ class CouponTest {
         @Test
         void createCouponWithLowercaseCode_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "testcode123", "테스트 쿠폰", "설명",
+                    createCoupon(discount, "testcode123", "테스트 쿠폰", "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -123,11 +123,11 @@ class CouponTest {
         @Test
         void createCouponWithShortCode_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TEST123", "테스트 쿠폰", "설명",
+                    createCoupon(discount, "TEST123", "테스트 쿠폰", "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -139,11 +139,11 @@ class CouponTest {
         @Test
         void createCouponWithLongCode_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TESTCODE1234567890123", "테스트 쿠폰", "설명",
+                    createCoupon(discount, "TESTCODE1234567890123", "테스트 쿠폰", "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -160,11 +160,11 @@ class CouponTest {
         @Test
         void createCouponWithNullName_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TESTCODE123", null, "설명",
+                    createCoupon(discount, "TESTCODE123", null, "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -176,11 +176,11 @@ class CouponTest {
         @Test
         void createCouponWithBlankName_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TESTCODE123", "   ", "설명",
+                    createCoupon(discount, "TESTCODE123", "   ", "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -191,7 +191,7 @@ class CouponTest {
 
     @DisplayName("할인 정책 검증")
     @Nested
-    class ValidateDiscountPolicy {
+    class ValidateDiscount {
 
         @DisplayName("할인 정책이 null이면 예외가 발생한다.")
         @Test
@@ -210,14 +210,14 @@ class CouponTest {
         @Test
         void createCouponWithNullDiscountType_throwException() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(null)
                     .discountValue(10)
                     .build();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+                    createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -229,14 +229,14 @@ class CouponTest {
         @Test
         void createCouponWithZeroDiscountValue_throwException() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.RATE)
                     .discountValue(0)
                     .build();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+                    createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -248,14 +248,14 @@ class CouponTest {
         @Test
         void createCouponWithNegativeDiscountValue_throwException() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.RATE)
                     .discountValue(-10)
                     .build();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+                    createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                             LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
             );
 
@@ -272,11 +272,11 @@ class CouponTest {
         @Test
         void createCouponWithNullStartDate_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명", null, LocalDate.of(2025, 12, 31))
+                    createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명", null, LocalDate.of(2025, 12, 31))
             );
 
             assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
@@ -287,11 +287,11 @@ class CouponTest {
         @Test
         void createCouponWithNullEndDate_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명", LocalDate.of(2025, 1, 1), null)
+                    createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명", LocalDate.of(2025, 1, 1), null)
             );
 
             assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
@@ -302,11 +302,11 @@ class CouponTest {
         @Test
         void createCouponWithInvalidDateRange_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
+            Discount discount = createValidDiscountPolicy();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
-                    createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+                    createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                             LocalDate.of(2025, 12, 31), LocalDate.of(2025, 1, 1))
             );
 
@@ -323,8 +323,8 @@ class CouponTest {
         @Test
         void isValidAt_withinRange_returnsTrue() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
             // when & then
@@ -337,8 +337,8 @@ class CouponTest {
         @Test
         void isValidAt_outsideRange_returnsFalse() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
             // when & then
@@ -355,8 +355,8 @@ class CouponTest {
         @Test
         void increaseIssuanceCount_success() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
             // when
@@ -370,8 +370,8 @@ class CouponTest {
         @Test
         void increaseIssuanceCount_withoutLimit_success() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
             // when
@@ -387,8 +387,8 @@ class CouponTest {
         @Test
         void increaseIssuanceCount_exceedLimit_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
             coupon.setMaxIssuanceLimit(3);
 
@@ -413,8 +413,8 @@ class CouponTest {
         @Test
         void activate_success() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
             coupon.deactivate();
 
@@ -429,8 +429,8 @@ class CouponTest {
         @Test
         void deactivate_success() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
             // when
@@ -444,8 +444,8 @@ class CouponTest {
         @Test
         void setMaxIssuanceLimit_success() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
             // when
@@ -459,8 +459,8 @@ class CouponTest {
         @Test
         void setMaxIssuanceLimit_unlimited_success() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
             coupon.setMaxIssuanceLimit(100);
 
@@ -475,8 +475,8 @@ class CouponTest {
         @Test
         void setMaxIssuanceLimit_negative_throwException() {
             // given
-            DiscountPolicy discountPolicy = createValidDiscountPolicy();
-            Coupon coupon = createCoupon(discountPolicy, "TESTCODE123", "테스트 쿠폰", "설명",
+            Discount discount = createValidDiscountPolicy();
+            Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
             // when & then
@@ -490,7 +490,7 @@ class CouponTest {
     }
 
     private static Coupon createCoupon(
-            DiscountPolicy discountPolicy, String code, String name,
+            Discount discount, String code, String name,
             String desc, LocalDate validStartDate, LocalDate validEndDate) {
         return Coupon.builder()
                 .code(code)
@@ -498,12 +498,12 @@ class CouponTest {
                 .description(desc)
                 .validStartDate(validStartDate)
                 .validEndDate(validEndDate)
-                .discountPolicy(discountPolicy)
+                .discount(discount)
                 .build();
     }
 
-    private static DiscountPolicy createValidDiscountPolicy() {
-        return DiscountPolicy.builder()
+    private static Discount createValidDiscountPolicy() {
+        return Discount.builder()
                 .discountType(DiscountType.RATE)
                 .discountValue(10)
                 .build();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
@@ -75,7 +75,7 @@ class CouponTest {
         @Test
         void createCouponWithNullCode_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -91,7 +91,7 @@ class CouponTest {
         @Test
         void createCouponWithSpecialCharCode_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -107,7 +107,7 @@ class CouponTest {
         @Test
         void createCouponWithLowercaseCode_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -123,7 +123,7 @@ class CouponTest {
         @Test
         void createCouponWithShortCode_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -139,7 +139,7 @@ class CouponTest {
         @Test
         void createCouponWithLongCode_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -160,7 +160,7 @@ class CouponTest {
         @Test
         void createCouponWithNullName_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -176,7 +176,7 @@ class CouponTest {
         @Test
         void createCouponWithBlankName_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -272,7 +272,7 @@ class CouponTest {
         @Test
         void createCouponWithNullStartDate_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -287,7 +287,7 @@ class CouponTest {
         @Test
         void createCouponWithNullEndDate_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -302,7 +302,7 @@ class CouponTest {
         @Test
         void createCouponWithInvalidDateRange_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
 
             // when & then
             CoreException result = assertThrows(CoreException.class, () ->
@@ -323,7 +323,7 @@ class CouponTest {
         @Test
         void isValidAt_withinRange_returnsTrue() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
@@ -337,7 +337,7 @@ class CouponTest {
         @Test
         void isValidAt_outsideRange_returnsFalse() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
@@ -355,7 +355,7 @@ class CouponTest {
         @Test
         void increaseIssuanceCount_success() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
@@ -370,7 +370,7 @@ class CouponTest {
         @Test
         void increaseIssuanceCount_withoutLimit_success() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
@@ -387,7 +387,7 @@ class CouponTest {
         @Test
         void increaseIssuanceCount_exceedLimit_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
             coupon.setMaxIssuanceLimit(3);
@@ -413,7 +413,7 @@ class CouponTest {
         @Test
         void activate_success() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
             coupon.deactivate();
@@ -429,7 +429,7 @@ class CouponTest {
         @Test
         void deactivate_success() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
@@ -444,7 +444,7 @@ class CouponTest {
         @Test
         void setMaxIssuanceLimit_success() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
@@ -459,7 +459,7 @@ class CouponTest {
         @Test
         void setMaxIssuanceLimit_unlimited_success() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
             coupon.setMaxIssuanceLimit(100);
@@ -475,7 +475,7 @@ class CouponTest {
         @Test
         void setMaxIssuanceLimit_negative_throwException() {
             // given
-            Discount discount = createValidDiscountPolicy();
+            Discount discount = createValidDiscount();
             Coupon coupon = createCoupon(discount, "TESTCODE123", "테스트 쿠폰", "설명",
                     LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
 
@@ -502,7 +502,7 @@ class CouponTest {
                 .build();
     }
 
-    private static Discount createValidDiscountPolicy() {
+    private static Discount createValidDiscount() {
         return Discount.builder()
                 .discountType(DiscountType.RATE)
                 .discountValue(10)

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/DiscountTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/DiscountTest.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class DiscountPolicyTest {
+class DiscountTest {
 
     @DisplayName("정률 할인")
     @Nested
@@ -19,14 +19,14 @@ class DiscountPolicyTest {
         @Test
         void calculateRateDiscount_10percent_success() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.RATE)
                     .discountValue(10)
                     .build();
             Money originalPrice = Money.of(10000);
 
             // when
-            Money discountAmount = discountPolicy.calculateDiscount(originalPrice);
+            Money discountAmount = discount.calculateDiscount(originalPrice);
 
             // then
             assertThat(discountAmount.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(1000));
@@ -36,14 +36,14 @@ class DiscountPolicyTest {
         @Test
         void calculateRateDiscount_20percent_success() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.RATE)
                     .discountValue(20)
                     .build();
             Money originalPrice = Money.of(50000);
 
             // when
-            Money discountAmount = discountPolicy.calculateDiscount(originalPrice);
+            Money discountAmount = discount.calculateDiscount(originalPrice);
 
             // then
             assertThat(discountAmount.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(10000));
@@ -53,14 +53,14 @@ class DiscountPolicyTest {
         @Test
         void applyRateDiscount_success() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.RATE)
                     .discountValue(10)
                     .build();
             Money originalPrice = Money.of(10000);
 
             // when
-            Money finalPrice = discountPolicy.applyDiscount(originalPrice);
+            Money finalPrice = discount.applyDiscount(originalPrice);
 
             // then
             assertThat(finalPrice.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(9000));
@@ -70,14 +70,14 @@ class DiscountPolicyTest {
         @Test
         void applyRateDiscount_exceedOriginal_returnZero() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.RATE)
                     .discountValue(150) // 150% 할인
                     .build();
             Money originalPrice = Money.of(10000);
 
             // when
-            Money finalPrice = discountPolicy.applyDiscount(originalPrice);
+            Money finalPrice = discount.applyDiscount(originalPrice);
 
             // then
             assertThat(finalPrice.getAmount()).isEqualByComparingTo(BigDecimal.ZERO);
@@ -92,14 +92,14 @@ class DiscountPolicyTest {
         @Test
         void calculateAmountDiscount_success() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.AMOUNT)
                     .discountValue(5000)
                     .build();
             Money originalPrice = Money.of(20000);
 
             // when
-            Money discountAmount = discountPolicy.calculateDiscount(originalPrice);
+            Money discountAmount = discount.calculateDiscount(originalPrice);
 
             // then
             assertThat(discountAmount.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(5000));
@@ -109,14 +109,14 @@ class DiscountPolicyTest {
         @Test
         void applyAmountDiscount_success() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.AMOUNT)
                     .discountValue(3000)
                     .build();
             Money originalPrice = Money.of(10000);
 
             // when
-            Money finalPrice = discountPolicy.applyDiscount(originalPrice);
+            Money finalPrice = discount.applyDiscount(originalPrice);
 
             // then
             assertThat(finalPrice.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(7000));
@@ -126,14 +126,14 @@ class DiscountPolicyTest {
         @Test
         void applyAmountDiscount_exceedOriginal_returnZero() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.AMOUNT)
                     .discountValue(15000)
                     .build();
             Money originalPrice = Money.of(10000);
 
             // when
-            Money finalPrice = discountPolicy.applyDiscount(originalPrice);
+            Money finalPrice = discount.applyDiscount(originalPrice);
 
             // then
             assertThat(finalPrice.getAmount()).isEqualByComparingTo(BigDecimal.ZERO);
@@ -143,15 +143,15 @@ class DiscountPolicyTest {
         @Test
         void calculateAmountDiscount_fixedAmount_success() {
             // given
-            DiscountPolicy discountPolicy = DiscountPolicy.builder()
+            Discount discount = Discount.builder()
                     .discountType(DiscountType.AMOUNT)
                     .discountValue(2000)
                     .build();
 
             // when
-            Money discount1 = discountPolicy.calculateDiscount(Money.of(10000));
-            Money discount2 = discountPolicy.calculateDiscount(Money.of(50000));
-            Money discount3 = discountPolicy.calculateDiscount(Money.of(100000));
+            Money discount1 = discount.calculateDiscount(Money.of(10000));
+            Money discount2 = discount.calculateDiscount(Money.of(50000));
+            Money discount3 = discount.calculateDiscount(Money.of(100000));
 
             // then
             assertThat(discount1.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(2000));

--- a/apps/commerce-api/src/test/java/com/loopers/domain/issuedcoupon/IssuedCouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/issuedcoupon/IssuedCouponTest.java
@@ -1,7 +1,7 @@
 package com.loopers.domain.issuedcoupon;
 
 import com.loopers.domain.coupon.Coupon;
-import com.loopers.domain.coupon.DiscountPolicy;
+import com.loopers.domain.coupon.Discount;
 import com.loopers.domain.coupon.DiscountType;
 import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.User;
@@ -254,7 +254,7 @@ class IssuedCouponTest {
     }
 
     private static Coupon createValidCoupon() {
-        DiscountPolicy discountPolicy = DiscountPolicy.builder()
+        Discount discount = Discount.builder()
                 .discountType(DiscountType.RATE)
                 .discountValue(10)
                 .build();
@@ -265,7 +265,7 @@ class IssuedCouponTest {
                 .description("테스트용 쿠폰")
                 .validStartDate(java.time.LocalDate.of(2025, 1, 1))
                 .validEndDate(java.time.LocalDate.of(2025, 12, 31))
-                .discountPolicy(discountPolicy)
+                .discount(discount)
                 .build();
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
@@ -188,27 +188,4 @@ class OrderTest {
         assertThat(exception.getCustomMessage()).contains("재고가 부족합니다");
     }
 
-    @DisplayName("주문 생성 시 포인트가 부족하면 예외가 발생한다.")
-    @Test
-    void createOrder_withInsufficientPoint_throwException() {
-        // given
-        User mockUser = mock(User.class);
-        when(mockUser.getPoint()).thenReturn(Money.of(10000)); // 포인트 10000
-
-        Product mockProduct = mock(Product.class);
-        when(mockProduct.getPrice()).thenReturn(Money.of(25000));
-        when(mockProduct.getStock()).thenReturn(Stock.of(100));
-
-        Map<Product, Integer> productQuantities = new HashMap<>();
-        productQuantities.put(mockProduct, 1); // 25000원 필요
-
-        // when // then
-        CoreException exception = assertThrows(CoreException.class, () ->
-            Order.createOrder(mockUser, productQuantities)
-        );
-
-        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
-        assertThat(exception.getCustomMessage()).contains("포인트가 부족합니다");
-    }
-
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
@@ -1,0 +1,153 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.Money;
+import com.loopers.domain.order.Order;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PaymentTest {
+
+    @DisplayName("결제 정보 저장 시 결제 방법은 필수값이다")
+    @Test
+    void createPaymentWithInvalidPaymentType_throwException() {
+        // given
+        Order order = Mockito.mock(Order.class);
+        Mockito.when(order.getId()).thenReturn(1L);
+
+        // when & then
+        CoreException result = assertThrows(CoreException.class, () -> {
+            Payment payment = Payment.builder()
+                    .paymentId("1234-123-4242")
+                    .amount(Money.of(30000))
+                    .order(order)
+                    .paymentType(null)
+                    .build();
+        });
+
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(result.getCustomMessage()).isEqualTo("결제 방식은 필수값입니다");
+    }
+
+    @DisplayName("결제 방법이 카드인 경우 카드사 정보는 필수값이다")
+    @Test
+    void createPaymentWithInvalidCardType_throwException() {
+        // given
+        Order order = Mockito.mock(Order.class);
+        Mockito.when(order.getId()).thenReturn(1L);
+
+        // when & then
+        CoreException result = assertThrows(CoreException.class, () -> {
+            Payment payment = Payment.builder()
+                    .paymentId("1234-123-4242")
+                    .amount(Money.of(30000))
+                    .order(order)
+                    .paymentType(PaymentType.CARD)
+                    .cardType(null)
+                    .cardNo("1234-1234-1234-1234")
+                    .build();
+        });
+
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(result.getCustomMessage()).isEqualTo("카드사 정보는 필수값입니다");
+    }
+
+    @DisplayName("결제 방법이 카드인 경우 카드 번호는 필수값이다")
+    @Test
+    void createPaymentWithInvalidCardNo_throwException() {
+        // given
+        Order order = Mockito.mock(Order.class);
+        Mockito.when(order.getId()).thenReturn(1L);
+
+        // when & then
+        CoreException result = assertThrows(CoreException.class, () -> {
+            Payment payment = Payment.builder()
+                    .paymentId("1234-123-4242")
+                    .amount(Money.of(30000))
+                    .order(order)
+                    .paymentType(PaymentType.CARD)
+                    .cardType(CardType.HYUNDAI)
+                    .cardNo(null)
+                    .build();
+        });
+
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(result.getCustomMessage()).isEqualTo("카드 번호는 필수값입니다");
+    }
+
+    @DisplayName("결제 방법이 카드인 경우 카드 번호가 빈 문자열이면 예외가 발생한다")
+    @Test
+    void createPaymentWithBlankCardNo_throwException() {
+        // given
+        Order order = Mockito.mock(Order.class);
+        Mockito.when(order.getId()).thenReturn(1L);
+
+        // when & then
+        CoreException result = assertThrows(CoreException.class, () -> {
+            Payment payment = Payment.builder()
+                    .paymentId("1234-123-4242")
+                    .amount(Money.of(30000))
+                    .order(order)
+                    .paymentType(PaymentType.CARD)
+                    .cardType(CardType.HYUNDAI)
+                    .cardNo("")
+                    .build();
+        });
+
+        assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(result.getCustomMessage()).isEqualTo("카드 번호는 필수값입니다");
+    }
+
+    @DisplayName("결제가 완료되면 결재 상태값이 성공으로 바뀐다")
+    @Test
+    void whenPaymentComplete_paymentStatusIsSuccess(){
+        // given
+        Payment payment = Payment.builder()
+                .paymentId("1234-123-4242")
+                .amount(Money.of(30000))
+                .order(Mockito.mock(Order.class))
+                .paymentType(PaymentType.CARD)
+                .cardType(CardType.HYUNDAI)
+                .cardNo("1234-1234-1234-1234")
+                .build();
+
+        // 결제 처리 시작 (PG 요청 후)
+        payment.startProcessing("test-pg-transaction-123");
+
+        // when
+        payment.completePayment();
+
+        //then
+        assertThat(payment.getCompletedAt()).isNotNull();
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+        assertThat(payment.getPgTransactionId()).isEqualTo("test-pg-transaction-123");
+    }
+
+    @DisplayName("포인트 결제는 카드 정보 없이 생성 가능하다")
+    @Test
+    void createPaymentWithPointType_success() {
+        // given
+        Order order = Mockito.mock(Order.class);
+        Mockito.when(order.getId()).thenReturn(1L);
+
+        // when
+        Payment payment = Payment.builder()
+                .paymentId("1234-123-4242")
+                .amount(Money.of(30000))
+                .order(order)
+                .paymentType(PaymentType.POINT)
+                .build();
+
+        // then
+        assertThat(payment.getPaymentType()).isEqualTo(PaymentType.POINT);
+        assertThat(payment.getCardType()).isNull();
+        assertThat(payment.getCardNo()).isNull();
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/payment/FeignPaymentGatewayE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/payment/FeignPaymentGatewayE2ETest.java
@@ -1,0 +1,236 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.Money;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentResult;
+import com.loopers.domain.payment.PaymentType;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import com.loopers.infrastructure.brand.BrandJpaRepository;
+import com.loopers.infrastructure.order.OrderJpaRepository;
+import com.loopers.infrastructure.product.ProductJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * FeignPaymentGateway E2E 테스트
+ * 실제 PG simulator와 통신하며 Circuit Breaker, Fallback 동작을 검증
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+        "external.pg-simulator.url=http://localhost:8082"
+})
+class FeignPaymentGatewayE2ETest {
+
+    private static final String TEST_USER_ID = "user123";
+    private static final String TEST_CALLBACK_URL = "http://localhost:8080/api/v1/payments/callback";
+
+    @Autowired
+    private FeignPaymentGateway paymentGateway;
+
+    @Autowired
+    private CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private BrandJpaRepository brandJpaRepository;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+
+    private User testUser;
+    private Order testOrder;
+
+    @BeforeEach
+    void setUp() {
+        // Circuit Breaker 초기화
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("paymentGateway");
+        circuitBreaker.reset();
+
+        // 테스트 데이터 생성
+        testUser = createTestUser();
+        testOrder = createTestOrder();
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("정상 결제 요청 시 Payment Result를 반환한다")
+    @Test
+    void shouldProcessPaymentSuccessfully() {
+        // given
+        Payment payment = createTestPayment();
+
+        // when
+        PaymentResult result = paymentGateway.processPayment(
+                TEST_USER_ID,
+                payment,
+                TEST_CALLBACK_URL
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.transactionId()).isNotNull();
+        assertThat(result.status()).isEqualTo("PENDING");
+        assertThat(result.message()).contains("결제 요청이 접수되었습니다");
+    }
+
+    @DisplayName("Circuit Breaker가 OPEN 상태일 때 fallback이 호출되어 FAIL 상태를 반환한다")
+    @Test
+    void shouldCallFallbackWhenCircuitIsOpen() {
+        // given
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("paymentGateway");
+        circuitBreaker.transitionToOpenState(); // Circuit을 강제로 OPEN 상태로 전환
+
+        Payment payment = createTestPayment();
+
+        // when
+        PaymentResult result = paymentGateway.processPayment(TEST_USER_ID, payment, TEST_CALLBACK_URL);
+
+        // then
+        // Fallback이 호출되어 FAIL 상태 반환
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo("FAIL");
+        assertThat(result.message()).contains("결제 시스템 장애");
+        assertThat(result.transactionId()).isNull();
+
+        // Circuit이 OPEN 상태인지 확인
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+    }
+
+    @DisplayName("PG 장애 시 연속 실패하면 fallback이 호출되어 FAIL 상태를 반환한다")
+    @Test
+    void shouldCallFallbackOnConsecutivePgFailures() {
+        // given
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("paymentGateway");
+        Payment payment = createTestPayment();
+
+        // Circuit Breaker 초기 상태 확인
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+
+        // when: PG simulator가 다운되어 연속 실패
+        // PG simulator가 없으므로 모든 호출이 실패하고 fallback이 호출됨
+        int failureCount = 0;
+        for (int i = 0; i < 5; i++) {
+            PaymentResult result = paymentGateway.processPayment(TEST_USER_ID, payment, TEST_CALLBACK_URL);
+
+            // fallback이 호출되어 FAIL 상태 반환
+            if ("FAIL".equals(result.status())) {
+                failureCount++;
+                assertThat(result.message()).contains("결제 시스템 장애");
+                assertThat(result.transactionId()).isNull();
+            }
+        }
+
+        // then
+
+        // 추가 호출도 fallback이 정상적으로 작동하는지 확인
+        PaymentResult result = paymentGateway.processPayment(TEST_USER_ID, payment, TEST_CALLBACK_URL);
+        assertThat(result.status()).isEqualTo("FAIL");
+        assertThat(result.message()).contains("결제 시스템 장애");
+    }
+
+    @DisplayName("Feign Client 타임아웃 설정이 적용되어 2초 내에 연결되지 않으면 fallback이 호출된다")
+    @Test
+    void shouldTimeoutWhenConnectionFails() {
+        // given
+        Payment payment = createTestPayment();
+        long startTime = System.currentTimeMillis();
+
+        // when
+        // PG simulator가 없으므로 Connection Timeout (1초) 발생 → fallback 호출
+        PaymentResult result = paymentGateway.processPayment(TEST_USER_ID, payment, TEST_CALLBACK_URL);
+
+        // then
+        // fallback이 호출되어 FAIL 상태 반환
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo("FAIL");
+        assertThat(result.message()).contains("결제 시스템 장애");
+
+        // 타임아웃 설정(1초)이 적용되었는지 확인
+        long elapsedTime = System.currentTimeMillis() - startTime;
+        assertThat(elapsedTime)
+                .describedAs("Connection timeout (2초)이 적용되어 3초 이내에 fallback이 호출되어야 함")
+                .isLessThan(2000);
+    }
+
+    /**
+     * 테스트용 User 생성
+     */
+    private User createTestUser() {
+        User user = User.createUser(
+                TEST_USER_ID,
+                "test@example.com",
+                "1990-01-01",
+                Gender.MALE
+        );
+        return userJpaRepository.save(user);
+    }
+
+    /**
+     * 테스트용 Order 생성
+     */
+    private Order createTestOrder() {
+        Brand brand = Brand.createBrand("Test Brand");
+        Brand savedBrand = brandJpaRepository.save(brand);
+
+        Product product = Product.createProduct(
+                "TEST-001",
+                "Test Product",
+                Money.of(BigDecimal.valueOf(10000)),
+                100,
+                savedBrand
+        );
+        Product savedProduct = productJpaRepository.save(product);
+
+        Map<Product, Integer> productQuantities = new HashMap<>();
+        productQuantities.put(savedProduct, 1);
+
+        Order order = Order.createOrder(testUser, productQuantities);
+        order.updateStatus(OrderStatus.INIT);
+        return orderJpaRepository.save(order);
+    }
+
+    /**
+     * 테스트용 Payment 생성
+     */
+    private Payment createTestPayment() {
+        return Payment.createPaymentForCard(
+                testOrder,
+                Money.of(BigDecimal.valueOf(10000)),
+                PaymentType.CARD,
+                CardType.SAMSUNG,
+                "1234-5678-9012-3456"
+        );
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/payment/FeignPaymentGatewayE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/payment/FeignPaymentGatewayE2ETest.java
@@ -168,7 +168,7 @@ class FeignPaymentGatewayE2ETest {
         long startTime = System.currentTimeMillis();
 
         // when
-        // PG simulator가 없으므로 Connection Timeout (1초) 발생 → fallback 호출
+        // PG simulator가 없으므로 Connection Timeout 발생 → fallback 호출
         PaymentResult result = paymentGateway.processPayment(TEST_USER_ID, payment, TEST_CALLBACK_URL);
 
         // then
@@ -177,11 +177,10 @@ class FeignPaymentGatewayE2ETest {
         assertThat(result.status()).isEqualTo("FAIL");
         assertThat(result.message()).contains("결제 시스템 장애");
 
-        // 타임아웃 설정(1초)이 적용되었는지 확인
+        // 타임아웃 설정이 적용되었는지 확인
         long elapsedTime = System.currentTimeMillis() - startTime;
         assertThat(elapsedTime)
-                .describedAs("Connection timeout (2초)이 적용되어 3초 이내에 fallback이 호출되어야 함")
-                .isLessThan(2000);
+                .isLessThan(3000); // connect timeout + read timeout 고려
     }
 
     /**

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/payment/FeignPaymentGatewayTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/payment/FeignPaymentGatewayTest.java
@@ -1,0 +1,124 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.Money;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentType;
+import com.loopers.infrastructure.external.feign.PaymentClient;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * FeignPaymentGateway 단위 테스트
+ * Circuit Breaker 동작을 검증하는 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+class FeignPaymentGatewayTest {
+
+    private static final String TEST_USER_ID = "user123";
+    private static final String TEST_CALLBACK_URL = "http://localhost:8080/api/v1/payments/callback";
+    private static final BigDecimal TEST_AMOUNT = BigDecimal.valueOf(10000);
+    private static final String CIRCUIT_BREAKER_NAME = "paymentGateway";
+
+    // Circuit Breaker 설정 상수
+    private static final int SLIDING_WINDOW_SIZE = 10;
+    private static final int MINIMUM_NUMBER_OF_CALLS = 5;
+    private static final float FAILURE_RATE_THRESHOLD = 50f;
+    private static final int WAIT_DURATION_SECONDS = 10;
+    private static final int PERMITTED_CALLS_IN_HALF_OPEN = 2;
+
+    private FeignPaymentGateway paymentGateway;
+    private CircuitBreaker circuitBreaker;
+
+    @Mock
+    private PaymentClient paymentClient;
+
+    @BeforeEach
+    void setUp() {
+        circuitBreaker = createCircuitBreaker();
+        paymentGateway = new FeignPaymentGateway(paymentClient);
+    }
+
+    @DisplayName("연속 실패 시 Circuit Breaker가 OPEN 상태로 전환된다")
+    @Test
+    void shouldOpenCircuitBreakerAfterConsecutiveFailures() {
+        // given
+        given(paymentClient.payment(any()))
+                .willThrow(new RuntimeException("Payment service unavailable"));
+
+        // when
+        int failureCount = executePaymentsAndCountFailures(MINIMUM_NUMBER_OF_CALLS);
+
+        // then
+        assertThat(failureCount).isEqualTo(MINIMUM_NUMBER_OF_CALLS);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(MINIMUM_NUMBER_OF_CALLS);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(MINIMUM_NUMBER_OF_CALLS);
+        assertThat(circuitBreaker.getMetrics().getFailureRate()).isEqualTo(100.0f);
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+    }
+
+    /**
+     * Circuit Breaker 설정 생성
+     */
+    private CircuitBreaker createCircuitBreaker() {
+        CircuitBreakerConfig config = CircuitBreakerConfig.custom()
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(SLIDING_WINDOW_SIZE)
+                .minimumNumberOfCalls(MINIMUM_NUMBER_OF_CALLS)
+                .failureRateThreshold(FAILURE_RATE_THRESHOLD)
+                .waitDurationInOpenState(Duration.ofSeconds(WAIT_DURATION_SECONDS))
+                .permittedNumberOfCallsInHalfOpenState(PERMITTED_CALLS_IN_HALF_OPEN)
+                .build();
+
+        return CircuitBreaker.of(CIRCUIT_BREAKER_NAME, config);
+    }
+
+    /**
+     * 결제 요청을 여러 번 시도하고 실패 횟수를 반환
+     */
+    private int executePaymentsAndCountFailures(int attempts) {
+        int failureCount = 0;
+
+        for (int i = 0; i < attempts; i++) {
+            try {
+                circuitBreaker.executeSupplier(() ->
+                        paymentGateway.processPayment(
+                                TEST_USER_ID,
+                                createTestPayment(),
+                                TEST_CALLBACK_URL)
+                );
+            } catch (Exception e) {
+                failureCount++;
+            }
+        }
+
+        return failureCount;
+    }
+
+    /**
+     * 테스트용 Payment 객체 생성
+     */
+    private Payment createTestPayment() {
+        return Payment.createPaymentForCard(
+                new Order(),
+                Money.of(TEST_AMOUNT),
+                PaymentType.CARD,
+                CardType.SAMSUNG,
+                "1234-5678-9012-3456"
+        );
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckSchedulerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckSchedulerTest.java
@@ -28,7 +28,7 @@ class PaymentStatusCheckSchedulerTest {
     private PaymentRepository paymentRepository;
 
     @Mock
-    private PaymentGateway paymentGateway;
+    private PaymentStatusCheckService paymentStatusCheckService;
 
     @InjectMocks
     private PaymentStatusCheckScheduler scheduler;
@@ -60,72 +60,28 @@ class PaymentStatusCheckSchedulerTest {
 
         // then
         verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
-        verify(paymentGateway, never()).checkPaymentStatus(anyString());
-        verify(paymentRepository, never()).save(any(Payment.class));
+        verify(paymentStatusCheckService, never()).checkPaymentStatus(anyString());
     }
 
     @Test
-    @DisplayName("PROCESSING 상태인 결제가 있으면 상태를 확인하고 SUCCESS로 업데이트한다")
-    void checkProcessingPayments_UpdateToSuccess() {
+    @DisplayName("PROCESSING 상태인 결제가 있으면 PaymentStatusCheckService를 호출한다")
+    void checkProcessingPayments_CallsService() {
         // given
         List<Payment> processingPayments = Collections.singletonList(processingPayment);
 
         given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
                 .willReturn(processingPayments);
-        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
-                .willReturn(new PaymentResult("test-pg-transaction-id", "SUCCESS", "결제 완료"));
 
         // when
         scheduler.checkProcessingPayments();
 
         // then
         verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
-        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
-        verify(paymentRepository).save(processingPayment);
+        verify(paymentStatusCheckService).checkPaymentStatus(processingPayment.getPaymentId());
     }
 
     @Test
-    @DisplayName("PROCESSING 상태인 결제가 있으면 상태를 확인하고 FAILED로 업데이트한다")
-    void checkProcessingPayments_UpdateToFailed() {
-        // given
-        List<Payment> processingPayments = Collections.singletonList(processingPayment);
-
-        given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
-                .willReturn(processingPayments);
-        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
-                .willReturn(new PaymentResult("test-pg-transaction-id", "FAILED", "결제 실패"));
-
-        // when
-        scheduler.checkProcessingPayments();
-
-        // then
-        verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
-        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
-        verify(paymentRepository).save(processingPayment);
-    }
-
-    @Test
-    @DisplayName("PROCESSING 상태가 유지되면 확인 횟수만 증가한다")
-    void checkProcessingPayments_StillProcessing() {
-        // given
-        List<Payment> processingPayments = Collections.singletonList(processingPayment);
-
-        given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
-                .willReturn(processingPayments);
-        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
-                .willReturn(new PaymentResult("test-pg-transaction-id", "PROCESSING", "결제 처리 중"));
-
-        // when
-        scheduler.checkProcessingPayments();
-
-        // then
-        verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
-        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
-        verify(paymentRepository).save(processingPayment);
-    }
-
-    @Test
-    @DisplayName("여러 개의 PROCESSING 결제를 순차적으로 확인한다")
+    @DisplayName("여러 개의 PROCESSING 결제를 순차적으로 Service에 위임한다")
     void checkProcessingPayments_MultiplePayments() {
         // given
         Payment payment1 = Payment.createPaymentForCard(
@@ -150,38 +106,13 @@ class PaymentStatusCheckSchedulerTest {
 
         given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
                 .willReturn(processingPayments);
-        given(paymentGateway.checkPaymentStatus("pg-tx-1"))
-                .willReturn(new PaymentResult("pg-tx-1", "SUCCESS", "결제 완료"));
-        given(paymentGateway.checkPaymentStatus("pg-tx-2"))
-                .willReturn(new PaymentResult("pg-tx-2", "FAILED", "결제 실패"));
 
         // when
         scheduler.checkProcessingPayments();
 
         // then
         verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
-        verify(paymentGateway).checkPaymentStatus("pg-tx-1");
-        verify(paymentGateway).checkPaymentStatus("pg-tx-2");
-        verify(paymentRepository, times(2)).save(any(Payment.class));
-    }
-
-    @Test
-    @DisplayName("결제 상태 확인 중 예외가 발생해도 확인 횟수는 증가한다")
-    void checkProcessingPayments_ExceptionHandling() {
-        // given
-        List<Payment> processingPayments = Collections.singletonList(processingPayment);
-
-        given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
-                .willReturn(processingPayments);
-        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
-                .willThrow(new RuntimeException("PG 시스템 장애"));
-
-        // when
-        scheduler.checkProcessingPayments();
-
-        // then
-        verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
-        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
-        verify(paymentRepository).save(processingPayment);
+        verify(paymentStatusCheckService).checkPaymentStatus(payment1.getPaymentId());
+        verify(paymentStatusCheckService).checkPaymentStatus(payment2.getPaymentId());
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckSchedulerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckSchedulerTest.java
@@ -1,0 +1,187 @@
+package com.loopers.infrastructure.scheduler;
+
+import com.loopers.domain.Money;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.payment.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentStatusCheckSchedulerTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @InjectMocks
+    private PaymentStatusCheckScheduler scheduler;
+
+    private Payment processingPayment;
+
+    @BeforeEach
+    void setUp() {
+        // PROCESSING 상태의 결제 생성
+        processingPayment = Payment.createPaymentForCard(
+                mock(Order.class),
+                Money.of(10000L),
+                PaymentType.CARD,
+                CardType.SAMSUNG,
+                "1234567890123456"
+        );
+        processingPayment.startProcessing("test-pg-transaction-id");
+    }
+
+    @Test
+    @DisplayName("PROCESSING 상태인 결제가 없으면 아무 작업도 수행하지 않는다")
+    void checkProcessingPayments_NoPayments() {
+        // given
+        given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
+                .willReturn(Collections.emptyList());
+
+        // when
+        scheduler.checkProcessingPayments();
+
+        // then
+        verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
+        verify(paymentGateway, never()).checkPaymentStatus(anyString());
+        verify(paymentRepository, never()).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("PROCESSING 상태인 결제가 있으면 상태를 확인하고 SUCCESS로 업데이트한다")
+    void checkProcessingPayments_UpdateToSuccess() {
+        // given
+        List<Payment> processingPayments = Collections.singletonList(processingPayment);
+
+        given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
+                .willReturn(processingPayments);
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willReturn(new PaymentResult("test-pg-transaction-id", "SUCCESS", "결제 완료"));
+
+        // when
+        scheduler.checkProcessingPayments();
+
+        // then
+        verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        verify(paymentRepository).save(processingPayment);
+    }
+
+    @Test
+    @DisplayName("PROCESSING 상태인 결제가 있으면 상태를 확인하고 FAILED로 업데이트한다")
+    void checkProcessingPayments_UpdateToFailed() {
+        // given
+        List<Payment> processingPayments = Collections.singletonList(processingPayment);
+
+        given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
+                .willReturn(processingPayments);
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willReturn(new PaymentResult("test-pg-transaction-id", "FAILED", "결제 실패"));
+
+        // when
+        scheduler.checkProcessingPayments();
+
+        // then
+        verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        verify(paymentRepository).save(processingPayment);
+    }
+
+    @Test
+    @DisplayName("PROCESSING 상태가 유지되면 확인 횟수만 증가한다")
+    void checkProcessingPayments_StillProcessing() {
+        // given
+        List<Payment> processingPayments = Collections.singletonList(processingPayment);
+
+        given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
+                .willReturn(processingPayments);
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willReturn(new PaymentResult("test-pg-transaction-id", "PROCESSING", "결제 처리 중"));
+
+        // when
+        scheduler.checkProcessingPayments();
+
+        // then
+        verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        verify(paymentRepository).save(processingPayment);
+    }
+
+    @Test
+    @DisplayName("여러 개의 PROCESSING 결제를 순차적으로 확인한다")
+    void checkProcessingPayments_MultiplePayments() {
+        // given
+        Payment payment1 = Payment.createPaymentForCard(
+                mock(Order.class),
+                Money.of(10000L),
+                PaymentType.CARD,
+                CardType.SAMSUNG,
+                "1234567890123456"
+        );
+        payment1.startProcessing("pg-tx-1");
+
+        Payment payment2 = Payment.createPaymentForCard(
+                mock(Order.class),
+                Money.of(20000L),
+                PaymentType.CARD,
+                CardType.KB,
+                "9876543210987654"
+        );
+        payment2.startProcessing("pg-tx-2");
+
+        List<Payment> processingPayments = Arrays.asList(payment1, payment2);
+
+        given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
+                .willReturn(processingPayments);
+        given(paymentGateway.checkPaymentStatus("pg-tx-1"))
+                .willReturn(new PaymentResult("pg-tx-1", "SUCCESS", "결제 완료"));
+        given(paymentGateway.checkPaymentStatus("pg-tx-2"))
+                .willReturn(new PaymentResult("pg-tx-2", "FAILED", "결제 실패"));
+
+        // when
+        scheduler.checkProcessingPayments();
+
+        // then
+        verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
+        verify(paymentGateway).checkPaymentStatus("pg-tx-1");
+        verify(paymentGateway).checkPaymentStatus("pg-tx-2");
+        verify(paymentRepository, times(2)).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("결제 상태 확인 중 예외가 발생해도 확인 횟수는 증가한다")
+    void checkProcessingPayments_ExceptionHandling() {
+        // given
+        List<Payment> processingPayments = Collections.singletonList(processingPayment);
+
+        given(paymentRepository.findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt()))
+                .willReturn(processingPayments);
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willThrow(new RuntimeException("PG 시스템 장애"));
+
+        // when
+        scheduler.checkProcessingPayments();
+
+        // then
+        verify(paymentRepository).findProcessingPaymentsForStatusCheck(any(LocalDateTime.class), anyInt());
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        verify(paymentRepository).save(processingPayment);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/scheduler/PaymentStatusCheckServiceTest.java
@@ -1,0 +1,205 @@
+package com.loopers.infrastructure.scheduler;
+
+import com.loopers.domain.Money;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.payment.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentStatusCheckServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @InjectMocks
+    private PaymentStatusCheckService paymentStatusCheckService;
+
+    private Payment processingPayment;
+    private String testPaymentId;
+
+    @BeforeEach
+    void setUp() {
+        // PROCESSING 상태의 결제 생성
+        processingPayment = Payment.createPaymentForCard(
+                mock(Order.class),
+                Money.of(10000L),
+                PaymentType.CARD,
+                CardType.SAMSUNG,
+                "1234567890123456"
+        );
+        processingPayment.startProcessing("test-pg-transaction-id");
+        testPaymentId = processingPayment.getPaymentId();
+    }
+
+    @Test
+    @DisplayName("결제를 찾을 수 없으면 예외를 발생시킨다")
+    void checkPaymentStatus_PaymentNotFound() {
+        // given
+        given(paymentRepository.findByPaymentId(testPaymentId))
+                .willReturn(Optional.empty());
+
+        // when
+        paymentStatusCheckService.checkPaymentStatus(testPaymentId);
+
+        // then
+        // 예외 발생 시 예외 처리 블록에서도 재조회 시도 (총 2번 호출)
+        verify(paymentRepository, times(2)).findByPaymentId(testPaymentId);
+        verify(paymentGateway, never()).checkPaymentStatus(anyString());
+        verify(paymentRepository, never()).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("PG 응답이 SUCCESS면 결제를 완료 처리한다")
+    void checkPaymentStatus_UpdateToSuccess() {
+        // given
+        given(paymentRepository.findByPaymentId(testPaymentId))
+                .willReturn(Optional.of(processingPayment));
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willReturn(new PaymentResult("test-pg-transaction-id", "SUCCESS", "결제 완료"));
+
+        // when
+        paymentStatusCheckService.checkPaymentStatus(testPaymentId);
+
+        // then
+        assertThat(processingPayment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+        assertThat(processingPayment.getStatusCheckCount()).isEqualTo(1);
+        verify(paymentRepository).findByPaymentId(testPaymentId);
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        verify(paymentRepository).save(processingPayment);
+    }
+
+    @Test
+    @DisplayName("PG 응답이 FAILED면 결제를 실패 처리한다")
+    void checkPaymentStatus_UpdateToFailed() {
+        // given
+        given(paymentRepository.findByPaymentId(testPaymentId))
+                .willReturn(Optional.of(processingPayment));
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willReturn(new PaymentResult("test-pg-transaction-id", "FAILED", "결제 실패"));
+
+        // when
+        paymentStatusCheckService.checkPaymentStatus(testPaymentId);
+
+        // then
+        assertThat(processingPayment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+        assertThat(processingPayment.getStatusCheckCount()).isEqualTo(1);
+        verify(paymentRepository).findByPaymentId(testPaymentId);
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        verify(paymentRepository).save(processingPayment);
+    }
+
+    @Test
+    @DisplayName("PG 응답이 FAIL이면 결제를 실패 처리한다")
+    void checkPaymentStatus_UpdateToFail() {
+        // given
+        given(paymentRepository.findByPaymentId(testPaymentId))
+                .willReturn(Optional.of(processingPayment));
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willReturn(new PaymentResult("test-pg-transaction-id", "FAIL", "카드 승인 거부"));
+
+        // when
+        paymentStatusCheckService.checkPaymentStatus(testPaymentId);
+
+        // then
+        assertThat(processingPayment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+        assertThat(processingPayment.getStatusCheckCount()).isEqualTo(1);
+        verify(paymentRepository).findByPaymentId(testPaymentId);
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        verify(paymentRepository).save(processingPayment);
+    }
+
+    @Test
+    @DisplayName("PG 응답이 PROCESSING이면 상태를 유지하고 확인 횟수만 증가한다")
+    void checkPaymentStatus_StillProcessing() {
+        // given
+        given(paymentRepository.findByPaymentId(testPaymentId))
+                .willReturn(Optional.of(processingPayment));
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willReturn(new PaymentResult("test-pg-transaction-id", "PROCESSING", "결제 처리 중"));
+
+        // when
+        paymentStatusCheckService.checkPaymentStatus(testPaymentId);
+
+        // then
+        assertThat(processingPayment.getStatus()).isEqualTo(PaymentStatus.PROCESSING);
+        assertThat(processingPayment.getStatusCheckCount()).isEqualTo(1);
+        verify(paymentRepository).findByPaymentId(testPaymentId);
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        verify(paymentRepository).save(processingPayment);
+    }
+
+    @Test
+    @DisplayName("PG 상태 확인 중 예외가 발생해도 확인 횟수는 증가하고 저장한다")
+    void checkPaymentStatus_ExceptionDuringPGCheck() {
+        // given
+        given(paymentRepository.findByPaymentId(testPaymentId))
+                .willReturn(Optional.of(processingPayment))
+                .willReturn(Optional.of(processingPayment)); // 예외 블록에서 재조회
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willThrow(new RuntimeException("PG 시스템 장애"));
+
+        // when
+        paymentStatusCheckService.checkPaymentStatus(testPaymentId);
+
+        // then
+        assertThat(processingPayment.getStatus()).isEqualTo(PaymentStatus.PROCESSING); // 상태 유지
+        assertThat(processingPayment.getStatusCheckCount()).isEqualTo(1); // 확인 횟수 증가
+        verify(paymentRepository, times(2)).findByPaymentId(testPaymentId); // 초기 조회 + 예외 블록 재조회
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        verify(paymentRepository, times(1)).save(processingPayment); // 에러 처리 블록에서 저장
+    }
+
+    @Test
+    @DisplayName("확인 횟수는 PG 호출 후 항상 증가한다")
+    void checkPaymentStatus_IncrementCheckCount() {
+        // given
+        given(paymentRepository.findByPaymentId(testPaymentId))
+                .willReturn(Optional.of(processingPayment));
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willReturn(new PaymentResult("test-pg-transaction-id", "SUCCESS", "결제 완료"));
+
+        int initialCheckCount = processingPayment.getStatusCheckCount();
+
+        // when
+        paymentStatusCheckService.checkPaymentStatus(testPaymentId);
+
+        // then
+        assertThat(processingPayment.getStatusCheckCount()).isEqualTo(initialCheckCount + 1);
+        verify(paymentRepository).save(processingPayment);
+    }
+
+    @Test
+    @DisplayName("예외 발생 시 확인 횟수 증가 중 또 예외가 발생하면 로그만 남긴다")
+    void checkPaymentStatus_ExceptionDuringIncrementCheckCount() {
+        // given
+        given(paymentRepository.findByPaymentId(testPaymentId))
+                .willReturn(Optional.of(processingPayment))
+                .willThrow(new RuntimeException("DB 연결 실패")); // 재조회 시 예외
+        given(paymentGateway.checkPaymentStatus("test-pg-transaction-id"))
+                .willThrow(new RuntimeException("PG 시스템 장애"));
+
+        // when
+        paymentStatusCheckService.checkPaymentStatus(testPaymentId);
+
+        // then
+        verify(paymentRepository, times(2)).findByPaymentId(testPaymentId);
+        verify(paymentGateway).checkPaymentStatus("test-pg-transaction-id");
+        // 예외 처리 블록 내부에서도 예외 발생하면 저장 안 됨 (로그만 남김)
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderV1ControllerE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderV1ControllerE2ETest.java
@@ -6,6 +6,7 @@ import com.loopers.domain.coupon.Coupon;
 import com.loopers.domain.coupon.DiscountType;
 import com.loopers.domain.issuedcoupon.IssuedCoupon;
 import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.PaymentType;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.User;
@@ -109,7 +110,10 @@ class OrderV1ControllerE2ETest {
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
                     savedUser.getUserId(),
                     items,
-                    savedCoupon.getId()
+                    savedCoupon.getId(),
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             ResponseEntity<ApiResponse<OrderV1Dto.OrderResponse>> response = testRestTemplate.exchange(
@@ -124,7 +128,7 @@ class OrderV1ControllerE2ETest {
             assertThat(response.getBody()).isNotNull();
             assertThat(response.getBody().data()).isNotNull();
             assertThat(response.getBody().data().id()).isNotNull();
-            assertThat(response.getBody().data().status()).isEqualTo(OrderStatus.INIT);
+            assertThat(response.getBody().data().status()).isEqualTo(OrderStatus.COMPLETED);
             assertThat(response.getBody().data().totalPrice()).isEqualByComparingTo(BigDecimal.valueOf(18000)); // 10,000 * 2 * 0.9 (10% 할인)
         }
 
@@ -149,7 +153,7 @@ class OrderV1ControllerE2ETest {
                     new OrderV1Dto.OrderRequest.OrderItemRequest(savedProduct.getId(), 2) // 20,000원
             );
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
-                    savedUser.getUserId(), items, null
+                    savedUser.getUserId(), items, null, PaymentType.POINT, null, null
             );
 
             // when
@@ -207,7 +211,12 @@ class OrderV1ControllerE2ETest {
                     new OrderV1Dto.OrderRequest.OrderItemRequest(savedProduct.getId(), 2) // 20,000원
             );
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
-                    savedUser.getUserId(), items, savedCoupon.getId()
+                    savedUser.getUserId(),
+                    items,
+                    savedCoupon.getId(),
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             // when - 동일한 쿠폰으로 동시에 2번 주문 시도
@@ -265,7 +274,11 @@ class OrderV1ControllerE2ETest {
 
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
                     "nonExistentUser", // 존재하지 않는 사용자
-                    items, null
+                    items,
+                    null,
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             ResponseEntity<ApiResponse<OrderV1Dto.OrderResponse>> response = testRestTemplate.exchange(
@@ -296,7 +309,11 @@ class OrderV1ControllerE2ETest {
 
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
                     savedUser.getUserId(),
-                    items, null
+                    items,
+                    null,
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             ResponseEntity<ApiResponse<OrderV1Dto.OrderResponse>> response = testRestTemplate.exchange(
@@ -343,7 +360,10 @@ class OrderV1ControllerE2ETest {
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
                     savedUser.getUserId(),
                     items,
-                    savedCoupon.getId()
+                    savedCoupon.getId(),
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             ResponseEntity<ApiResponse<OrderV1Dto.OrderResponse>> response = testRestTemplate.exchange(
@@ -390,7 +410,10 @@ class OrderV1ControllerE2ETest {
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
                     savedUser.getUserId(),
                     items,
-                    savedCoupon.getId()
+                    savedCoupon.getId(),
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             ResponseEntity<ApiResponse<OrderV1Dto.OrderResponse>> response = testRestTemplate.exchange(
@@ -428,6 +451,9 @@ class OrderV1ControllerE2ETest {
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
                     savedUser.getUserId(),
                     items,
+                    null,
+                    PaymentType.POINT,
+                    null,
                     null
             );
 
@@ -466,6 +492,9 @@ class OrderV1ControllerE2ETest {
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
                     savedUser.getUserId(),
                     items,
+                    null,
+                    PaymentType.POINT,
+                    null,
                     null
             );
 
@@ -493,8 +522,11 @@ class OrderV1ControllerE2ETest {
             // when
             OrderV1Dto.OrderRequest request = new OrderV1Dto.OrderRequest(
                     savedUser.getUserId(),
-                    List.of() // 빈 항목 리스트
-                    ,null
+                    List.of(), // 빈 항목 리스트
+                    null,
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             ResponseEntity<ApiResponse<OrderV1Dto.OrderResponse>> response = testRestTemplate.exchange(

--- a/apps/pg-simulator/README.md
+++ b/apps/pg-simulator/README.md
@@ -1,0 +1,42 @@
+## PG-Simulator (PaymentGateway)
+
+### Description
+Loopback BE 과정을 위해 PaymentGateway 를 시뮬레이션하는 App Module 입니다.
+`local` 프로필로 실행 권장하며, 커머스 서비스와의 동시 실행을 위해 서버 포트가 조정되어 있습니다.
+- server port : 8082
+- actuator port : 8083
+
+### Getting Started
+부트 서버를 아래 명령어 혹은 `intelliJ` 통해 실행해주세요.
+```shell
+./gradlew :apps:pg-simulator:bootRun
+```
+
+API 는 아래와 같이 주어지니, 커머스 서비스와 동시에 실행시킨 후 진행해주시면 됩니다.
+- 결제 요청 API
+- 결제 정보 확인 `by transactionKey`
+- 결제 정보 목록 조회 `by orderId`
+
+```http request
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135
+
+```

--- a/apps/pg-simulator/build.gradle.kts
+++ b/apps/pg-simulator/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    val kotlinVersion = "2.0.20"
+
+    id("org.jetbrains.kotlin.jvm") version(kotlinVersion)
+    id("org.jetbrains.kotlin.kapt") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.spring") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.jpa") version(kotlinVersion)
+}
+
+kotlin {
+    compilerOptions {
+        jvmToolchain(21)
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // kotlin
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+
+    // querydsl
+    kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
@@ -1,0 +1,24 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
+import java.util.TimeZone
+
+@ConfigurationPropertiesScan
+@EnableAsync
+@SpringBootApplication
+class PaymentGatewayApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<PaymentGatewayApplication>(*args)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
@@ -1,0 +1,14 @@
+package com.loopers.application.payment
+
+/**
+ * 결제 주문 정보
+ *
+ * 결제는 주문에 대한 다수 트랜잭션으로 구성됩니다.
+ *
+ * @property orderId 주문 정보
+ * @property transactions 주문에 엮인 트랜잭션 목록
+ */
+data class OrderInfo(
+    val orderId: String,
+    val transactions: List<TransactionInfo>,
+)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
@@ -1,0 +1,88 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import com.loopers.domain.payment.PaymentRelay
+import com.loopers.domain.payment.PaymentRepository
+import com.loopers.domain.payment.TransactionKeyGenerator
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PaymentApplicationService(
+    private val paymentRepository: PaymentRepository,
+    private val paymentEventPublisher: PaymentEventPublisher,
+    private val paymentRelay: PaymentRelay,
+    private val transactionKeyGenerator: TransactionKeyGenerator,
+) {
+    companion object {
+        private val RATE_LIMIT_EXCEEDED = (1..20)
+        private val RATE_INVALID_CARD = (21..30)
+    }
+
+    @Transactional
+    fun createTransaction(command: PaymentCommand.CreateTransaction): TransactionInfo {
+        command.validate()
+
+        val transactionKey = transactionKeyGenerator.generate()
+        val payment = paymentRepository.save(
+            Payment(
+                transactionKey = transactionKey,
+                userId = command.userId,
+                orderId = command.orderId,
+                cardType = command.cardType,
+                cardNo = command.cardNo,
+                amount = command.amount,
+                callbackUrl = command.callbackUrl,
+            ),
+        )
+
+        paymentEventPublisher.publish(PaymentEvent.PaymentCreated.from(payment = payment))
+
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun getTransactionDetailInfo(userInfo: UserInfo, transactionKey: String): TransactionInfo {
+        val payment = paymentRepository.findByTransactionKey(userId = userInfo.userId, transactionKey = transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun findTransactionsByOrderId(userInfo: UserInfo, orderId: String): OrderInfo {
+        val payments = paymentRepository.findByOrderId(userId = userInfo.userId, orderId = orderId)
+        if (payments.isEmpty()) {
+            throw CoreException(ErrorType.NOT_FOUND, "(orderId: $orderId) 에 해당하는 결제건이 존재하지 않습니다.")
+        }
+
+        return OrderInfo(
+            orderId = orderId,
+            transactions = payments.map { TransactionInfo.from(it) },
+        )
+    }
+
+    @Transactional
+    fun handle(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+
+        val rate = (1..100).random()
+        when (rate) {
+            in RATE_LIMIT_EXCEEDED -> payment.limitExceeded()
+            in RATE_INVALID_CARD -> payment.invalidCard()
+            else -> payment.approve()
+        }
+        paymentEventPublisher.publish(event = PaymentEvent.PaymentHandled.from(payment))
+    }
+
+    fun notifyTransactionResult(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        paymentRelay.notify(callbackUrl = payment.callbackUrl, transactionInfo = TransactionInfo.from(payment))
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
@@ -1,0 +1,22 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentCommand {
+    data class CreateTransaction(
+        val userId: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        fun validate() {
+            if (amount <= 0L) {
+                throw CoreException(ErrorType.BAD_REQUEST, "요청 금액은 0 보다 큰 정수여야 합니다.")
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
@@ -1,0 +1,39 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.TransactionStatus
+
+/**
+ * 트랜잭션 정보
+ *
+ * @property transactionKey 트랜잭션 KEY
+ * @property orderId 주문 ID
+ * @property cardType 카드 종류
+ * @property cardNo 카드 번호
+ * @property amount 금액
+ * @property status 처리 상태
+ * @property reason 처리 사유
+ */
+data class TransactionInfo(
+    val transactionKey: String,
+    val orderId: String,
+    val cardType: CardType,
+    val cardNo: String,
+    val amount: Long,
+    val status: TransactionStatus,
+    val reason: String?,
+) {
+    companion object {
+        fun from(payment: Payment): TransactionInfo =
+            TransactionInfo(
+                transactionKey = payment.transactionKey,
+                orderId = payment.orderId,
+                cardType = payment.cardType,
+                cardNo = payment.cardNo,
+                amount = payment.amount,
+                status = payment.status,
+                reason = payment.reason,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package com.loopers.config.web
+
+import com.loopers.interfaces.api.argumentresolver.UserInfoArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
+        resolvers.add(UserInfoArgumentResolver())
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
@@ -1,0 +1,87 @@
+package com.loopers.domain.payment
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "payments",
+    indexes = [
+        Index(name = "idx_user_transaction", columnList = "user_id, transaction_key"),
+        Index(name = "idx_user_order", columnList = "user_id, order_id"),
+        Index(name = "idx_unique_user_order_transaction", columnList = "user_id, order_id, transaction_key", unique = true),
+    ]
+)
+class Payment(
+    @Id
+    @Column(name = "transaction_key", nullable = false, unique = true)
+    val transactionKey: String,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: String,
+
+    @Column(name = "order_id", nullable = false)
+    val orderId: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "card_type", nullable = false)
+    val cardType: CardType,
+
+    @Column(name = "card_no", nullable = false)
+    val cardNo: String,
+
+    @Column(name = "amount", nullable = false)
+    val amount: Long,
+
+    @Column(name = "callback_url", nullable = false)
+    val callbackUrl: String,
+) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: TransactionStatus = TransactionStatus.PENDING
+        private set
+
+    @Column(name = "reason", nullable = true)
+    var reason: String? = null
+        private set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    fun approve() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제승인은 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.SUCCESS
+        reason = "정상 승인되었습니다."
+    }
+
+    fun invalidCard() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "잘못된 카드입니다. 다른 카드를 선택해주세요."
+    }
+
+    fun limitExceeded() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "한도초과 처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "한도초과입니다. 다른 카드를 선택해주세요."
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
@@ -1,0 +1,28 @@
+package com.loopers.domain.payment
+
+object PaymentEvent {
+    data class PaymentCreated(
+        val transactionKey: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentCreated = PaymentCreated(transactionKey = payment.transactionKey)
+        }
+    }
+
+    data class PaymentHandled(
+        val transactionKey: String,
+        val status: TransactionStatus,
+        val reason: String?,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentHandled =
+                PaymentHandled(
+                    transactionKey = payment.transactionKey,
+                    status = payment.status,
+                    reason = payment.reason,
+                    callbackUrl = payment.callbackUrl,
+                )
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment
+
+interface PaymentEventPublisher {
+    fun publish(event: PaymentEvent.PaymentCreated)
+    fun publish(event: PaymentEvent.PaymentHandled)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+import com.loopers.application.payment.TransactionInfo
+
+interface PaymentRelay {
+    fun notify(callbackUrl: String, transactionInfo: TransactionInfo)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment
+
+interface PaymentRepository {
+    fun save(payment: Payment): Payment
+    fun findByTransactionKey(transactionKey: String): Payment?
+    fun findByTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
@@ -1,0 +1,20 @@
+package com.loopers.domain.payment
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@Component
+class TransactionKeyGenerator {
+    companion object {
+        private const val KEY_TRANSACTION = "TR"
+        private val DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
+    }
+
+    fun generate(): String {
+        val now = LocalDateTime.now()
+        val uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 6)
+        return "${DATETIME_FORMATTER.format(now)}:$KEY_TRANSACTION:$uuid"
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.user
+
+/**
+ * user 정보
+ *
+ * @param userId 유저 식별자
+ */
+data class UserInfo(val userId: String)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentCoreEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : PaymentEventPublisher {
+    override fun publish(event: PaymentEvent.PaymentCreated) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    override fun publish(event: PaymentEvent.PaymentHandled) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.PaymentRelay
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class PaymentCoreRelay : PaymentRelay {
+    companion object {
+        private val logger = LoggerFactory.getLogger(PaymentCoreRelay::class.java)
+        private val restTemplate = RestTemplate()
+    }
+
+    override fun notify(callbackUrl: String, transactionInfo: TransactionInfo) {
+        runCatching {
+            restTemplate.postForEntity(callbackUrl, transactionInfo, Any::class.java)
+        }.onFailure { e -> logger.error("콜백 호출을 실패했습니다. {}", e.message, e) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
@@ -1,0 +1,32 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
+
+@Component
+class PaymentCoreRepository(
+    private val paymentJpaRepository: PaymentJpaRepository,
+) : PaymentRepository {
+    @Transactional
+    override fun save(payment: Payment): Payment {
+        return paymentJpaRepository.save(payment)
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(transactionKey: String): Payment? {
+        return paymentJpaRepository.findById(transactionKey).getOrNull()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(userId: String, transactionKey: String): Payment? {
+        return paymentJpaRepository.findByUserIdAndTransactionKey(userId, transactionKey)
+    }
+
+    override fun findByOrderId(userId: String, orderId: String): List<Payment> {
+        return paymentJpaRepository.findByUserIdAndOrderId(userId, orderId)
+            .sortedByDescending { it.updatedAt }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentJpaRepository : JpaRepository<Payment, String> {
+    fun findByUserIdAndTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByUserIdAndOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
@@ -1,0 +1,119 @@
+package com.loopers.interfaces.api
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.server.ServerWebInputException
+import org.springframework.web.servlet.resource.NoResourceFoundException
+import kotlin.collections.joinToString
+import kotlin.jvm.java
+import kotlin.text.isNotEmpty
+import kotlin.text.toRegex
+
+@RestControllerAdvice
+class ApiControllerAdvice {
+    private val log = LoggerFactory.getLogger(ApiControllerAdvice::class.java)
+
+    @ExceptionHandler
+    fun handle(e: CoreException): ResponseEntity<ApiResponse<*>> {
+        log.warn("CoreException : {}", e.customMessage ?: e.message, e)
+        return failureResponse(errorType = e.errorType, errorMessage = e.customMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<*>> {
+        val name = e.name
+        val type = e.requiredType?.simpleName ?: "unknown"
+        val value = e.value ?: "null"
+        val message = "요청 파라미터 '$name' (타입: $type)의 값 '$value'이(가) 잘못되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MissingServletRequestParameterException): ResponseEntity<ApiResponse<*>> {
+        val name = e.parameterName
+        val type = e.parameterType
+        val message = "필수 요청 파라미터 '$name' (타입: $type)가 누락되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<*>> {
+        val errorMessage = when (val rootCause = e.rootCause) {
+            is InvalidFormatException -> {
+                val fieldName = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+
+                val valueIndicationMessage = when {
+                    rootCause.targetType.isEnum -> {
+                        val enumClass = rootCause.targetType
+                        val enumValues = enumClass.enumConstants.joinToString(", ") { it.toString() }
+                        "사용 가능한 값 : [$enumValues]"
+                    }
+
+                    else -> ""
+                }
+
+                val expectedType = rootCause.targetType.simpleName
+                val value = rootCause.value
+
+                "필드 '$fieldName'의 값 '$value'이(가) 예상 타입($expectedType)과 일치하지 않습니다. $valueIndicationMessage"
+            }
+
+            is MismatchedInputException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필수 필드 '$fieldPath'이(가) 누락되었습니다."
+            }
+
+            is JsonMappingException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필드 '$fieldPath'에서 JSON 매핑 오류가 발생했습니다: ${rootCause.originalMessage}"
+            }
+
+            else -> "요청 본문을 처리하는 중 오류가 발생했습니다. JSON 메세지 규격을 확인해주세요."
+        }
+
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = errorMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: ServerWebInputException): ResponseEntity<ApiResponse<*>> {
+        fun extractMissingParameter(message: String): String {
+            val regex = "'(.+?)'".toRegex()
+            return regex.find(message)?.groupValues?.get(1) ?: ""
+        }
+
+        val missingParams = extractMissingParameter(e.reason ?: "")
+        return if (missingParams.isNotEmpty()) {
+            failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = "필수 요청 값 \'$missingParams\'가 누락되었습니다.")
+        } else {
+            failureResponse(errorType = ErrorType.BAD_REQUEST)
+        }
+    }
+
+    @ExceptionHandler
+    fun handleNotFound(e: NoResourceFoundException): ResponseEntity<ApiResponse<*>> {
+        return failureResponse(errorType = ErrorType.NOT_FOUND)
+    }
+
+    @ExceptionHandler
+    fun handle(e: Throwable): ResponseEntity<ApiResponse<*>> {
+        log.error("Exception : {}", e.message, e)
+        val errorType = ErrorType.INTERNAL_ERROR
+        return failureResponse(errorType = errorType)
+    }
+
+    private fun failureResponse(errorType: ErrorType, errorMessage: String? = null): ResponseEntity<ApiResponse<*>> =
+        ResponseEntity(
+            ApiResponse.fail(errorCode = errorType.code, errorMessage = errorMessage ?: errorType.message),
+            errorType.status,
+        )
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api
+
+data class ApiResponse<T>(
+    val meta: Metadata,
+    val data: T?,
+) {
+    data class Metadata(
+        val result: Result,
+        val errorCode: String?,
+        val message: String?,
+    ) {
+        enum class Result { SUCCESS, FAIL }
+
+        companion object {
+            fun success() = Metadata(Result.SUCCESS, null, null)
+
+            fun fail(errorCode: String, errorMessage: String) = Metadata(Result.FAIL, errorCode, errorMessage)
+        }
+    }
+
+    companion object {
+        fun success(): ApiResponse<Any> = ApiResponse(Metadata.success(), null)
+
+        fun <T> success(data: T? = null) = ApiResponse(Metadata.success(), data)
+
+        fun fail(errorCode: String, errorMessage: String): ApiResponse<Any?> =
+            ApiResponse(
+                meta = Metadata.fail(errorCode = errorCode, errorMessage = errorMessage),
+                data = null,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api.argumentresolver
+
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+class UserInfoArgumentResolver: HandlerMethodArgumentResolver {
+    companion object {
+        private const val KEY_USER_ID = "X-USER-ID"
+    }
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return UserInfo::class.java.isAssignableFrom(parameter.parameterType)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): UserInfo {
+        val userId = webRequest.getHeader(KEY_USER_ID)
+            ?: throw CoreException(ErrorType.BAD_REQUEST, "유저 ID 헤더는 필수입니다.")
+
+        return UserInfo(userId)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
@@ -1,0 +1,60 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/payments")
+class PaymentApi(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @PostMapping
+    fun request(
+        userInfo: UserInfo,
+        @RequestBody request: PaymentDto.PaymentRequest,
+    ): ApiResponse<PaymentDto.TransactionResponse> {
+        request.validate()
+
+        // 100ms ~ 500ms 지연
+        Thread.sleep((100..500L).random())
+
+        // 40% 확률로 요청 실패
+        if ((1..100).random() <= 40) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "현재 서버가 불안정합니다. 잠시 후 다시 시도해주세요.")
+        }
+
+        return paymentApplicationService.createTransaction(request.toCommand(userInfo.userId))
+            .let { PaymentDto.TransactionResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping("/{transactionKey}")
+    fun getTransaction(
+        userInfo: UserInfo,
+        @PathVariable("transactionKey") transactionKey: String,
+    ): ApiResponse<PaymentDto.TransactionDetailResponse> {
+        return paymentApplicationService.getTransactionDetailInfo(userInfo, transactionKey)
+            .let { PaymentDto.TransactionDetailResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping
+    fun getTransactionsByOrder(
+        userInfo: UserInfo,
+        @RequestParam("orderId", required = false) orderId: String,
+    ): ApiResponse<PaymentDto.OrderResponse> {
+        return paymentApplicationService.findTransactionsByOrderId(userInfo, orderId)
+            .let { PaymentDto.OrderResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
@@ -1,0 +1,136 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.OrderInfo
+import com.loopers.application.payment.PaymentCommand
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.TransactionStatus
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentDto {
+    data class PaymentRequest(
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            private val REGEX_CARD_NO = Regex("^\\d{4}-\\d{4}-\\d{4}-\\d{4}$")
+            private const val PREFIX_CALLBACK_URL = "http://localhost:8080"
+        }
+
+        fun validate() {
+            if (orderId.isBlank() || orderId.length < 6) {
+                throw CoreException(ErrorType.BAD_REQUEST, "주문 ID는 6자리 이상 문자열이어야 합니다.")
+            }
+            if (!REGEX_CARD_NO.matches(cardNo)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.")
+            }
+            if (amount <= 0) {
+                throw CoreException(ErrorType.BAD_REQUEST, "결제금액은 양의 정수여야 합니다.")
+            }
+            if (!callbackUrl.startsWith(PREFIX_CALLBACK_URL)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "콜백 URL 은 $PREFIX_CALLBACK_URL 로 시작해야 합니다.")
+            }
+        }
+
+        fun toCommand(userId: String): PaymentCommand.CreateTransaction =
+            PaymentCommand.CreateTransaction(
+                userId = userId,
+                orderId = orderId,
+                cardType = cardType.toCardType(),
+                cardNo = cardNo,
+                amount = amount,
+                callbackUrl = callbackUrl,
+            )
+    }
+
+    data class TransactionDetailResponse(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionDetailResponse =
+                TransactionDetailResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    orderId = transactionInfo.orderId,
+                    cardType = CardTypeDto.from(transactionInfo.cardType),
+                    cardNo = transactionInfo.cardNo,
+                    amount = transactionInfo.amount,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class TransactionResponse(
+        val transactionKey: String,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionResponse =
+                TransactionResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class OrderResponse(
+        val orderId: String,
+        val transactions: List<TransactionResponse>,
+    ) {
+        companion object {
+            fun from(orderInfo: OrderInfo): OrderResponse =
+                OrderResponse(
+                    orderId = orderInfo.orderId,
+                    transactions = orderInfo.transactions.map { TransactionResponse.from(it) },
+                )
+        }
+    }
+
+    enum class CardTypeDto {
+        SAMSUNG,
+        KB,
+        HYUNDAI,
+        ;
+
+        fun toCardType(): CardType = when (this) {
+            SAMSUNG -> CardType.SAMSUNG
+            KB -> CardType.KB
+            HYUNDAI -> CardType.HYUNDAI
+        }
+
+        companion object {
+            fun from(cardType: CardType) = when (cardType) {
+                CardType.SAMSUNG -> SAMSUNG
+                CardType.KB -> KB
+                CardType.HYUNDAI -> HYUNDAI
+            }
+        }
+    }
+
+    enum class TransactionStatusResponse {
+        PENDING,
+        SUCCESS,
+        FAILED,
+        ;
+
+        companion object {
+            fun from(transactionStatus: TransactionStatus) = when (transactionStatus) {
+                TransactionStatus.PENDING -> PENDING
+                TransactionStatus.SUCCESS -> SUCCESS
+                TransactionStatus.FAILED -> FAILED
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.event.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.domain.payment.PaymentEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class PaymentEventListener(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentCreated) {
+        val thresholdMillis = (1000L..5000L).random()
+        Thread.sleep(thresholdMillis)
+
+        paymentApplicationService.handle(event.transactionKey)
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentHandled) {
+        paymentApplicationService.notifyTransactionResult(transactionKey = event.transactionKey)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.error
+
+class CoreException(
+    val errorType: ErrorType,
+    val customMessage: String? = null,
+) : RuntimeException(customMessage ?: errorType.message)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
@@ -1,0 +1,11 @@
+package com.loopers.support.error
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorType(val status: HttpStatus, val code: String, val message: String) {
+    /** 범용 에러 */
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase, "일시적인 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.reasonPhrase, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.reasonPhrase, "존재하지 않는 요청입니다."),
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.reasonPhrase, "이미 존재하는 리소스입니다."),
+}

--- a/apps/pg-simulator/src/main/resources/application.yml
+++ b/apps/pg-simulator/src/main/resources/application.yml
@@ -1,0 +1,77 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+
+datasource:
+  mysql-jpa:
+    main:
+      jdbc-url: jdbc:mysql://localhost:3306/paymentgateway
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/docs/week2/03-class-diagram.md
+++ b/docs/week2/03-class-diagram.md
@@ -4,6 +4,7 @@
 classDiagram
 
     class Money {
+        <<VO>>
         - BigDecimal amount
         + of(BigDecimal amount) Money
         + of(long amount) Money
@@ -20,6 +21,7 @@ classDiagram
     }
 
     class Stock {
+        <<VO>>
         - int quantity
         + of(int quantity) Stock
         + increase(int amount) Stock
@@ -29,6 +31,7 @@ classDiagram
     }
 
     class User {
+        <<Entity>>
         -Long id
         -String userId
         -String name
@@ -47,6 +50,7 @@ classDiagram
     }
 
     class Brand {
+        <<Entity>>
         -Long id
         -String brandName
         -boolean isActive
@@ -58,6 +62,7 @@ classDiagram
     }
 
     class Product {
+        <<Entity>>
         -Long id
         -String productCode
         -String productName
@@ -79,6 +84,7 @@ classDiagram
     }
 
     class OrderItem {
+        <<Entity>>
         -Long id
         -Order order
         -Product product
@@ -91,6 +97,7 @@ classDiagram
     }
 
     class Order {
+        <<Entity>>
         -Long id
         -User user
         -String status
@@ -106,6 +113,7 @@ classDiagram
     }
 
     class ProductLike {
+        <<Entity>>
         -Long id
         -User user
         -Product product
@@ -113,6 +121,94 @@ classDiagram
         +isSameUserAndProduct()
         -validateUser(User user)
         -validateProduct(Product product)
+    }
+    
+    class Coupon {
+        <<Entity>>
+        -Long id
+        -String code
+        -String name
+        -String description
+        -LocaleDate validStartDate
+        -LocaleDate validEndDate
+        -Discount discount
+        -boolean isActive
+        -Integer maxIssuanceLimit
+        -Integer currentIssuanceCount
+        -validateCouponCode(String code)
+        -validateCouponName(String name)
+        -validateDiscount(Discount discount)
+        -validateCouponDates(LocaleDate validStartDate, LocaleDate validEndDate)
+        +increaseIssuanceCount()
+        +isValidAt(LocalDate date)
+        +isValidNow()
+        +canIssue()
+        +setMaxIssuanceLimit(Integer limit)
+        +activate()
+        +deactivate()
+    }
+
+    class IssuedCoupon {
+        <<Entity>>
+        +User user
+        +Coupon coupon
+        +CouponStatus status
+        +LocalDateTime usedAt
+        +IssuedCoupon(User, Coupon, CouponStatus)
+        +static IssuedCoupon issue(User, Coupon)
+        +void useCoupon()
+        -static void validateIssuedCouponFields(User, Coupon, CouponStatus)
+        -static void validateCanIssue(Coupon)
+        -void validateCanUseCoupon()
+    }
+
+    class Payment {
+        <<Entity>>
+        -String paymentId
+        -Order order
+        -String pgTransactionId
+        -Money amount
+        -PaymentStatus status
+        -PaymentType paymentType
+        -CardType cardType
+        -String cardNo
+        -LocalDateTime createdAt
+        -LocalDateTime completedAt
+        -Integer statusCheckCount
+        -LocalDateTime lastStatusCheckAt
+        +createPaymentForPoint(Order, Money, PaymentType)
+        +createPaymentForCard(Order, Money, PaymentType, CardType, String) 
+        +startProcessing(String pgTransactionId)
+        +completePointPayment()
+        +completePayment()
+        +failPayment(String reason)
+        +incrementStatusCheckCount()
+        +canCheckStatus(int maxCheckCount) boolean
+        +isProcessingOverMinutes(int minutes) boolean
+        -validatePaymentType(PaymentType, CardType, String)
+        -validateCardNo(String)
+        -validateCardType(CardType)
+    }
+
+    class PaymentStatus {
+        <<Enum>>
+        PENDING
+        PROCESSING
+        SUCCESS
+        FAILED
+    }
+
+    class PaymentType {
+        <<Enum>>
+        CARD
+        POINT
+    }
+
+    class CardType {
+        <<Enum>>
+        SAMSUNG
+        KB
+        HYUNDAI
     }
 
     User "1" -- "0..*" Order : 
@@ -129,6 +225,15 @@ classDiagram
     OrderItem "1" *-- "1" Money : totalPrice
     Order "1" *-- "1" Money : totalPrice
 
+    IssuedCoupon "0..*" *-- "1" User : user
+    IssuedCoupon "0..*" *-- "1" Coupon : coupon
+
+    Order "1" -- "0..1" Payment : 
+    Payment "1" *-- "1" Money : amount
+    Payment "1" --> "1" PaymentStatus : status
+    Payment "1" --> "1" PaymentType : paymentType
+    Payment "1" --> "0..1" CardType : cardType
+
 ```
 
 ### 클래스 다이어그램 설명
@@ -139,3 +244,9 @@ classDiagram
 *   **Order**: 사용자의 주문 정보를 나타냅니다.
 *   **OrderItem**: 주문 내역에 포함된 개별 상품의 정보를 나타냅니다. `Order`와 `Product` 간의 N:M 관계를 해소하는 중간 엔티티 역할을 합니다.
 *   **ProductLike**: 사용자가 특정 상품에 '좋아요'를 표시한 관계를 나타냅니다. `User`와 `Product` 간의 N:M 관계를 해소하는 중간 엔티티 역할을 합니다.
+*   **Coupon**: 쿠폰 정보를 나타냅니다.
+*   **IssuedCoupon**: 유저에게 발행된 쿠폰 정보를 나타냅니다.
+*   **Payment**: 주문에 대한 결제 정보를 나타냅니다. PG사와의 연동을 통해 결제 처리 상태를 추적하며, 카드 결제와 포인트 결제를 지원합니다.
+*   **PaymentStatus**: 결제의 상태를 나타내는 Enum입니다. PENDING(대기), PROCESSING(처리중), SUCCESS(성공), FAILED(실패) 상태를 가집니다.
+*   **PaymentType**: 결제 수단을 나타내는 Enum입니다. CARD(카드 결제), POINT(포인트 결제)를 지원합니다.
+*   **CardType**: 카드사 정보를 나타내는 Enum입니다. SAMSUNG, KB, HYUNDAI 카드를 지원합니다.

--- a/docs/week2/04-erd.md
+++ b/docs/week2/04-erd.md
@@ -51,6 +51,51 @@ erDiagram
         datetime deleted_at "삭제 일시"
     }
 
+    COUPON {
+        bigint id PK "쿠폰 고유 ID"
+        varchar coupon_code UK "쿠폰 코드 (10~20자)"
+        varchar coupon_name "쿠폰명"
+        text description "쿠폰 설명"
+        date valid_start_date "유효 시작일"
+        date valid_end_date "유효 종료일"
+        varchar discount_type "할인 타입 (PERCENTAGE/FIXED_AMOUNT)"
+        int discount_value "할인 값 (비율 또는 금액)"
+        boolean is_active "활성화 여부"
+        int max_issuance_limit "최대 발행 수량 (null이면 무제한)"
+        int current_issuance_count "현재 발행된 수량"
+        datetime created_at "생성 일시"
+        datetime updated_at "수정 일시"
+        datetime deleted_at "삭제 일시"
+    }
+
+    ISSUED_COUPON {
+        bigint id PK "발행 쿠폰 고유 ID"
+        bigint user_id FK "사용자 고유 ID"
+        bigint coupon_id FK "쿠폰 고유 ID"
+        varchar status "쿠폰 상태 (USABLE/USED/EXPIRED)"
+        datetime used_at "사용 일시"
+        datetime created_at "발행 일시"
+        datetime updated_at "수정 일시"
+        datetime deleted_at "삭제 일시"
+    }
+
+    PAYMENT {
+        bigint id PK "결제 고유 ID"
+        varchar payment_id UK "결제 ID (UUID)"
+        bigint order_id FK "주문 고유 ID"
+        varchar pg_transaction_id "PG사 거래 ID"
+        numeric amount "결제 금액"
+        varchar status "결제 상태 (PENDING/PROCESSING/SUCCESS/FAILED)"
+        varchar payment_type "결제 수단 (CARD/POINT)"
+        varchar card_type "카드사 (SAMSUNG/KB/HYUNDAI)"
+        varchar card_no "카드 번호"
+        int status_check_count "상태 확인 횟수"
+        datetime last_status_check_at "마지막 상태 확인 일시"
+        datetime created_at "생성 일시"
+        datetime completed_at "완료 일시"
+        datetime deleted_at "삭제 일시"
+    }
+
     USER ||--o{ ORDERS : ""
     USER ||--o{ PRODUCT_LIKE : ""
 
@@ -60,4 +105,8 @@ erDiagram
     ORDERS ||--|{ ORDER_ITEM : ""
 
     BRAND ||--|{ PRODUCT : ""
+
+    USER ||--o{ ISSUED_COUPON : ""
+    COUPON ||--o{ ISSUED_COUPON : ""
+    ORDERS ||--o| PAYMENT : ""
 ```

--- a/docs/week2/04-erd.md
+++ b/docs/week2/04-erd.md
@@ -58,7 +58,7 @@ erDiagram
         text description "쿠폰 설명"
         date valid_start_date "유효 시작일"
         date valid_end_date "유효 종료일"
-        varchar discount_type "할인 타입 (PERCENTAGE/FIXED_AMOUNT)"
+        varchar discount_type "할인 타입 (RATE/AMOUNT)"
         int discount_value "할인 값 (비율 또는 금액)"
         boolean is_active "활성화 여부"
         int max_issuance_limit "최대 발행 수량 (null이면 무제한)"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "loopers-java-spring-template"
 
 include(
     ":apps:commerce-api",
+    ":apps:pg-simulator",
     ":apps:commerce-streamer",
     ":modules:jpa",
     ":modules:redis",


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

- 외부 PG 결제 기능 추가
- 외부 API 장애 전파 방지를 위한 Resilence4j(CircuitBreaker, Retry) 적용
- 안정적인 결제 상태 확인을 위한 스케줄링 추가

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

###  application.yml 에서 Resilence4j 설정 관련 궁금한 점
1. 느린 호출에 대한 Circuit Breaker 설정
```
slow-call-rate-threshold: 70
slow-call-duration-threshold: 2s
```
느린 호출의 기준 시간(`slow-call-duration-threshold`)을 SLO(`Service Level Objective`) 또는 P95/P99 통계 기반으로 설정한다는 점은 이해했습니다.
저는 느린 호출 비율에 대해서 70%가 넘어가면 시스템에 부하가 생길 것 같다고 판단하여, 느린 호출이  70% 일 경우 Circuit이 OPEN되도록 설정하였는데, 
그렇다면, 실무에서는 이 느린 호출이 전체 요청 중 몇 퍼센트(`slow-call-rate-threshold`)일 때 Circuit을 OPEN 하도록 책정하는지에 대한 기준이 궁금합니다. 

2. 기록할 예외와 무시할 예외에 대해
```
# 기록할 예외 (이 예외들은 실패로 카운트)
record-exceptions:
  - feign.FeignException
  - java.util.concurrent.TimeoutException
  - java.io.IOException
# Circuit Breaker에서 무시할 예외 (실패로 카운트하지 않음)
# 비즈니스 로직 예외는 PG 시스템 장애가 아니므로 제외함
ignore-exceptions:
  - com.loopers.support.error.CoreException
```
Resilience4j에서 기록할 예외와 무시할 예외를 설정하는 부분이 있었는데, 현재는 CoreException 을 무시할 예외로 설정하였습니다.
궁금한 점은 CoreException은 비즈니스에 대한 오류를 통합으로 관리하는 커스텀 예외인데, 외부 호출용 커스텀 예외 처리를 하는 것이 좋을 지 궁금합니다(e.g. PaymentGatewayException)

3. Retry 어노테이션 설정
  ```
retry:
    instances:
      paymentGateway:
        # 최대 재시도 횟수 (초기 호출 포함 총 3회 시도)
        max-attempts: 3
        # 재시도 간격 (1초)
        wait-duration: 1s
        # 재시도 간격을 지수적으로 증가시킬지 여부
        enable-exponential-backoff: true
        # 지수 백오프 승수 (1초 -> 2초 -> 4초)
        exponential-backoff-multiplier: 2
        # 재시도할 예외 타입
        retry-exceptions:
          - java.util.concurrent.TimeoutException
          - feign.RetryableException
          - java.net.SocketTimeoutException
        # 재시도하지 않을 예외 타입
        ignore-exceptions:
          - com.loopers.support.error.CoreException
```

재시도 관련하여 설정을 위와 같이 하였는데, 재시도 횟수에 대해서 어느 정도까지 허용을 하는것이 좋을 지 감이 잡히지 않습니다.
재시도에 대한 설정은 민감하다고 생각합니다 @Retry를 통해 재시도를 많이 시도한다면 서버에 부하가 생길 것이고, 너무 적게 허용한다면 재시도의 의미가 있는 것일까에 대한 의문이 생겼습니다.
이번 과제에서는 `최대 재시도 횟수를 3번`으로 처리하였는데, `적절한 재시도 회수`가 무엇일까에 대해 궁금합니다.

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

### **⚡ PG 연동 대응**

- [ ]  PG 연동 API는 RestTemplate 혹은 FeignClient 로 외부 시스템을 호출한다.
- [ ]  응답 지연에 대해 타임아웃을 설정하고, 실패 시 적절한 예외 처리 로직을 구현한다.
- [ ]  결제 요청에 대한 실패 응답에 대해 적절한 시스템 연동을 진행한다.
- [ ]  콜백 방식 + **결제 상태 확인 API**를 활용해 적절하게 시스템과 결제정보를 연동한다.

### **🛡 Resilience 설계**

- [ ]  서킷 브레이커 혹은 재시도 정책을 적용하여 장애 확산을 방지한다.
- [ ]  외부 시스템 장애 시에도 내부 시스템은 **정상적으로 응답**하도록 보호한다.
- [ ]  콜백이 오지 않더라도, 일정 주기 혹은 수동 API 호출로 상태를 복구할 수 있다.
- [ ]  PG 에 대한 요청이 타임아웃에 의해 실패되더라도 해당 결제건에 대한 정보를 확인하여 정상적으로 시스템에 반영한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 카드 및 포인트 결제 기능 추가
  * 결제 콜백 처리 및 자동 상태 확인 스케줄러 추가
  * 결제 게이트웨이 재시도 및 회로 차단 메커니즘 구현

* **개선 사항**
  * 주문 생성 프로세스 단순화
  * 쿠폰 도메인 구조 개선

* **문서**
  * 결제 플로우 및 데이터베이스 스키마 문서화

* **테스트**
  * 결제 및 주문 기능 테스트 확대

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->