### PR TITLE
[volume - 8] Decoupling with Kafka

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
     implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))
@@ -34,4 +35,5 @@ dependencies {
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
     testImplementation(testFixtures(project(":modules:redis")))
+    testImplementation(testFixtures(project(":modules:kafka")))
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/catalog/CatalogFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/catalog/CatalogFacade.java
@@ -6,10 +6,13 @@ import com.loopers.application.product.ProductService;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductDetail;
+import com.loopers.domain.product.ProductEvent;
+import com.loopers.domain.product.ProductEventPublisher;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -30,6 +33,7 @@ public class CatalogFacade {
     private final BrandService brandService;
     private final ProductService productService;
     private final ProductCacheService productCacheService;
+    private final ProductEventPublisher productEventPublisher;
 
     /**
      * 상품 목록을 조회합니다.
@@ -103,16 +107,20 @@ public class CatalogFacade {
      * 상품 정보를 조회합니다.
      * <p>
      * Redis 캐시를 먼저 확인하고, 캐시에 없으면 DB에서 조회한 후 캐시에 저장합니다.
+     * 상품 조회 시 ProductViewed 이벤트를 발행하여 메트릭 집계에 사용합니다.
      * </p>
      *
      * @param productId 상품 ID
      * @return 상품 정보와 좋아요 수
      * @throws CoreException 상품을 찾을 수 없는 경우
      */
+    @Transactional(readOnly = true)
     public ProductInfo getProduct(Long productId) {
         // 캐시에서 조회 시도
         ProductInfo cachedResult = productCacheService.getCachedProduct(productId);
         if (cachedResult != null) {
+            // 캐시 히트 시에도 조회 수 집계를 위해 이벤트 발행
+            productEventPublisher.publish(ProductEvent.ProductViewed.from(productId));
             return cachedResult;
         }
         
@@ -132,6 +140,9 @@ public class CatalogFacade {
         
         // 캐시에 저장
         productCacheService.cacheProduct(productId, result);
+        
+        // ✅ 상품 조회 이벤트 발행 (메트릭 집계용)
+        productEventPublisher.publish(ProductEvent.ProductViewed.from(productId));
         
         // 로컬 캐시의 좋아요 수 델타 적용 (DB 조회 결과에도 델타 반영)
         return productCacheService.applyLikeCountDelta(result);

--- a/apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxBridgeEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxBridgeEventListener.java
@@ -1,0 +1,141 @@
+package com.loopers.application.outbox;
+
+import com.loopers.domain.like.LikeEvent;
+import com.loopers.domain.order.OrderEvent;
+import com.loopers.domain.product.ProductEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Outbox Bridge Event Listener.
+ * <p>
+ * ApplicationEvent를 구독하여 외부 시스템(Kafka)으로 전송해야 하는 이벤트를
+ * Transactional Outbox Pattern을 통해 Outbox에 저장합니다.
+ * </p>
+ * <p>
+ * <b>표준 패턴:</b>
+ * <ul>
+ *   <li>EventPublisher는 ApplicationEvent만 발행 (단일 책임)</li>
+ *   <li>이 컴포넌트가 ApplicationEvent를 구독하여 Outbox에 저장 (관심사 분리)</li>
+ *   <li>트랜잭션 커밋 후(AFTER_COMMIT) 처리하여 에러 격리</li>
+ * </ul>
+ * </p>
+ * <p>
+ * <b>처리 이벤트:</b>
+ * <ul>
+ *   <li><b>LikeEvent:</b> LikeAdded, LikeRemoved → like-events</li>
+ *   <li><b>OrderEvent:</b> OrderCreated → order-events</li>
+ *   <li><b>ProductEvent:</b> ProductViewed → product-events</li>
+ * </ul>
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxBridgeEventListener {
+
+    private final OutboxEventService outboxEventService;
+
+    /**
+     * LikeAdded 이벤트를 Outbox에 저장합니다.
+     *
+     * @param event LikeAdded 이벤트
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeAdded(LikeEvent.LikeAdded event) {
+        try {
+            outboxEventService.saveEvent(
+                "LikeAdded",
+                event.productId().toString(),
+                "Product",
+                event,
+                "like-events",
+                event.productId().toString()
+            );
+            log.debug("LikeAdded 이벤트를 Outbox에 저장: productId={}", event.productId());
+        } catch (Exception e) {
+            log.error("LikeAdded 이벤트 Outbox 저장 실패: productId={}", event.productId(), e);
+            // 외부 시스템 전송 실패는 내부 처리에 영향 없음
+        }
+    }
+
+    /**
+     * LikeRemoved 이벤트를 Outbox에 저장합니다.
+     *
+     * @param event LikeRemoved 이벤트
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeRemoved(LikeEvent.LikeRemoved event) {
+        try {
+            outboxEventService.saveEvent(
+                "LikeRemoved",
+                event.productId().toString(),
+                "Product",
+                event,
+                "like-events",
+                event.productId().toString()
+            );
+            log.debug("LikeRemoved 이벤트를 Outbox에 저장: productId={}", event.productId());
+        } catch (Exception e) {
+            log.error("LikeRemoved 이벤트 Outbox 저장 실패: productId={}", event.productId(), e);
+            // 외부 시스템 전송 실패는 내부 처리에 영향 없음
+        }
+    }
+
+    /**
+     * OrderCreated 이벤트를 Outbox에 저장합니다.
+     *
+     * @param event OrderCreated 이벤트
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCreated(OrderEvent.OrderCreated event) {
+        try {
+            outboxEventService.saveEvent(
+                "OrderCreated",
+                event.orderId().toString(),
+                "Order",
+                event,
+                "order-events",
+                event.orderId().toString()
+            );
+            log.debug("OrderCreated 이벤트를 Outbox에 저장: orderId={}", event.orderId());
+        } catch (Exception e) {
+            log.error("OrderCreated 이벤트 Outbox 저장 실패: orderId={}", event.orderId(), e);
+            // 외부 시스템 전송 실패는 내부 처리에 영향 없음
+        }
+    }
+
+    /**
+     * ProductViewed 이벤트를 Outbox에 저장합니다.
+     *
+     * @param event ProductViewed 이벤트
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductViewed(ProductEvent.ProductViewed event) {
+        try {
+            outboxEventService.saveEvent(
+                "ProductViewed",
+                event.productId().toString(),
+                "Product",
+                event,
+                "product-events",
+                event.productId().toString()
+            );
+            log.debug("ProductViewed 이벤트를 Outbox에 저장: productId={}", event.productId());
+        } catch (Exception e) {
+            log.error("ProductViewed 이벤트 Outbox 저장 실패: productId={}", event.productId(), e);
+            // 외부 시스템 전송 실패는 내부 처리에 영향 없음
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxEventService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxEventService.java
@@ -1,0 +1,100 @@
+package com.loopers.application.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.outbox.OutboxEvent;
+import com.loopers.domain.outbox.OutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Outbox 이벤트 저장 서비스.
+ * <p>
+ * 도메인 트랜잭션과 같은 트랜잭션에서 Outbox에 이벤트를 저장합니다.
+ * Application 레이어에 위치하여 비즈니스 로직(이벤트 저장 결정)을 처리합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxEventService {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Kafka로 전송할 이벤트를 Outbox에 저장합니다.
+     * <p>
+     * 도메인 트랜잭션과 같은 트랜잭션에서 실행되어야 합니다.
+     * 집계 ID별로 순차적인 버전을 자동으로 부여합니다.
+     * </p>
+     * <p>
+     * 버전 충돌 시 최대 3회까지 재시도합니다.
+     * 유니크 제약 조건을 통해 경쟁 조건을 감지하고 재시도합니다.
+     * </p>
+     *
+     * @param eventType 이벤트 타입 (예: "OrderCreated", "LikeAdded")
+     * @param aggregateId 집계 ID (예: orderId, productId)
+     * @param aggregateType 집계 타입 (예: "Order", "Product")
+     * @param event 이벤트 객체
+     * @param topic Kafka 토픽 이름
+     * @param partitionKey 파티션 키
+     */
+    @Transactional
+    public void saveEvent(
+        String eventType,
+        String aggregateId,
+        String aggregateType,
+        Object event,
+        String topic,
+        String partitionKey
+    ) {
+        int maxRetries = 3;
+        for (int i = 0; i < maxRetries; i++) {
+            try {
+                String eventId = UUID.randomUUID().toString();
+                String payload = objectMapper.writeValueAsString(event);
+
+                // 집계 ID별 최신 버전 조회 후 +1
+                Long latestVersion = outboxEventRepository.findLatestVersionByAggregateId(aggregateId, aggregateType);
+                Long nextVersion = latestVersion + 1L;
+
+                OutboxEvent outboxEvent = OutboxEvent.builder()
+                    .eventId(eventId)
+                    .eventType(eventType)
+                    .aggregateId(aggregateId)
+                    .aggregateType(aggregateType)
+                    .payload(payload)
+                    .topic(topic)
+                    .partitionKey(partitionKey)
+                    .version(nextVersion)
+                    .build();
+
+                outboxEventRepository.save(outboxEvent);
+                log.debug("Outbox 이벤트 저장: eventType={}, aggregateId={}, topic={}, version={}", 
+                    eventType, aggregateId, topic, nextVersion);
+                return; // 성공
+            } catch (DataIntegrityViolationException e) {
+                // 유니크 제약 조건 위반 (버전 충돌)
+                if (i == maxRetries - 1) {
+                    log.error("Outbox 이벤트 저장 실패 (최대 재시도 횟수 초과): eventType={}, aggregateId={}, retryCount={}", 
+                        eventType, aggregateId, i + 1, e);
+                    throw new RuntimeException("Outbox 이벤트 저장 실패: 버전 충돌", e);
+                }
+                log.warn("Outbox 이벤트 저장 재시도: eventType={}, aggregateId={}, retryCount={}", 
+                    eventType, aggregateId, i + 1);
+            } catch (Exception e) {
+                log.error("Outbox 이벤트 저장 실패: eventType={}, aggregateId={}", 
+                    eventType, aggregateId, e);
+                throw new RuntimeException("Outbox 이벤트 저장 실패", e);
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxEvent.java
@@ -1,0 +1,123 @@
+package com.loopers.domain.outbox;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Outbox 이벤트 엔티티.
+ * <p>
+ * Transactional Outbox Pattern을 구현하기 위한 엔티티입니다.
+ * 도메인 트랜잭션과 같은 트랜잭션에서 이벤트를 저장하고,
+ * 별도 프로세스가 이를 읽어 Kafka로 발행합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Entity
+@Table(name = "outbox_event", 
+    indexes = {
+        @Index(name = "idx_status_created", columnList = "status, created_at")
+    },
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_aggregate_version",
+            columnNames = {"aggregate_id", "aggregate_type", "version"}
+        )
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OutboxEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "event_id", nullable = false, unique = true, length = 255)
+    private String eventId;
+
+    @Column(name = "event_type", nullable = false, length = 100)
+    private String eventType;
+
+    @Column(name = "aggregate_id", nullable = false, length = 255)
+    private String aggregateId;
+
+    @Column(name = "aggregate_type", nullable = false, length = 100)
+    private String aggregateType;
+
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Column(name = "topic", nullable = false, length = 255)
+    private String topic;
+
+    @Column(name = "partition_key", length = 255)
+    private String partitionKey;
+
+    @Column(name = "version")
+    private Long version;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 50)
+    private OutboxStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Builder
+    public OutboxEvent(
+        String eventId,
+        String eventType,
+        String aggregateId,
+        String aggregateType,
+        String payload,
+        String topic,
+        String partitionKey,
+        Long version
+    ) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.aggregateId = aggregateId;
+        this.aggregateType = aggregateType;
+        this.payload = payload;
+        this.topic = topic;
+        this.partitionKey = partitionKey;
+        this.version = version;
+        this.status = OutboxStatus.PENDING;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    /**
+     * 이벤트를 발행 완료 상태로 변경합니다.
+     */
+    public void markAsPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 이벤트를 실패 상태로 변경합니다.
+     */
+    public void markAsFailed() {
+        this.status = OutboxStatus.FAILED;
+    }
+
+    /**
+     * Outbox 이벤트 상태.
+     */
+    public enum OutboxStatus {
+        PENDING,    // 발행 대기 중
+        PUBLISHED,  // 발행 완료
+        FAILED      // 발행 실패
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxEventRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxEventRepository.java
@@ -1,0 +1,51 @@
+package com.loopers.domain.outbox;
+
+import java.util.List;
+
+/**
+ * OutboxEvent 저장소 인터페이스.
+ * <p>
+ * DIP를 준수하여 도메인 레이어에서 인터페이스를 정의합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+public interface OutboxEventRepository {
+
+    /**
+     * Outbox 이벤트를 저장합니다.
+     *
+     * @param outboxEvent 저장할 Outbox 이벤트
+     * @return 저장된 Outbox 이벤트
+     */
+    OutboxEvent save(OutboxEvent outboxEvent);
+
+    /**
+     * 발행 대기 중인 이벤트 목록을 조회합니다.
+     *
+     * @param limit 조회할 최대 개수
+     * @return 발행 대기 중인 이벤트 목록
+     */
+    List<OutboxEvent> findPendingEvents(int limit);
+
+    /**
+     * ID로 Outbox 이벤트를 조회합니다.
+     *
+     * @param id Outbox 이벤트 ID
+     * @return 조회된 Outbox 이벤트
+     */
+    OutboxEvent findById(Long id);
+
+    /**
+     * 집계 ID와 집계 타입으로 최신 버전을 조회합니다.
+     * <p>
+     * 같은 집계에 대한 이벤트의 최신 버전을 조회하여 순차적인 버전 관리를 위해 사용됩니다.
+     * </p>
+     *
+     * @param aggregateId 집계 ID (예: productId, orderId)
+     * @param aggregateType 집계 타입 (예: "Product", "Order")
+     * @return 최신 버전 (없으면 0L)
+     */
+    Long findLatestVersionByAggregateId(String aggregateId, String aggregateType);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEvent.java
@@ -1,0 +1,59 @@
+package com.loopers.domain.product;
+
+import java.time.LocalDateTime;
+
+/**
+ * 상품 도메인 이벤트.
+ * <p>
+ * 상품 도메인의 중요한 상태 변화를 나타내는 이벤트들입니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+public class ProductEvent {
+
+    /**
+     * 상품 상세 페이지 조회 이벤트.
+     * <p>
+     * 상품 상세 페이지가 조회되었을 때 발행되는 이벤트입니다.
+     * 메트릭 집계를 위해 사용됩니다.
+     * </p>
+     *
+     * @param productId 상품 ID
+     * @param userId 사용자 ID (null 가능 - 비로그인 사용자)
+     * @param occurredAt 이벤트 발생 시각
+     */
+    public record ProductViewed(
+            Long productId,
+            Long userId,
+            LocalDateTime occurredAt
+    ) {
+        public ProductViewed {
+            if (productId == null) {
+                throw new IllegalArgumentException("productId는 필수입니다.");
+            }
+        }
+
+        /**
+         * 상품 ID로부터 ProductViewed 이벤트를 생성합니다.
+         *
+         * @param productId 상품 ID
+         * @return ProductViewed 이벤트
+         */
+        public static ProductViewed from(Long productId) {
+            return new ProductViewed(productId, null, LocalDateTime.now());
+        }
+
+        /**
+         * 상품 ID와 사용자 ID로부터 ProductViewed 이벤트를 생성합니다.
+         *
+         * @param productId 상품 ID
+         * @param userId 사용자 ID
+         * @return ProductViewed 이벤트
+         */
+        public static ProductViewed from(Long productId, Long userId) {
+            return new ProductViewed(productId, userId, LocalDateTime.now());
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEventPublisher.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.product;
+
+/**
+ * 상품 도메인 이벤트 발행 인터페이스.
+ * <p>
+ * DIP를 준수하여 도메인 레이어에서 이벤트 발행 인터페이스를 정의합니다.
+ * 구현은 인프라 레이어에서 제공됩니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+public interface ProductEventPublisher {
+
+    /**
+     * 상품 상세 페이지 조회 이벤트를 발행합니다.
+     *
+     * @param event 상품 조회 이벤트
+     */
+    void publish(ProductEvent.ProductViewed event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventJpaRepository.java
@@ -1,0 +1,40 @@
+package com.loopers.infrastructure.outbox;
+
+import com.loopers.domain.outbox.OutboxEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * OutboxEvent JPA Repository.
+ */
+public interface OutboxEventJpaRepository extends JpaRepository<OutboxEvent, Long> {
+
+    /**
+     * 발행 대기 중인 이벤트 목록을 생성 시간 순으로 조회합니다.
+     *
+     * @param limit 조회할 최대 개수
+     * @return 발행 대기 중인 이벤트 목록
+     */
+    @Query(value = "SELECT * FROM outbox_event e " +
+           "WHERE e.status = 'PENDING' " +
+           "ORDER BY e.created_at ASC " +
+           "LIMIT :limit", nativeQuery = true)
+    List<OutboxEvent> findPendingEvents(@Param("limit") int limit);
+
+    /**
+     * 집계 ID와 집계 타입으로 최신 버전을 조회합니다.
+     *
+     * @param aggregateId 집계 ID (예: productId, orderId)
+     * @param aggregateType 집계 타입 (예: "Product", "Order")
+     * @return 최신 버전 (없으면 0L)
+     */
+    @Query("SELECT COALESCE(MAX(e.version), 0L) FROM OutboxEvent e " +
+           "WHERE e.aggregateId = :aggregateId AND e.aggregateType = :aggregateType")
+    Long findLatestVersionByAggregateId(
+        @Param("aggregateId") String aggregateId,
+        @Param("aggregateType") String aggregateType
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventPublisher.java
@@ -1,0 +1,133 @@
+package com.loopers.infrastructure.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.outbox.OutboxEvent;
+import com.loopers.domain.outbox.OutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Outbox 이벤트 발행 프로세스.
+ * <p>
+ * 주기적으로 Outbox에서 발행 대기 중인 이벤트를 읽어 Kafka로 발행합니다.
+ * Transactional Outbox Pattern의 Polling 프로세스입니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventPublisher {
+
+    private static final int BATCH_SIZE = 100;
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 발행 대기 중인 Outbox 이벤트를 Kafka로 발행합니다.
+     * <p>
+     * 1초마다 실행되어 PENDING 상태의 이벤트를 처리합니다.
+     * </p>
+     */
+    @Scheduled(fixedDelay = 1000) // 1초마다 실행
+    @Transactional
+    public void publishPendingEvents() {
+        try {
+            List<OutboxEvent> pendingEvents = outboxEventRepository.findPendingEvents(BATCH_SIZE);
+
+            if (pendingEvents.isEmpty()) {
+                return;
+            }
+
+            log.debug("Outbox 이벤트 발행 시작: count={}", pendingEvents.size());
+
+            for (OutboxEvent event : pendingEvents) {
+                try {
+                    publishEvent(event);
+                } catch (Exception e) {
+                    log.error("Outbox 이벤트 발행 요청 실패: eventId={}, topic={}", 
+                        event.getEventId(), event.getTopic(), e);
+                    event.markAsFailed();
+                    outboxEventRepository.save(event);
+                    // 개별 이벤트 실패는 계속 진행
+                }
+            }
+
+            log.debug("Outbox 이벤트 발행 완료: count={}", pendingEvents.size());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 발행 프로세스 실패", e);
+            // 프로세스 실패는 다음 스케줄에서 재시도
+        }
+    }
+
+    /**
+     * Outbox 이벤트를 Kafka로 발행합니다.
+     * <p>
+     * 멱등성 처리를 위해 `eventId`를 Kafka 메시지 헤더에 포함시킵니다.
+     * </p>
+     *
+     * @param event 발행할 Outbox 이벤트
+     */
+    private void publishEvent(OutboxEvent event) {
+        try {
+            // JSON 문자열을 Map으로 역직렬화하여 Kafka로 전송
+            // KafkaTemplate의 JsonSerializer가 자동으로 직렬화합니다
+            Object payload = objectMapper.readValue(event.getPayload(), Object.class);
+            
+            // Kafka 메시지 헤더에 eventId, eventType, version 추가 (멱등성 및 버전 비교 처리용)
+            var messageBuilder = MessageBuilder
+                .withPayload(payload)
+                .setHeader(KafkaHeaders.KEY, event.getPartitionKey())
+                .setHeader("eventId", event.getEventId())
+                .setHeader("eventType", event.getEventType());
+            
+            // version이 있으면 헤더에 추가
+            if (event.getVersion() != null) {
+                messageBuilder.setHeader("version", event.getVersion());
+            }
+            
+            var message = messageBuilder.build();
+            
+            // Kafka로 비동기 발행 (콜백에서 상태 업데이트)
+            kafkaTemplate.send(event.getTopic(), message)
+                .whenComplete((result, ex) -> handleSendResult(event, result, ex));
+        } catch (Exception e) {
+            log.error("Kafka 이벤트 발행 실패: eventId={}, topic={}", 
+                event.getEventId(), event.getTopic(), e);
+            throw new RuntimeException("Kafka 이벤트 발행 실패", e);
+        }
+    }
+
+    /**
+     * Kafka 전송 결과를 처리합니다.
+     */
+    private void handleSendResult(OutboxEvent event, SendResult<String, Object> result, Throwable ex) {
+        try {
+            if (ex != null) {
+                log.error("Kafka 전송 실패: eventId={}, topic={}", event.getEventId(), event.getTopic(), ex);
+                event.markAsFailed();
+            } else {
+                log.debug("Outbox 이벤트 Kafka 발행 성공: eventId={}, topic={}", 
+                    event.getEventId(), event.getTopic());
+                event.markAsPublished();
+            }
+            outboxEventRepository.save(event);
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 상태 업데이트 실패: eventId={}, topic={}", 
+                event.getEventId(), event.getTopic(), e);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.loopers.infrastructure.outbox;
+
+import com.loopers.domain.outbox.OutboxEvent;
+import com.loopers.domain.outbox.OutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * OutboxEventRepository의 JPA 구현체.
+ */
+@Component
+@RequiredArgsConstructor
+public class OutboxEventRepositoryImpl implements OutboxEventRepository {
+
+    private final OutboxEventJpaRepository outboxEventJpaRepository;
+
+    @Override
+    public OutboxEvent save(OutboxEvent outboxEvent) {
+        return outboxEventJpaRepository.save(outboxEvent);
+    }
+
+    @Override
+    public List<OutboxEvent> findPendingEvents(int limit) {
+        return outboxEventJpaRepository.findPendingEvents(limit);
+    }
+
+    @Override
+    public OutboxEvent findById(Long id) {
+        return outboxEventJpaRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("OutboxEvent not found: " + id));
+    }
+
+    @Override
+    public Long findLatestVersionByAggregateId(String aggregateId, String aggregateType) {
+        return outboxEventJpaRepository.findLatestVersionByAggregateId(aggregateId, aggregateType);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductEventPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductEventPublisherImpl.java
@@ -1,0 +1,36 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductEvent;
+import com.loopers.domain.product.ProductEventPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+/**
+ * ProductEventPublisher 인터페이스의 구현체.
+ * <p>
+ * Spring ApplicationEventPublisher를 사용하여 상품 이벤트를 발행합니다.
+ * DIP를 준수하여 도메인 인터페이스를 구현합니다.
+ * </p>
+ * <p>
+ * <b>표준 패턴:</b>
+ * <ul>
+ *   <li>ApplicationEvent만 발행 (단일 책임 원칙)</li>
+ *   <li>Kafka 전송은 OutboxBridgeEventListener가 처리 (관심사 분리)</li>
+ * </ul>
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Component
+@RequiredArgsConstructor
+public class ProductEventPublisherImpl implements ProductEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(ProductEvent.ProductViewed event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
   config:
     import:
       - jpa.yml
+      - kafka.yml
       - redis.yml
       - logging.yml
       - monitoring.yml

--- a/apps/commerce-api/src/test/java/com/loopers/application/outbox/OutboxBridgeEventListenerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/outbox/OutboxBridgeEventListenerTest.java
@@ -1,0 +1,163 @@
+package com.loopers.application.outbox;
+
+import com.loopers.domain.like.LikeEvent;
+import com.loopers.domain.order.OrderEvent;
+import com.loopers.domain.product.ProductEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * OutboxBridgeEventListener 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class OutboxBridgeEventListenerTest {
+
+    @Mock
+    private OutboxEventService outboxEventService;
+
+    @InjectMocks
+    private OutboxBridgeEventListener outboxBridgeEventListener;
+
+    @DisplayName("LikeAdded 이벤트를 Outbox에 저장할 수 있다.")
+    @Test
+    void canHandleLikeAdded() {
+        // arrange
+        Long userId = 100L;
+        Long productId = 1L;
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(userId, productId, LocalDateTime.now());
+
+        // act
+        outboxBridgeEventListener.handleLikeAdded(event);
+
+        // assert
+        verify(outboxEventService).saveEvent(
+            "LikeAdded",
+            productId.toString(),
+            "Product",
+            event,
+            "like-events",
+            productId.toString()
+        );
+    }
+
+    @DisplayName("LikeRemoved 이벤트를 Outbox에 저장할 수 있다.")
+    @Test
+    void canHandleLikeRemoved() {
+        // arrange
+        Long userId = 100L;
+        Long productId = 1L;
+        LikeEvent.LikeRemoved event = new LikeEvent.LikeRemoved(userId, productId, LocalDateTime.now());
+
+        // act
+        outboxBridgeEventListener.handleLikeRemoved(event);
+
+        // assert
+        verify(outboxEventService).saveEvent(
+            "LikeRemoved",
+            productId.toString(),
+            "Product",
+            event,
+            "like-events",
+            productId.toString()
+        );
+    }
+
+    @DisplayName("OrderCreated 이벤트를 Outbox에 저장할 수 있다.")
+    @Test
+    void canHandleOrderCreated() {
+        // arrange
+        Long orderId = 1L;
+        Long userId = 100L;
+        List<OrderEvent.OrderCreated.OrderItemInfo> orderItems = List.of(
+            new OrderEvent.OrderCreated.OrderItemInfo(1L, 3)
+        );
+        OrderEvent.OrderCreated event = new OrderEvent.OrderCreated(
+            orderId, userId, null, 10000, 0L, orderItems, LocalDateTime.now()
+        );
+
+        // act
+        outboxBridgeEventListener.handleOrderCreated(event);
+
+        // assert
+        verify(outboxEventService).saveEvent(
+            "OrderCreated",
+            orderId.toString(),
+            "Order",
+            event,
+            "order-events",
+            orderId.toString()
+        );
+    }
+
+    @DisplayName("ProductViewed 이벤트를 Outbox에 저장할 수 있다.")
+    @Test
+    void canHandleProductViewed() {
+        // arrange
+        Long productId = 1L;
+        Long userId = 100L;
+        ProductEvent.ProductViewed event = new ProductEvent.ProductViewed(
+            productId, userId, LocalDateTime.now()
+        );
+
+        // act
+        outboxBridgeEventListener.handleProductViewed(event);
+
+        // assert
+        verify(outboxEventService).saveEvent(
+            "ProductViewed",
+            productId.toString(),
+            "Product",
+            event,
+            "product-events",
+            productId.toString()
+        );
+    }
+
+    @DisplayName("Outbox 저장 실패 시에도 예외를 던지지 않는다 (에러 격리).")
+    @Test
+    void doesNotThrowException_whenOutboxSaveFails() {
+        // arrange
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(100L, 1L, LocalDateTime.now());
+        doThrow(new RuntimeException("Outbox 저장 실패"))
+            .when(outboxEventService).saveEvent(anyString(), anyString(), anyString(), 
+                any(), anyString(), anyString());
+
+        // act & assert - 예외가 발생하지 않아야 함
+        outboxBridgeEventListener.handleLikeAdded(event);
+
+        // verify
+        verify(outboxEventService).saveEvent(anyString(), anyString(), anyString(), 
+            any(), anyString(), anyString());
+    }
+
+    @DisplayName("여러 이벤트를 순차적으로 처리할 수 있다.")
+    @Test
+    void canHandleMultipleEvents() {
+        // arrange
+        LikeEvent.LikeAdded likeAdded = new LikeEvent.LikeAdded(100L, 1L, LocalDateTime.now());
+        LikeEvent.LikeRemoved likeRemoved = new LikeEvent.LikeRemoved(100L, 1L, LocalDateTime.now());
+        ProductEvent.ProductViewed productViewed = new ProductEvent.ProductViewed(
+            1L, 100L, LocalDateTime.now()
+        );
+
+        // act
+        outboxBridgeEventListener.handleLikeAdded(likeAdded);
+        outboxBridgeEventListener.handleLikeRemoved(likeRemoved);
+        outboxBridgeEventListener.handleProductViewed(productViewed);
+
+        // assert
+        verify(outboxEventService, times(3)).saveEvent(
+            anyString(), anyString(), anyString(), any(), anyString(), anyString()
+        );
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/outbox/OutboxEventServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/outbox/OutboxEventServiceTest.java
@@ -1,0 +1,168 @@
+package com.loopers.application.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.like.LikeEvent;
+import com.loopers.domain.outbox.OutboxEvent;
+import com.loopers.domain.outbox.OutboxEventRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * OutboxEventService 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class OutboxEventServiceTest {
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private OutboxEventService outboxEventService;
+
+    @DisplayName("이벤트를 Outbox에 저장할 수 있다.")
+    @Test
+    void canSaveEvent() throws Exception {
+        // arrange
+        String eventType = "LikeAdded";
+        String aggregateId = "1";
+        String aggregateType = "Product";
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(100L, 1L, LocalDateTime.now());
+        String topic = "like-events";
+        String partitionKey = "1";
+        String payload = "{\"userId\":100,\"productId\":1}";
+
+        when(objectMapper.writeValueAsString(event)).thenReturn(payload);
+        when(outboxEventRepository.findLatestVersionByAggregateId(aggregateId, aggregateType))
+            .thenReturn(0L);
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        outboxEventService.saveEvent(eventType, aggregateId, aggregateType, event, topic, partitionKey);
+
+        // assert
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository).save(captor.capture());
+        
+        OutboxEvent savedEvent = captor.getValue();
+        assertThat(savedEvent.getEventType()).isEqualTo(eventType);
+        assertThat(savedEvent.getAggregateId()).isEqualTo(aggregateId);
+        assertThat(savedEvent.getAggregateType()).isEqualTo(aggregateType);
+        assertThat(savedEvent.getPayload()).isEqualTo(payload);
+        assertThat(savedEvent.getTopic()).isEqualTo(topic);
+        assertThat(savedEvent.getPartitionKey()).isEqualTo(partitionKey);
+        assertThat(savedEvent.getVersion()).isEqualTo(1L); // 최신 버전(0) + 1
+        assertThat(savedEvent.getStatus()).isEqualTo(OutboxEvent.OutboxStatus.PENDING);
+        assertThat(savedEvent.getEventId()).isNotNull();
+        assertThat(savedEvent.getCreatedAt()).isNotNull();
+    }
+
+    @DisplayName("이벤트 저장 시 UUID로 고유한 eventId가 생성된다.")
+    @Test
+    void generatesUniqueEventId() throws Exception {
+        // arrange
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(100L, 1L, LocalDateTime.now());
+        when(objectMapper.writeValueAsString(event)).thenReturn("{}");
+        when(outboxEventRepository.findLatestVersionByAggregateId(anyString(), anyString()))
+            .thenReturn(0L);
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        outboxEventService.saveEvent("LikeAdded", "1", "Product", event, "like-events", "1");
+        outboxEventService.saveEvent("LikeAdded", "2", "Product", event, "like-events", "2");
+
+        // assert
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository, times(2)).save(captor.capture());
+        
+        OutboxEvent event1 = captor.getAllValues().get(0);
+        OutboxEvent event2 = captor.getAllValues().get(1);
+        assertThat(event1.getEventId()).isNotEqualTo(event2.getEventId());
+    }
+
+    @DisplayName("같은 집계 ID에 대해 버전이 순차적으로 증가한다.")
+    @Test
+    void incrementsVersionSequentially() throws Exception {
+        // arrange
+        String aggregateId = "1";
+        String aggregateType = "Product";
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(100L, 1L, LocalDateTime.now());
+        when(objectMapper.writeValueAsString(event)).thenReturn("{}");
+        when(outboxEventRepository.findLatestVersionByAggregateId(aggregateId, aggregateType))
+            .thenReturn(0L)  // 첫 번째 호출: 최신 버전 0
+            .thenReturn(1L)  // 두 번째 호출: 최신 버전 1
+            .thenReturn(2L); // 세 번째 호출: 최신 버전 2
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        outboxEventService.saveEvent("LikeAdded", aggregateId, aggregateType, event, "like-events", aggregateId);
+        outboxEventService.saveEvent("LikeRemoved", aggregateId, aggregateType, event, "like-events", aggregateId);
+        outboxEventService.saveEvent("ProductViewed", aggregateId, aggregateType, event, "product-events", aggregateId);
+
+        // assert
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository, times(3)).save(captor.capture());
+        
+        OutboxEvent event1 = captor.getAllValues().get(0);
+        OutboxEvent event2 = captor.getAllValues().get(1);
+        OutboxEvent event3 = captor.getAllValues().get(2);
+        
+        assertThat(event1.getVersion()).isEqualTo(1L);
+        assertThat(event2.getVersion()).isEqualTo(2L);
+        assertThat(event3.getVersion()).isEqualTo(3L);
+    }
+
+    @DisplayName("JSON 직렬화 실패 시 예외를 발생시킨다.")
+    @Test
+    void throwsException_whenJsonSerializationFails() throws Exception {
+        // arrange
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(100L, 1L, LocalDateTime.now());
+        when(objectMapper.writeValueAsString(event))
+            .thenThrow(new RuntimeException("JSON 직렬화 실패"));
+
+        // act & assert
+        assertThatThrownBy(() -> 
+            outboxEventService.saveEvent("LikeAdded", "1", "Product", event, "like-events", "1")
+        ).isInstanceOf(RuntimeException.class)
+         .hasMessageContaining("Outbox 이벤트 저장 실패");
+
+        verify(outboxEventRepository, never()).save(any());
+    }
+
+    @DisplayName("Repository 저장 실패 시 예외를 발생시킨다.")
+    @Test
+    void throwsException_whenRepositorySaveFails() throws Exception {
+        // arrange
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(100L, 1L, LocalDateTime.now());
+        when(objectMapper.writeValueAsString(event)).thenReturn("{}");
+        when(outboxEventRepository.findLatestVersionByAggregateId("1", "Product"))
+            .thenReturn(0L);
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenThrow(new RuntimeException("DB 저장 실패"));
+
+        // act & assert
+        assertThatThrownBy(() -> 
+            outboxEventService.saveEvent("LikeAdded", "1", "Product", event, "like-events", "1")
+        ).isInstanceOf(RuntimeException.class)
+         .hasMessageContaining("Outbox 이벤트 저장 실패");
+
+        verify(outboxEventRepository).save(any(OutboxEvent.class));
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/outbox/OutboxEventTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/outbox/OutboxEventTest.java
@@ -1,0 +1,124 @@
+package com.loopers.domain.outbox;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * OutboxEvent 도메인 테스트.
+ */
+class OutboxEventTest {
+
+    @DisplayName("OutboxEvent는 필수 필드로 생성되며 초기 상태가 PENDING이다.")
+    @Test
+    void createsOutboxEventWithPendingStatus() {
+        // arrange
+        String eventId = "event-123";
+        String eventType = "OrderCreated";
+        String aggregateId = "1";
+        String aggregateType = "Order";
+        String payload = "{\"orderId\":1}";
+        String topic = "order-events";
+        String partitionKey = "1";
+
+        // act
+        OutboxEvent outboxEvent = OutboxEvent.builder()
+            .eventId(eventId)
+            .eventType(eventType)
+            .aggregateId(aggregateId)
+            .aggregateType(aggregateType)
+            .payload(payload)
+            .topic(topic)
+            .partitionKey(partitionKey)
+            .build();
+
+        // assert
+        assertThat(outboxEvent.getEventId()).isEqualTo(eventId);
+        assertThat(outboxEvent.getEventType()).isEqualTo(eventType);
+        assertThat(outboxEvent.getAggregateId()).isEqualTo(aggregateId);
+        assertThat(outboxEvent.getAggregateType()).isEqualTo(aggregateType);
+        assertThat(outboxEvent.getPayload()).isEqualTo(payload);
+        assertThat(outboxEvent.getTopic()).isEqualTo(topic);
+        assertThat(outboxEvent.getPartitionKey()).isEqualTo(partitionKey);
+        assertThat(outboxEvent.getStatus()).isEqualTo(OutboxEvent.OutboxStatus.PENDING);
+        assertThat(outboxEvent.getCreatedAt()).isNotNull();
+        assertThat(outboxEvent.getPublishedAt()).isNull();
+    }
+
+    @DisplayName("이벤트를 발행 완료 상태로 변경할 수 있다.")
+    @Test
+    void canMarkAsPublished() throws InterruptedException {
+        // arrange
+        OutboxEvent outboxEvent = OutboxEvent.builder()
+            .eventId("event-123")
+            .eventType("OrderCreated")
+            .aggregateId("1")
+            .aggregateType("Order")
+            .payload("{}")
+            .topic("order-events")
+            .partitionKey("1")
+            .build();
+
+        LocalDateTime beforePublish = outboxEvent.getCreatedAt();
+        Thread.sleep(1); // 시간 차이를 보장하기 위한 작은 지연
+
+        // act
+        outboxEvent.markAsPublished();
+
+        // assert
+        assertThat(outboxEvent.getStatus()).isEqualTo(OutboxEvent.OutboxStatus.PUBLISHED);
+        assertThat(outboxEvent.getPublishedAt()).isNotNull();
+        assertThat(outboxEvent.getPublishedAt()).isAfter(beforePublish);
+    }
+
+    @DisplayName("이벤트를 실패 상태로 변경할 수 있다.")
+    @Test
+    void canMarkAsFailed() {
+        // arrange
+        OutboxEvent outboxEvent = OutboxEvent.builder()
+            .eventId("event-123")
+            .eventType("OrderCreated")
+            .aggregateId("1")
+            .aggregateType("Order")
+            .payload("{}")
+            .topic("order-events")
+            .partitionKey("1")
+            .build();
+
+        // act
+        outboxEvent.markAsFailed();
+
+        // assert
+        assertThat(outboxEvent.getStatus()).isEqualTo(OutboxEvent.OutboxStatus.FAILED);
+        assertThat(outboxEvent.getPublishedAt()).isNull();
+    }
+
+    @DisplayName("발행 완료 후 실패 상태로 변경할 수 있다.")
+    @Test
+    void canMarkAsFailedAfterPublished() {
+        // arrange
+        OutboxEvent outboxEvent = OutboxEvent.builder()
+            .eventId("event-123")
+            .eventType("OrderCreated")
+            .aggregateId("1")
+            .aggregateType("Order")
+            .payload("{}")
+            .topic("order-events")
+            .partitionKey("1")
+            .build();
+
+        outboxEvent.markAsPublished();
+        LocalDateTime publishedAt = outboxEvent.getPublishedAt();
+
+        // act
+        outboxEvent.markAsFailed();
+
+        // assert
+        assertThat(outboxEvent.getStatus()).isEqualTo(OutboxEvent.OutboxStatus.FAILED);
+        // markAsFailed는 publishedAt을 변경하지 않음
+        assertThat(outboxEvent.getPublishedAt()).isEqualTo(publishedAt);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/outbox/OutboxEventPublisherIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/outbox/OutboxEventPublisherIntegrationTest.java
@@ -1,0 +1,43 @@
+package com.loopers.infrastructure.outbox;
+
+import com.loopers.testcontainers.KafkaTestContainersConfig;
+import com.loopers.utils.KafkaCleanUp;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * OutboxEventPublisher 통합 테스트.
+ * <p>
+ * 실제 Kafka를 사용하여 Outbox 패턴의 이벤트 발행 동작을 검증합니다.
+ * </p>
+ * <p>
+ * <b>Kafka 컨테이너:</b>
+ * {@link KafkaTestContainersConfig}가 테스트 실행 시 자동으로 Kafka 컨테이너를 시작합니다.
+ * </p>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(KafkaTestContainersConfig.class)
+class OutboxEventPublisherIntegrationTest {
+
+    @Autowired
+    private KafkaCleanUp kafkaCleanUp;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 전에 토픽의 모든 메시지 삭제 및 재생성
+        kafkaCleanUp.resetAllTestTopics();
+    }
+
+    @DisplayName("통합 테스트: Outbox 패턴을 통한 Kafka 이벤트 발행이 정상적으로 동작한다.")
+    @Test
+    void integrationTest() {
+        // TODO: 실제 Kafka를 사용한 통합 테스트 구현
+        // 예: OutboxEvent를 저장한 후 OutboxEventPublisher가 Kafka로 발행하는지 확인
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/outbox/OutboxEventPublisherTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/outbox/OutboxEventPublisherTest.java
@@ -1,0 +1,299 @@
+package com.loopers.infrastructure.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.outbox.OutboxEvent;
+import com.loopers.domain.outbox.OutboxEventRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.messaging.Message;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * OutboxEventPublisher 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class OutboxEventPublisherTest {
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private OutboxEventPublisher outboxEventPublisher;
+
+    @DisplayName("PENDING 상태의 이벤트를 Kafka로 발행할 수 있다.")
+    @Test
+    void canPublishPendingEvents() throws Exception {
+        // arrange
+        OutboxEvent event1 = createPendingEvent("event-1", "order-events", "1");
+        OutboxEvent event2 = createPendingEvent("event-2", "like-events", "1");
+        List<OutboxEvent> pendingEvents = List.of(event1, event2);
+
+        when(outboxEventRepository.findPendingEvents(100)).thenReturn(pendingEvents);
+        when(objectMapper.readValue(anyString(), eq(Object.class)))
+            .thenReturn(Map.of("orderId", 1));
+        when(kafkaTemplate.send(anyString(), any(Message.class)))
+            .thenReturn(createSuccessFuture());
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        outboxEventPublisher.publishPendingEvents();
+
+        // assert
+        verify(kafkaTemplate, times(2)).send(anyString(), any(Message.class));
+        verify(outboxEventRepository, times(2)).save(any(OutboxEvent.class));
+        
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository, times(2)).save(captor.capture());
+        
+        List<OutboxEvent> savedEvents = captor.getAllValues();
+        assertThat(savedEvents).allMatch(e -> 
+            e.getStatus() == OutboxEvent.OutboxStatus.PUBLISHED
+        );
+        assertThat(savedEvents).allMatch(e -> 
+            e.getPublishedAt() != null
+        );
+    }
+
+    @DisplayName("PENDING 이벤트가 없으면 아무것도 발행하지 않는다.")
+    @Test
+    void doesNothing_whenNoPendingEvents() {
+        // arrange
+        when(outboxEventRepository.findPendingEvents(100)).thenReturn(List.of());
+
+        // act
+        outboxEventPublisher.publishPendingEvents();
+
+        // assert
+        verify(kafkaTemplate, never()).send(anyString(), any(Message.class));
+        verify(outboxEventRepository, never()).save(any(OutboxEvent.class));
+    }
+
+    @DisplayName("개별 이벤트 발행 실패 시에도 배치 처리를 계속한다.")
+    @Test
+    void continuesProcessing_whenIndividualEventFails() throws Exception {
+        // arrange
+        OutboxEvent event1 = createPendingEvent("event-1", "order-events", "1");
+        OutboxEvent event2 = createPendingEvent("event-2", "like-events", "1");
+        List<OutboxEvent> pendingEvents = List.of(event1, event2);
+
+        when(outboxEventRepository.findPendingEvents(100)).thenReturn(pendingEvents);
+        when(objectMapper.readValue(anyString(), eq(Object.class)))
+            .thenReturn(Map.of("orderId", 1));
+        when(kafkaTemplate.send(eq("order-events"), any(Message.class)))
+            .thenThrow(new RuntimeException("Kafka 발행 실패"));
+        when(kafkaTemplate.send(eq("like-events"), any(Message.class)))
+            .thenReturn(createSuccessFuture());
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        outboxEventPublisher.publishPendingEvents();
+
+        // assert
+        verify(kafkaTemplate, times(2)).send(anyString(), any(Message.class));
+        verify(outboxEventRepository, times(2)).save(any(OutboxEvent.class));
+        
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository, times(2)).save(captor.capture());
+        
+        List<OutboxEvent> savedEvents = captor.getAllValues();
+        // event1은 FAILED, event2는 PUBLISHED
+        assertThat(savedEvents).anyMatch(e -> 
+            e.getEventId().equals("event-1") && 
+            e.getStatus() == OutboxEvent.OutboxStatus.FAILED
+        );
+        assertThat(savedEvents).anyMatch(e -> 
+            e.getEventId().equals("event-2") && 
+            e.getStatus() == OutboxEvent.OutboxStatus.PUBLISHED
+        );
+    }
+
+    @DisplayName("Kafka 발행 성공 시 이벤트 상태를 PUBLISHED로 변경한다.")
+    @Test
+    void marksAsPublished_whenKafkaPublishSucceeds() throws Exception {
+        // arrange
+        OutboxEvent event = createPendingEvent("event-1", "order-events", "1");
+        List<OutboxEvent> pendingEvents = List.of(event);
+
+        when(outboxEventRepository.findPendingEvents(100)).thenReturn(pendingEvents);
+        when(objectMapper.readValue(anyString(), eq(Object.class)))
+            .thenReturn(Map.of("orderId", 1));
+        when(kafkaTemplate.send(anyString(), any(Message.class)))
+            .thenReturn(createSuccessFuture());
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        outboxEventPublisher.publishPendingEvents();
+
+        // assert
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository).save(captor.capture());
+        
+        OutboxEvent savedEvent = captor.getValue();
+        assertThat(savedEvent.getStatus()).isEqualTo(OutboxEvent.OutboxStatus.PUBLISHED);
+        assertThat(savedEvent.getPublishedAt()).isNotNull();
+    }
+
+    @DisplayName("Kafka 발행 실패 시 이벤트 상태를 FAILED로 변경한다.")
+    @Test
+    void marksAsFailed_whenKafkaPublishFails() throws Exception {
+        // arrange
+        OutboxEvent event = createPendingEvent("event-1", "order-events", "1");
+        List<OutboxEvent> pendingEvents = List.of(event);
+
+        when(outboxEventRepository.findPendingEvents(100)).thenReturn(pendingEvents);
+        when(objectMapper.readValue(anyString(), eq(Object.class)))
+            .thenReturn(Map.of("orderId", 1));
+        when(kafkaTemplate.send(anyString(), any(Message.class)))
+            .thenThrow(new RuntimeException("Kafka 발행 실패"));
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        outboxEventPublisher.publishPendingEvents();
+
+        // assert
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository).save(captor.capture());
+        
+        OutboxEvent savedEvent = captor.getValue();
+        assertThat(savedEvent.getStatus()).isEqualTo(OutboxEvent.OutboxStatus.FAILED);
+        assertThat(savedEvent.getPublishedAt()).isNull();
+    }
+
+    @DisplayName("JSON 역직렬화 실패 시 이벤트 상태를 FAILED로 변경한다.")
+    @Test
+    void marksAsFailed_whenJsonDeserializationFails() throws Exception {
+        // arrange
+        OutboxEvent event = createPendingEvent("event-1", "order-events", "1");
+        List<OutboxEvent> pendingEvents = List.of(event);
+
+        when(outboxEventRepository.findPendingEvents(100)).thenReturn(pendingEvents);
+        when(objectMapper.readValue(anyString(), eq(Object.class)))
+            .thenThrow(new RuntimeException("JSON 역직렬화 실패"));
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        outboxEventPublisher.publishPendingEvents();
+
+        // assert
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository).save(captor.capture());
+        
+        OutboxEvent savedEvent = captor.getValue();
+        assertThat(savedEvent.getStatus()).isEqualTo(OutboxEvent.OutboxStatus.FAILED);
+        verify(kafkaTemplate, never()).send(anyString(), any(Message.class));
+    }
+
+    @DisplayName("배치 크기만큼 이벤트를 조회한다.")
+    @Test
+    void queriesEventsWithBatchSize() {
+        // arrange
+        when(outboxEventRepository.findPendingEvents(100)).thenReturn(List.of());
+
+        // act
+        outboxEventPublisher.publishPendingEvents();
+
+        // assert
+        verify(outboxEventRepository).findPendingEvents(100);
+    }
+
+    @DisplayName("각 토픽에 적절한 파티션 키를 사용하여 Kafka로 발행한다.")
+    @Test
+    void usesCorrectPartitionKeyForEachTopic() throws Exception {
+        // arrange
+        OutboxEvent likeEvent = createPendingEvent("event-1", "like-events", "product-123");
+        OutboxEvent orderEvent = createPendingEvent("event-2", "order-events", "order-456");
+        OutboxEvent productEvent = createPendingEvent("event-3", "product-events", "product-789");
+        List<OutboxEvent> pendingEvents = List.of(likeEvent, orderEvent, productEvent);
+
+        when(outboxEventRepository.findPendingEvents(100)).thenReturn(pendingEvents);
+        when(objectMapper.readValue(anyString(), eq(Object.class)))
+            .thenReturn(Map.of("productId", 123));
+        when(kafkaTemplate.send(anyString(), any(Message.class)))
+            .thenReturn(createSuccessFuture());
+        when(outboxEventRepository.save(any(OutboxEvent.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        outboxEventPublisher.publishPendingEvents();
+
+        // assert - 각 토픽에 올바른 파티션 키가 전달되는지 검증
+        ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        
+        verify(kafkaTemplate, times(3)).send(
+            topicCaptor.capture(), 
+            messageCaptor.capture()
+        );
+        
+        List<String> topics = topicCaptor.getAllValues();
+        List<Message> messages = messageCaptor.getAllValues();
+        
+        // like-events는 productId를 파티션 키로 사용
+        int likeIndex = topics.indexOf("like-events");
+        assertThat(likeIndex).isNotEqualTo(-1);
+        assertThat(messages.get(likeIndex).getHeaders().get(KafkaHeaders.KEY))
+            .isEqualTo("product-123");
+        
+        // order-events는 orderId를 파티션 키로 사용
+        int orderIndex = topics.indexOf("order-events");
+        assertThat(orderIndex).isNotEqualTo(-1);
+        assertThat(messages.get(orderIndex).getHeaders().get(KafkaHeaders.KEY))
+            .isEqualTo("order-456");
+        
+        // product-events는 productId를 파티션 키로 사용
+        int productIndex = topics.indexOf("product-events");
+        assertThat(productIndex).isNotEqualTo(-1);
+        assertThat(messages.get(productIndex).getHeaders().get(KafkaHeaders.KEY))
+            .isEqualTo("product-789");
+    }
+
+    /**
+     * PENDING 상태의 OutboxEvent를 생성합니다.
+     */
+    private OutboxEvent createPendingEvent(String eventId, String topic, String partitionKey) {
+        return OutboxEvent.builder()
+            .eventId(eventId)
+            .eventType("OrderCreated")
+            .aggregateId("1")
+            .aggregateType("Order")
+            .payload("{\"orderId\":1}")
+            .topic(topic)
+            .partitionKey(partitionKey)
+            .build();
+    }
+
+    /**
+     * Kafka 발행 성공을 시뮬레이션하는 CompletableFuture를 생성합니다.
+     */
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<SendResult<String, Object>> createSuccessFuture() {
+        return (CompletableFuture<SendResult<String, Object>>) (CompletableFuture<?>) 
+            CompletableFuture.completedFuture(null);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/eventhandled/EventHandledService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/eventhandled/EventHandledService.java
@@ -1,0 +1,64 @@
+package com.loopers.application.eventhandled;
+
+import com.loopers.domain.eventhandled.EventHandled;
+import com.loopers.domain.eventhandled.EventHandledRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이벤트 처리 기록 서비스.
+ * <p>
+ * Kafka Consumer에서 이벤트의 멱등성을 보장하기 위한 서비스입니다.
+ * 이벤트 처리 전 `eventId`가 이미 처리되었는지 확인하고,
+ * 처리되지 않은 경우에만 처리 기록을 저장합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventHandledService {
+
+    private final EventHandledRepository eventHandledRepository;
+
+    /**
+     * 이벤트가 이미 처리되었는지 확인합니다.
+     *
+     * @param eventId 이벤트 ID
+     * @return 이미 처리된 경우 true, 그렇지 않으면 false
+     */
+    @Transactional(readOnly = true)
+    public boolean isAlreadyHandled(String eventId) {
+        return eventHandledRepository.existsByEventId(eventId);
+    }
+
+    /**
+     * 이벤트 처리 기록을 저장합니다.
+     * <p>
+     * UNIQUE 제약조건 위반 시 예외를 발생시킵니다.
+     * 이는 동시성 상황에서 중복 처리를 방지하기 위한 것입니다.
+     * </p>
+     *
+     * @param eventId 이벤트 ID
+     * @param eventType 이벤트 타입 (예: "LikeAdded", "OrderCreated")
+     * @param topic Kafka 토픽 이름
+     * @throws org.springframework.dao.DataIntegrityViolationException 이미 처리된 이벤트인 경우
+     */
+    @Transactional
+    public void markAsHandled(String eventId, String eventType, String topic) {
+        try {
+            EventHandled eventHandled = new EventHandled(eventId, eventType, topic);
+            eventHandledRepository.save(eventHandled);
+            log.debug("이벤트 처리 기록 저장: eventId={}, eventType={}, topic={}", 
+                eventId, eventType, topic);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            // UNIQUE 제약조건 위반 = 이미 처리됨 (멱등성 보장)
+            log.warn("이벤트가 이미 처리되었습니다: eventId={}", eventId);
+            throw e;
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java
@@ -1,0 +1,165 @@
+package com.loopers.application.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 상품 메트릭 집계 서비스.
+ * <p>
+ * Kafka Consumer에서 이벤트를 수취하여 상품 메트릭을 집계합니다.
+ * 좋아요 수, 판매량, 상세 페이지 조회 수 등을 upsert합니다.
+ * </p>
+ * <p>
+ * <b>도메인 분리 근거:</b>
+ * <ul>
+ *   <li>외부 시스템(데이터 플랫폼, 분석 시스템)을 위한 메트릭 집계</li>
+ *   <li>Product 도메인의 핵심 비즈니스 로직과는 분리된 관심사</li>
+ *   <li>Kafka Consumer를 통한 이벤트 기반 집계</li>
+ * </ul>
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductMetricsService {
+
+    private final ProductMetricsRepository productMetricsRepository;
+
+    /**
+     * 좋아요 수를 증가시킵니다.
+     * <p>
+     * 이벤트의 버전을 기준으로 최신 이벤트만 반영합니다.
+     * </p>
+     *
+     * @param productId 상품 ID
+     * @param eventVersion 이벤트의 버전
+     */
+    @Transactional
+    public void incrementLikeCount(Long productId, Long eventVersion) {
+        ProductMetrics metrics = findOrCreate(productId);
+        
+        // 버전 비교: 이벤트가 최신이 아니면 스킵
+        if (!metrics.shouldUpdate(eventVersion)) {
+            log.debug("오래된 이벤트 스킵: productId={}, eventVersion={}, metricsVersion={}", 
+                productId, eventVersion, metrics.getVersion());
+            return;
+        }
+        
+        metrics.incrementLikeCount();
+        productMetricsRepository.save(metrics);
+        log.debug("좋아요 수 증가: productId={}, likeCount={}", productId, metrics.getLikeCount());
+    }
+
+    /**
+     * 좋아요 수를 감소시킵니다.
+     * <p>
+     * 이벤트의 버전을 기준으로 최신 이벤트만 반영합니다.
+     * </p>
+     *
+     * @param productId 상품 ID
+     * @param eventVersion 이벤트의 버전
+     */
+    @Transactional
+    public void decrementLikeCount(Long productId, Long eventVersion) {
+        ProductMetrics metrics = findOrCreate(productId);
+        
+        // 버전 비교: 이벤트가 최신이 아니면 스킵
+        if (!metrics.shouldUpdate(eventVersion)) {
+            log.debug("오래된 이벤트 스킵: productId={}, eventVersion={}, metricsVersion={}", 
+                productId, eventVersion, metrics.getVersion());
+            return;
+        }
+        
+        metrics.decrementLikeCount();
+        productMetricsRepository.save(metrics);
+        log.debug("좋아요 수 감소: productId={}, likeCount={}", productId, metrics.getLikeCount());
+    }
+
+    /**
+     * 판매량을 증가시킵니다.
+     * <p>
+     * 이벤트의 버전을 기준으로 최신 이벤트만 반영합니다.
+     * </p>
+     *
+     * @param productId 상품 ID
+     * @param quantity 판매 수량
+     * @param eventVersion 이벤트의 버전
+     */
+    @Transactional
+    public void incrementSalesCount(Long productId, Integer quantity, Long eventVersion) {
+        ProductMetrics metrics = findOrCreate(productId);
+        
+        // 버전 비교: 이벤트가 최신이 아니면 스킵
+        if (!metrics.shouldUpdate(eventVersion)) {
+            log.debug("오래된 이벤트 스킵: productId={}, eventVersion={}, metricsVersion={}", 
+                productId, eventVersion, metrics.getVersion());
+            return;
+        }
+        
+        metrics.incrementSalesCount(quantity);
+        productMetricsRepository.save(metrics);
+        log.debug("판매량 증가: productId={}, quantity={}, salesCount={}", 
+            productId, quantity, metrics.getSalesCount());
+    }
+
+    /**
+     * 상세 페이지 조회 수를 증가시킵니다.
+     * <p>
+     * 이벤트의 버전을 기준으로 최신 이벤트만 반영합니다.
+     * </p>
+     *
+     * @param productId 상품 ID
+     * @param eventVersion 이벤트의 버전
+     */
+    @Transactional
+    public void incrementViewCount(Long productId, Long eventVersion) {
+        ProductMetrics metrics = findOrCreate(productId);
+        
+        // 버전 비교: 이벤트가 최신이 아니면 스킵
+        if (!metrics.shouldUpdate(eventVersion)) {
+            log.debug("오래된 이벤트 스킵: productId={}, eventVersion={}, metricsVersion={}", 
+                productId, eventVersion, metrics.getVersion());
+            return;
+        }
+        
+        metrics.incrementViewCount();
+        productMetricsRepository.save(metrics);
+        log.debug("조회 수 증가: productId={}, viewCount={}", productId, metrics.getViewCount());
+    }
+
+    /**
+     * 상품 메트릭을 조회하거나 없으면 생성합니다.
+     * <p>
+     * 비관적 락을 사용하여 동시성 제어를 보장합니다.
+     * 신규 생성 시 동시 삽입으로 인한 unique constraint violation을 처리합니다.
+     * </p>
+     *
+     * @param productId 상품 ID
+     * @return ProductMetrics 인스턴스
+     */
+    private ProductMetrics findOrCreate(Long productId) {
+        return productMetricsRepository
+            .findByProductIdForUpdate(productId)
+            .orElseGet(() -> {
+                try {
+                    ProductMetrics newMetrics = new ProductMetrics(productId);
+                    return productMetricsRepository.save(newMetrics);
+                } catch (DataIntegrityViolationException e) {
+                    // 동시 삽입 시 재조회
+                    log.debug("동시 삽입 감지, 재조회: productId={}", productId);
+                    return productMetricsRepository
+                        .findByProductIdForUpdate(productId)
+                        .orElseThrow(() -> new IllegalStateException(
+                            "ProductMetrics 생성 실패: productId=" + productId));
+                }
+            });
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/event/LikeEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/event/LikeEvent.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.event;
+
+import java.time.LocalDateTime;
+
+/**
+ * 좋아요 이벤트 DTO.
+ * <p>
+ * Kafka에서 수신한 좋아요 이벤트를 파싱하기 위한 DTO입니다.
+ * <b>주의:</b> 이 클래스는 commerce-api의 LikeEvent와 동일한 구조를 가진 DTO입니다.
+ * 향후 공유 모듈로 분리하는 것을 고려해야 합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+public class LikeEvent {
+
+    /**
+     * 좋아요 추가 이벤트.
+     */
+    public record LikeAdded(
+            Long userId,
+            Long productId,
+            LocalDateTime occurredAt
+    ) {
+    }
+
+    /**
+     * 좋아요 취소 이벤트.
+     */
+    public record LikeRemoved(
+            Long userId,
+            Long productId,
+            LocalDateTime occurredAt
+    ) {
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/event/OrderEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/event/OrderEvent.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 주문 이벤트 DTO.
+ * <p>
+ * Kafka에서 수신한 주문 이벤트를 파싱하기 위한 DTO입니다.
+ * <b>주의:</b> 이 클래스는 commerce-api의 OrderEvent와 동일한 구조를 가진 DTO입니다.
+ * 향후 공유 모듈로 분리하는 것을 고려해야 합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+public class OrderEvent {
+
+    /**
+     * 주문 생성 이벤트.
+     */
+    public record OrderCreated(
+            Long orderId,
+            Long userId,
+            String couponCode,
+            Integer subtotal,
+            Long usedPointAmount,
+            List<OrderItemInfo> orderItems,
+            LocalDateTime createdAt
+    ) {
+        /**
+         * 주문 아이템 정보.
+         */
+        public record OrderItemInfo(
+                Long productId,
+                Integer quantity
+        ) {
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/event/ProductEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/event/ProductEvent.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.event;
+
+import java.time.LocalDateTime;
+
+/**
+ * 상품 이벤트 DTO.
+ * <p>
+ * Kafka에서 수신한 상품 이벤트를 파싱하기 위한 DTO입니다.
+ * <b>주의:</b> 이 클래스는 commerce-api의 ProductEvent와 동일한 구조를 가진 DTO입니다.
+ * 향후 공유 모듈로 분리하는 것을 고려해야 합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+public class ProductEvent {
+
+    /**
+     * 상품 상세 페이지 조회 이벤트.
+     */
+    public record ProductViewed(
+            Long productId,
+            Long userId,
+            LocalDateTime occurredAt
+    ) {
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandled.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandled.java
@@ -1,0 +1,62 @@
+package com.loopers.domain.eventhandled;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이벤트 처리 기록 엔티티.
+ * <p>
+ * Kafka Consumer에서 처리한 이벤트의 멱등성을 보장하기 위한 엔티티입니다.
+ * `eventId`를 Primary Key로 사용하여 중복 처리를 방지합니다.
+ * </p>
+ * <p>
+ * <b>멱등성 보장:</b>
+ * <ul>
+ *   <li>동일한 `eventId`를 가진 이벤트는 한 번만 처리됩니다</li>
+ *   <li>UNIQUE 제약조건으로 데이터베이스 레벨에서 중복 방지</li>
+ *   <li>이벤트 처리 전 `eventId` 존재 여부를 확인하여 중복 처리 방지</li>
+ * </ul>
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Entity
+@Table(name = "event_handled", indexes = {
+    @Index(name = "idx_handled_at", columnList = "handled_at")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class EventHandled {
+
+    @Id
+    @Column(name = "event_id", nullable = false, length = 255)
+    private String eventId;
+
+    @Column(name = "event_type", nullable = false, length = 100)
+    private String eventType;
+
+    @Column(name = "topic", nullable = false, length = 255)
+    private String topic;
+
+    @Column(name = "handled_at", nullable = false)
+    private LocalDateTime handledAt;
+
+    /**
+     * EventHandled 인스턴스를 생성합니다.
+     *
+     * @param eventId 이벤트 ID (UUID)
+     * @param eventType 이벤트 타입 (예: "LikeAdded", "OrderCreated")
+     * @param topic Kafka 토픽 이름
+     */
+    public EventHandled(String eventId, String eventType, String topic) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.topic = topic;
+        this.handledAt = LocalDateTime.now();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandledRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandledRepository.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.eventhandled;
+
+import java.util.Optional;
+
+/**
+ * EventHandled 엔티티에 대한 저장소 인터페이스.
+ * <p>
+ * 이벤트 처리 기록의 영속성 계층과의 상호작용을 정의합니다.
+ * DIP를 준수하여 도메인 레이어에서 인터페이스를 정의합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+public interface EventHandledRepository {
+
+    /**
+     * 이벤트 처리 기록을 저장합니다.
+     *
+     * @param eventHandled 저장할 이벤트 처리 기록
+     * @return 저장된 이벤트 처리 기록
+     */
+    EventHandled save(EventHandled eventHandled);
+
+    /**
+     * 이벤트 ID로 처리 기록을 조회합니다.
+     *
+     * @param eventId 이벤트 ID
+     * @return 조회된 처리 기록을 담은 Optional
+     */
+    Optional<EventHandled> findByEventId(String eventId);
+
+    /**
+     * 이벤트 ID가 이미 처리되었는지 확인합니다.
+     *
+     * @param eventId 이벤트 ID
+     * @return 이미 처리된 경우 true, 그렇지 않으면 false
+     */
+    boolean existsByEventId(String eventId);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -1,0 +1,127 @@
+package com.loopers.domain.metrics;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 상품 메트릭 집계 엔티티.
+ * <p>
+ * Kafka Consumer에서 이벤트를 수취하여 집계한 메트릭을 저장합니다.
+ * 좋아요 수, 판매량, 상세 페이지 조회 수 등을 관리합니다.
+ * </p>
+ * <p>
+ * <b>도메인 분리 근거:</b>
+ * <ul>
+ *   <li>외부 시스템(데이터 플랫폼, 분석 시스템)을 위한 메트릭 집계</li>
+ *   <li>Product 도메인의 핵심 비즈니스 로직과는 분리된 관심사</li>
+ *   <li>Kafka Consumer를 통한 이벤트 기반 집계</li>
+ * </ul>
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Entity
+@Table(name = "product_metrics")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ProductMetrics {
+
+    @Id
+    @Column(name = "product_id")
+    private Long productId;
+
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount;
+
+    @Column(name = "sales_count", nullable = false)
+    private Long salesCount;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    @Column(name = "version", nullable = false)
+    private Long version;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /**
+     * ProductMetrics 인스턴스를 생성합니다.
+     *
+     * @param productId 상품 ID
+     */
+    public ProductMetrics(Long productId) {
+        this.productId = productId;
+        this.likeCount = 0L;
+        this.salesCount = 0L;
+        this.viewCount = 0L;
+        this.version = 0L;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 좋아요 수를 증가시킵니다.
+     */
+    public void incrementLikeCount() {
+        this.likeCount++;
+        this.version++;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 좋아요 수를 감소시킵니다.
+     */
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+            this.version++;
+            this.updatedAt = LocalDateTime.now();
+        }
+    }
+
+    /**
+     * 판매량을 증가시킵니다.
+     *
+     * @param quantity 판매 수량
+     */
+    public void incrementSalesCount(Integer quantity) {
+        if (quantity != null && quantity > 0) {
+            this.salesCount += quantity;
+            this.version++;
+            this.updatedAt = LocalDateTime.now();
+        }
+    }
+
+    /**
+     * 상세 페이지 조회 수를 증가시킵니다.
+     */
+    public void incrementViewCount() {
+        this.viewCount++;
+        this.version++;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 이벤트의 버전을 기준으로 메트릭을 업데이트해야 하는지 확인합니다.
+     * <p>
+     * 이벤트의 `version`이 메트릭의 `version`보다 크면 업데이트합니다.
+     * 이를 통해 오래된 이벤트가 최신 메트릭을 덮어쓰는 것을 방지합니다.
+     * </p>
+     *
+     * @param eventVersion 이벤트의 버전
+     * @return 업데이트해야 하면 true, 그렇지 않으면 false
+     */
+    public boolean shouldUpdate(Long eventVersion) {
+        if (eventVersion == null) {
+            // 이벤트에 버전 정보가 없으면 업데이트 (하위 호환성)
+            return true;
+        }
+        // 이벤트 버전이 메트릭 버전보다 크면 업데이트
+        return eventVersion > this.version;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
@@ -1,0 +1,58 @@
+package com.loopers.domain.metrics;
+
+import java.util.Optional;
+
+/**
+ * ProductMetrics 엔티티에 대한 저장소 인터페이스.
+ * <p>
+ * 상품 메트릭 집계 데이터의 영속성 계층과의 상호작용을 정의합니다.
+ * DIP를 준수하여 도메인 레이어에서 인터페이스를 정의합니다.
+ * </p>
+ * <p>
+ * <b>도메인 분리 근거:</b>
+ * <ul>
+ *   <li>Metric 도메인은 외부 시스템 연동을 위한 별도 관심사</li>
+ *   <li>Product 도메인의 핵심 비즈니스 로직과는 분리</li>
+ * </ul>
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+public interface ProductMetricsRepository {
+
+    /**
+     * 상품 메트릭을 저장합니다.
+     *
+     * @param productMetrics 저장할 상품 메트릭
+     * @return 저장된 상품 메트릭
+     */
+    ProductMetrics save(ProductMetrics productMetrics);
+
+    /**
+     * 상품 ID로 메트릭을 조회합니다.
+     *
+     * @param productId 상품 ID
+     * @return 조회된 메트릭을 담은 Optional
+     */
+    Optional<ProductMetrics> findByProductId(Long productId);
+
+    /**
+     * 상품 ID로 메트릭을 조회합니다. (비관적 락)
+     * <p>
+     * Upsert 시 동시성 제어를 위해 사용합니다.
+     * </p>
+     * <p>
+     * <b>Lock 전략:</b>
+     * <ul>
+     *   <li><b>PESSIMISTIC_WRITE:</b> SELECT ... FOR UPDATE 사용</li>
+     *   <li><b>Lock 범위:</b> PK(productId) 기반 조회로 해당 행만 락 (최소화)</li>
+     *   <li><b>사용 목적:</b> 메트릭 집계 시 Lost Update 방지</li>
+     * </ul>
+     * </p>
+     *
+     * @param productId 상품 ID
+     * @return 조회된 메트릭을 담은 Optional
+     */
+    Optional<ProductMetrics> findByProductIdForUpdate(Long productId);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledJpaRepository.java
@@ -1,0 +1,31 @@
+package com.loopers.infrastructure.eventhandled;
+
+import com.loopers.domain.eventhandled.EventHandled;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * EventHandled 엔티티에 대한 JPA Repository.
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+public interface EventHandledJpaRepository extends JpaRepository<EventHandled, String> {
+
+    /**
+     * 이벤트 ID로 처리 기록을 조회합니다.
+     *
+     * @param eventId 이벤트 ID
+     * @return 조회된 처리 기록을 담은 Optional
+     */
+    Optional<EventHandled> findByEventId(String eventId);
+
+    /**
+     * 이벤트 ID가 이미 처리되었는지 확인합니다.
+     *
+     * @param eventId 이벤트 ID
+     * @return 이미 처리된 경우 true, 그렇지 않으면 false
+     */
+    boolean existsByEventId(String eventId);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.loopers.infrastructure.eventhandled;
+
+import com.loopers.domain.eventhandled.EventHandled;
+import com.loopers.domain.eventhandled.EventHandledRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * EventHandledRepository의 구현체.
+ * <p>
+ * JPA를 사용하여 EventHandled 엔티티의 영속성을 관리합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Repository
+@RequiredArgsConstructor
+public class EventHandledRepositoryImpl implements EventHandledRepository {
+
+    private final EventHandledJpaRepository jpaRepository;
+
+    @Override
+    public EventHandled save(EventHandled eventHandled) {
+        return jpaRepository.save(eventHandled);
+    }
+
+    @Override
+    public Optional<EventHandled> findByEventId(String eventId) {
+        return jpaRepository.findByEventId(eventId);
+    }
+
+    @Override
+    public boolean existsByEventId(String eventId) {
+        return jpaRepository.existsByEventId(eventId);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -1,0 +1,40 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+
+/**
+ * ProductMetrics JPA Repository.
+ * <p>
+ * 상품 메트릭 집계 데이터를 관리합니다.
+ * </p>
+ */
+public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
+
+    /**
+     * 상품 ID로 메트릭을 조회합니다.
+     *
+     * @param productId 상품 ID
+     * @return 조회된 메트릭을 담은 Optional
+     */
+    Optional<ProductMetrics> findByProductId(Long productId);
+
+    /**
+     * 상품 ID로 메트릭을 조회합니다. (비관적 락)
+     * <p>
+     * Upsert 시 동시성 제어를 위해 사용합니다.
+     * </p>
+     *
+     * @param productId 상품 ID
+     * @return 조회된 메트릭을 담은 Optional
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT pm FROM ProductMetrics pm WHERE pm.productId = :productId")
+    Optional<ProductMetrics> findByProductIdForUpdate(@Param("productId") Long productId);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * ProductMetricsRepository의 JPA 구현체.
+ * <p>
+ * Spring Data JPA를 활용하여 ProductMetrics 엔티티의
+ * 영속성 작업을 처리합니다.
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Component
+@RequiredArgsConstructor
+public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
+
+    private final ProductMetricsJpaRepository productMetricsJpaRepository;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProductMetrics save(ProductMetrics productMetrics) {
+        return productMetricsJpaRepository.save(productMetrics);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<ProductMetrics> findByProductId(Long productId) {
+        return productMetricsJpaRepository.findByProductId(productId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<ProductMetrics> findByProductIdForUpdate(Long productId) {
+        return productMetricsJpaRepository.findByProductIdForUpdate(productId);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ProductMetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ProductMetricsConsumer.java
@@ -1,0 +1,430 @@
+package com.loopers.interfaces.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.eventhandled.EventHandledService;
+import com.loopers.application.metrics.ProductMetricsService;
+import com.loopers.confg.kafka.KafkaConfig;
+import com.loopers.domain.event.LikeEvent;
+import com.loopers.domain.event.OrderEvent;
+import com.loopers.domain.event.ProductEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * 상품 메트릭 집계 Kafka Consumer.
+ * <p>
+ * Kafka에서 이벤트를 수취하여 상품 메트릭을 집계합니다.
+ * 좋아요 수, 판매량, 상세 페이지 조회 수 등을 `product_metrics` 테이블에 upsert합니다.
+ * </p>
+ * <p>
+ * <b>처리 이벤트:</b>
+ * <ul>
+ *   <li><b>like-events:</b> LikeAdded, LikeRemoved (좋아요 수 집계)</li>
+ *   <li><b>order-events:</b> OrderCreated (판매량 집계)</li>
+ *   <li><b>product-events:</b> ProductViewed (조회 수 집계)</li>
+ * </ul>
+ * </p>
+ * <p>
+ * <b>Manual Ack:</b>
+ * <ul>
+ *   <li>이벤트 처리 성공 후 수동으로 커밋하여 At Most Once 보장</li>
+ *   <li>에러 발생 시 커밋하지 않아 재처리 가능</li>
+ * </ul>
+ * </p>
+ *
+ * @author Loopers
+ * @version 1.0
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductMetricsConsumer {
+
+    private final ProductMetricsService productMetricsService;
+    private final EventHandledService eventHandledService;
+    private final ObjectMapper objectMapper;
+
+    private static final String EVENT_ID_HEADER = "eventId";
+    private static final String EVENT_TYPE_HEADER = "eventType";
+    private static final String VERSION_HEADER = "version";
+
+    /**
+     * like-events 토픽을 구독하여 좋아요 수를 집계합니다.
+     * <p>
+     * <b>멱등성 처리:</b>
+     * <ul>
+     *   <li>Kafka 메시지 헤더에서 `eventId`를 추출</li>
+     *   <li>이미 처리된 이벤트는 스킵하여 중복 처리 방지</li>
+     *   <li>처리 후 `event_handled` 테이블에 기록</li>
+     * </ul>
+     * </p>
+     *
+     * @param records Kafka 메시지 레코드 목록
+     * @param acknowledgment 수동 커밋을 위한 Acknowledgment
+     */
+    @KafkaListener(
+        topics = "like-events",
+        containerFactory = KafkaConfig.BATCH_LISTENER
+    )
+    public void consumeLikeEvents(
+        List<ConsumerRecord<String, Object>> records,
+        Acknowledgment acknowledgment
+    ) {
+        try {
+            for (ConsumerRecord<String, Object> record : records) {
+                try {
+                    String eventId = extractEventId(record);
+                    if (eventId == null) {
+                        log.warn("eventId가 없는 메시지는 건너뜁니다: offset={}, partition={}", 
+                            record.offset(), record.partition());
+                        continue;
+                    }
+
+                    // 멱등성 체크: 이미 처리된 이벤트는 스킵
+                    if (eventHandledService.isAlreadyHandled(eventId)) {
+                        log.debug("이미 처리된 이벤트 스킵: eventId={}", eventId);
+                        continue;
+                    }
+
+                    Object value = record.value();
+                    String eventType;
+                    
+                    // 버전 추출 (헤더에서)
+                    Long eventVersion = extractVersion(record);
+                    
+                    // Spring Kafka가 자동으로 역직렬화한 경우
+                    if (value instanceof LikeEvent.LikeAdded) {
+                        LikeEvent.LikeAdded event = (LikeEvent.LikeAdded) value;
+                        productMetricsService.incrementLikeCount(
+                            event.productId(), 
+                            eventVersion
+                        );
+                        eventType = "LikeAdded";
+                    } else if (value instanceof LikeEvent.LikeRemoved) {
+                        LikeEvent.LikeRemoved event = (LikeEvent.LikeRemoved) value;
+                        productMetricsService.decrementLikeCount(
+                            event.productId(), 
+                            eventVersion
+                        );
+                        eventType = "LikeRemoved";
+                    } else {
+                        // JSON 문자열인 경우 이벤트 타입 헤더로 구분
+                        String eventTypeHeader = extractEventType(record);
+                        if ("LikeRemoved".equals(eventTypeHeader)) {
+                            LikeEvent.LikeRemoved event = parseLikeRemovedEvent(value);
+                            productMetricsService.decrementLikeCount(
+                                event.productId(), 
+                                eventVersion
+                            );
+                            eventType = "LikeRemoved";
+                        } else {
+                            // 기본값은 LikeAdded
+                            LikeEvent.LikeAdded event = parseLikeEvent(value);
+                            productMetricsService.incrementLikeCount(
+                                event.productId(), 
+                                eventVersion
+                            );
+                            eventType = "LikeAdded";
+                        }
+                    }
+
+                    // 이벤트 처리 기록 저장
+                    eventHandledService.markAsHandled(eventId, eventType, "like-events");
+                } catch (org.springframework.dao.DataIntegrityViolationException e) {
+                    // UNIQUE 제약조건 위반 = 동시성 상황에서 이미 처리됨 (정상)
+                    log.debug("동시성 상황에서 이미 처리된 이벤트: offset={}, partition={}", 
+                        record.offset(), record.partition());
+                } catch (Exception e) {
+                    log.error("좋아요 이벤트 처리 실패: offset={}, partition={}", 
+                        record.offset(), record.partition(), e);
+                    // 개별 이벤트 처리 실패는 로그만 기록하고 계속 진행
+                }
+            }
+            
+            // 모든 이벤트 처리 완료 후 수동 커밋
+            acknowledgment.acknowledge();
+            log.debug("좋아요 이벤트 처리 완료: count={}", records.size());
+        } catch (Exception e) {
+            log.error("좋아요 이벤트 배치 처리 실패: count={}", records.size(), e);
+            // 에러 발생 시 커밋하지 않음 (재처리 가능)
+            throw e;
+        }
+    }
+
+    /**
+     * order-events 토픽을 구독하여 판매량을 집계합니다.
+     * <p>
+     * <b>멱등성 처리:</b>
+     * <ul>
+     *   <li>Kafka 메시지 헤더에서 `eventId`를 추출</li>
+     *   <li>이미 처리된 이벤트는 스킵하여 중복 처리 방지</li>
+     *   <li>처리 후 `event_handled` 테이블에 기록</li>
+     * </ul>
+     * </p>
+     *
+     * @param records Kafka 메시지 레코드 목록
+     * @param acknowledgment 수동 커밋을 위한 Acknowledgment
+     */
+    @KafkaListener(
+        topics = "order-events",
+        containerFactory = KafkaConfig.BATCH_LISTENER
+    )
+    public void consumeOrderEvents(
+        List<ConsumerRecord<String, Object>> records,
+        Acknowledgment acknowledgment
+    ) {
+        try {
+            for (ConsumerRecord<String, Object> record : records) {
+                try {
+                    String eventId = extractEventId(record);
+                    if (eventId == null) {
+                        log.warn("eventId가 없는 메시지는 건너뜁니다: offset={}, partition={}", 
+                            record.offset(), record.partition());
+                        continue;
+                    }
+
+                    // 멱등성 체크: 이미 처리된 이벤트는 스킵
+                    if (eventHandledService.isAlreadyHandled(eventId)) {
+                        log.debug("이미 처리된 이벤트 스킵: eventId={}", eventId);
+                        continue;
+                    }
+
+                    Object value = record.value();
+                    OrderEvent.OrderCreated event = parseOrderCreatedEvent(value);
+                    
+                    // 버전 추출 (헤더에서)
+                    Long eventVersion = extractVersion(record);
+                    
+                    // 주문 아이템별로 판매량 집계
+                    for (OrderEvent.OrderCreated.OrderItemInfo item : event.orderItems()) {
+                        productMetricsService.incrementSalesCount(
+                            item.productId(),
+                            item.quantity(),
+                            eventVersion
+                        );
+                    }
+
+                    // 이벤트 처리 기록 저장
+                    eventHandledService.markAsHandled(eventId, "OrderCreated", "order-events");
+                } catch (org.springframework.dao.DataIntegrityViolationException e) {
+                    // UNIQUE 제약조건 위반 = 동시성 상황에서 이미 처리됨 (정상)
+                    log.debug("동시성 상황에서 이미 처리된 이벤트: offset={}, partition={}", 
+                        record.offset(), record.partition());
+                } catch (Exception e) {
+                    log.error("주문 이벤트 처리 실패: offset={}, partition={}", 
+                        record.offset(), record.partition(), e);
+                    // 개별 이벤트 처리 실패는 로그만 기록하고 계속 진행
+                }
+            }
+            
+            // 모든 이벤트 처리 완료 후 수동 커밋
+            acknowledgment.acknowledge();
+            log.debug("주문 이벤트 처리 완료: count={}", records.size());
+        } catch (Exception e) {
+            log.error("주문 이벤트 배치 처리 실패: count={}", records.size(), e);
+            // 에러 발생 시 커밋하지 않음 (재처리 가능)
+            throw e;
+        }
+    }
+
+    /**
+     * Kafka 메시지 값을 LikeAdded 이벤트로 파싱합니다.
+     *
+     * @param value Kafka 메시지 값
+     * @return 파싱된 LikeAdded 이벤트
+     */
+    private LikeEvent.LikeAdded parseLikeEvent(Object value) {
+        try {
+            // JSON 문자열인 경우 파싱
+            String json = value instanceof String ? (String) value : objectMapper.writeValueAsString(value);
+            return objectMapper.readValue(json, LikeEvent.LikeAdded.class);
+        } catch (Exception e) {
+            throw new RuntimeException("LikeAdded 이벤트 파싱 실패", e);
+        }
+    }
+
+    /**
+     * Kafka 메시지 값을 LikeRemoved 이벤트로 파싱합니다.
+     *
+     * @param value Kafka 메시지 값
+     * @return 파싱된 LikeRemoved 이벤트
+     */
+    private LikeEvent.LikeRemoved parseLikeRemovedEvent(Object value) {
+        try {
+            // JSON 문자열인 경우 파싱
+            String json = value instanceof String ? (String) value : objectMapper.writeValueAsString(value);
+            return objectMapper.readValue(json, LikeEvent.LikeRemoved.class);
+        } catch (Exception e) {
+            throw new RuntimeException("LikeRemoved 이벤트 파싱 실패", e);
+        }
+    }
+
+    /**
+     * product-events 토픽을 구독하여 조회 수를 집계합니다.
+     * <p>
+     * <b>멱등성 처리:</b>
+     * <ul>
+     *   <li>Kafka 메시지 헤더에서 `eventId`를 추출</li>
+     *   <li>이미 처리된 이벤트는 스킵하여 중복 처리 방지</li>
+     *   <li>처리 후 `event_handled` 테이블에 기록</li>
+     * </ul>
+     * </p>
+     *
+     * @param records Kafka 메시지 레코드 목록
+     * @param acknowledgment 수동 커밋을 위한 Acknowledgment
+     */
+    @KafkaListener(
+        topics = "product-events",
+        containerFactory = KafkaConfig.BATCH_LISTENER
+    )
+    public void consumeProductEvents(
+        List<ConsumerRecord<String, Object>> records,
+        Acknowledgment acknowledgment
+    ) {
+        try {
+            for (ConsumerRecord<String, Object> record : records) {
+                try {
+                    String eventId = extractEventId(record);
+                    if (eventId == null) {
+                        log.warn("eventId가 없는 메시지는 건너뜁니다: offset={}, partition={}", 
+                            record.offset(), record.partition());
+                        continue;
+                    }
+
+                    // 멱등성 체크: 이미 처리된 이벤트는 스킵
+                    if (eventHandledService.isAlreadyHandled(eventId)) {
+                        log.debug("이미 처리된 이벤트 스킵: eventId={}", eventId);
+                        continue;
+                    }
+
+                    Object value = record.value();
+                    ProductEvent.ProductViewed event = parseProductViewedEvent(value);
+                    
+                    // 버전 추출 (헤더에서)
+                    Long eventVersion = extractVersion(record);
+                    
+                    productMetricsService.incrementViewCount(
+                        event.productId(), 
+                        eventVersion
+                    );
+
+                    // 이벤트 처리 기록 저장
+                    eventHandledService.markAsHandled(eventId, "ProductViewed", "product-events");
+                } catch (org.springframework.dao.DataIntegrityViolationException e) {
+                    // UNIQUE 제약조건 위반 = 동시성 상황에서 이미 처리됨 (정상)
+                    log.debug("동시성 상황에서 이미 처리된 이벤트: offset={}, partition={}", 
+                        record.offset(), record.partition());
+                } catch (Exception e) {
+                    log.error("상품 조회 이벤트 처리 실패: offset={}, partition={}", 
+                        record.offset(), record.partition(), e);
+                    // 개별 이벤트 처리 실패는 로그만 기록하고 계속 진행
+                }
+            }
+            
+            // 모든 이벤트 처리 완료 후 수동 커밋
+            acknowledgment.acknowledge();
+            log.debug("상품 조회 이벤트 처리 완료: count={}", records.size());
+        } catch (Exception e) {
+            log.error("상품 조회 이벤트 배치 처리 실패: count={}", records.size(), e);
+            // 에러 발생 시 커밋하지 않음 (재처리 가능)
+            throw e;
+        }
+    }
+
+    /**
+     * Kafka 메시지 값을 OrderCreated 이벤트로 파싱합니다.
+     *
+     * @param value Kafka 메시지 값
+     * @return 파싱된 OrderCreated 이벤트
+     */
+    private OrderEvent.OrderCreated parseOrderCreatedEvent(Object value) {
+        try {
+            if (value instanceof OrderEvent.OrderCreated) {
+                return (OrderEvent.OrderCreated) value;
+            }
+            
+            // JSON 문자열인 경우 파싱
+            String json = value instanceof String ? (String) value : objectMapper.writeValueAsString(value);
+            return objectMapper.readValue(json, OrderEvent.OrderCreated.class);
+        } catch (Exception e) {
+            throw new RuntimeException("OrderCreated 이벤트 파싱 실패", e);
+        }
+    }
+
+    /**
+     * Kafka 메시지 값을 ProductViewed 이벤트로 파싱합니다.
+     *
+     * @param value Kafka 메시지 값
+     * @return 파싱된 ProductViewed 이벤트
+     */
+    private ProductEvent.ProductViewed parseProductViewedEvent(Object value) {
+        try {
+            if (value instanceof ProductEvent.ProductViewed) {
+                return (ProductEvent.ProductViewed) value;
+            }
+            
+            // JSON 문자열인 경우 파싱
+            String json = value instanceof String ? (String) value : objectMapper.writeValueAsString(value);
+            return objectMapper.readValue(json, ProductEvent.ProductViewed.class);
+        } catch (Exception e) {
+            throw new RuntimeException("ProductViewed 이벤트 파싱 실패", e);
+        }
+    }
+
+    /**
+     * Kafka 메시지 헤더에서 eventId를 추출합니다.
+     *
+     * @param record Kafka 메시지 레코드
+     * @return eventId (없으면 null)
+     */
+    private String extractEventId(ConsumerRecord<String, Object> record) {
+        Header header = record.headers().lastHeader(EVENT_ID_HEADER);
+        if (header != null && header.value() != null) {
+            return new String(header.value(), StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+
+    /**
+     * Kafka 메시지 헤더에서 eventType을 추출합니다.
+     *
+     * @param record Kafka 메시지 레코드
+     * @return eventType (없으면 null)
+     */
+    private String extractEventType(ConsumerRecord<String, Object> record) {
+        Header header = record.headers().lastHeader(EVENT_TYPE_HEADER);
+        if (header != null && header.value() != null) {
+            return new String(header.value(), StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+
+    /**
+     * Kafka 메시지 헤더에서 version을 추출합니다.
+     *
+     * @param record Kafka 메시지 레코드
+     * @return version (없으면 null)
+     */
+    private Long extractVersion(ConsumerRecord<String, Object> record) {
+        Header header = record.headers().lastHeader(VERSION_HEADER);
+        if (header != null && header.value() != null) {
+            try {
+                String versionStr = new String(header.value(), StandardCharsets.UTF_8);
+                return Long.parseLong(versionStr);
+            } catch (NumberFormatException e) {
+                log.warn("버전 헤더 파싱 실패: offset={}, partition={}", 
+                    record.offset(), record.partition());
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/application/eventhandled/EventHandledServiceTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/application/eventhandled/EventHandledServiceTest.java
@@ -1,0 +1,96 @@
+package com.loopers.application.eventhandled;
+
+import com.loopers.domain.eventhandled.EventHandled;
+import com.loopers.domain.eventhandled.EventHandledRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * EventHandledService 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class EventHandledServiceTest {
+
+    @Mock
+    private EventHandledRepository eventHandledRepository;
+
+    @InjectMocks
+    private EventHandledService eventHandledService;
+
+    @DisplayName("처리되지 않은 이벤트는 false를 반환한다.")
+    @Test
+    void isAlreadyHandled_returnsFalse_whenNotHandled() {
+        // arrange
+        String eventId = "test-event-id";
+        when(eventHandledRepository.existsByEventId(eventId)).thenReturn(false);
+
+        // act
+        boolean result = eventHandledService.isAlreadyHandled(eventId);
+
+        // assert
+        assertThat(result).isFalse();
+        verify(eventHandledRepository).existsByEventId(eventId);
+    }
+
+    @DisplayName("이미 처리된 이벤트는 true를 반환한다.")
+    @Test
+    void isAlreadyHandled_returnsTrue_whenAlreadyHandled() {
+        // arrange
+        String eventId = "test-event-id";
+        when(eventHandledRepository.existsByEventId(eventId)).thenReturn(true);
+
+        // act
+        boolean result = eventHandledService.isAlreadyHandled(eventId);
+
+        // assert
+        assertThat(result).isTrue();
+        verify(eventHandledRepository).existsByEventId(eventId);
+    }
+
+    @DisplayName("처리되지 않은 이벤트는 정상적으로 저장된다.")
+    @Test
+    void markAsHandled_savesSuccessfully_whenNotHandled() {
+        // arrange
+        String eventId = "test-event-id";
+        String eventType = "LikeAdded";
+        String topic = "like-events";
+        
+        EventHandled savedEventHandled = new EventHandled(eventId, eventType, topic);
+        when(eventHandledRepository.save(any(EventHandled.class))).thenReturn(savedEventHandled);
+
+        // act
+        eventHandledService.markAsHandled(eventId, eventType, topic);
+
+        // assert
+        verify(eventHandledRepository).save(any(EventHandled.class));
+    }
+
+    @DisplayName("이미 처리된 이벤트는 DataIntegrityViolationException을 발생시킨다.")
+    @Test
+    void markAsHandled_throwsException_whenAlreadyHandled() {
+        // arrange
+        String eventId = "test-event-id";
+        String eventType = "LikeAdded";
+        String topic = "like-events";
+        
+        when(eventHandledRepository.save(any(EventHandled.class)))
+            .thenThrow(new DataIntegrityViolationException("UNIQUE constraint violation"));
+
+        // act & assert
+        assertThatThrownBy(() -> 
+            eventHandledService.markAsHandled(eventId, eventType, topic)
+        ).isInstanceOf(DataIntegrityViolationException.class);
+
+        verify(eventHandledRepository).save(any(EventHandled.class));
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/application/metrics/ProductMetricsServiceTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/application/metrics/ProductMetricsServiceTest.java
@@ -1,0 +1,217 @@
+package com.loopers.application.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * ProductMetricsService 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProductMetricsServiceTest {
+
+    @Mock
+    private ProductMetricsRepository productMetricsRepository;
+
+    @InjectMocks
+    private ProductMetricsService productMetricsService;
+
+    @DisplayName("좋아요 수를 증가시킬 수 있다.")
+    @Test
+    void canIncrementLikeCount() {
+        // arrange
+        Long productId = 1L;
+        ProductMetrics existingMetrics = new ProductMetrics(productId);
+        existingMetrics.incrementLikeCount(); // 초기값: 1
+        
+        when(productMetricsRepository.findByProductIdForUpdate(productId))
+            .thenReturn(Optional.of(existingMetrics));
+        when(productMetricsRepository.save(any(ProductMetrics.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        productMetricsService.incrementLikeCount(productId, existingMetrics.getVersion() + 1L);
+
+        // assert
+        assertThat(existingMetrics.getLikeCount()).isEqualTo(2L);
+        verify(productMetricsRepository).findByProductIdForUpdate(productId);
+        verify(productMetricsRepository).save(existingMetrics);
+    }
+
+    @DisplayName("좋아요 수를 감소시킬 수 있다.")
+    @Test
+    void canDecrementLikeCount() {
+        // arrange
+        Long productId = 1L;
+        ProductMetrics existingMetrics = new ProductMetrics(productId);
+        existingMetrics.incrementLikeCount(); // 초기값: 1
+        
+        when(productMetricsRepository.findByProductIdForUpdate(productId))
+            .thenReturn(Optional.of(existingMetrics));
+        when(productMetricsRepository.save(any(ProductMetrics.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        productMetricsService.decrementLikeCount(productId, existingMetrics.getVersion() + 1L);
+
+        // assert
+        assertThat(existingMetrics.getLikeCount()).isEqualTo(0L);
+        verify(productMetricsRepository).findByProductIdForUpdate(productId);
+        verify(productMetricsRepository).save(existingMetrics);
+    }
+
+    @DisplayName("판매량을 증가시킬 수 있다.")
+    @Test
+    void canIncrementSalesCount() {
+        // arrange
+        Long productId = 1L;
+        Integer quantity = 5;
+        ProductMetrics existingMetrics = new ProductMetrics(productId);
+        
+        when(productMetricsRepository.findByProductIdForUpdate(productId))
+            .thenReturn(Optional.of(existingMetrics));
+        when(productMetricsRepository.save(any(ProductMetrics.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        productMetricsService.incrementSalesCount(productId, quantity, existingMetrics.getVersion() + 1L);
+
+        // assert
+        assertThat(existingMetrics.getSalesCount()).isEqualTo(5L);
+        verify(productMetricsRepository).findByProductIdForUpdate(productId);
+        verify(productMetricsRepository).save(existingMetrics);
+    }
+
+    @DisplayName("조회 수를 증가시킬 수 있다.")
+    @Test
+    void canIncrementViewCount() {
+        // arrange
+        Long productId = 1L;
+        ProductMetrics existingMetrics = new ProductMetrics(productId);
+        
+        when(productMetricsRepository.findByProductIdForUpdate(productId))
+            .thenReturn(Optional.of(existingMetrics));
+        when(productMetricsRepository.save(any(ProductMetrics.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        productMetricsService.incrementViewCount(productId, existingMetrics.getVersion() + 1L);
+
+        // assert
+        assertThat(existingMetrics.getViewCount()).isEqualTo(1L);
+        verify(productMetricsRepository).findByProductIdForUpdate(productId);
+        verify(productMetricsRepository).save(existingMetrics);
+    }
+
+    @DisplayName("메트릭이 없으면 새로 생성한다.")
+    @Test
+    void createsNewMetrics_whenNotExists() {
+        // arrange
+        Long productId = 1L;
+        Long eventVersion = 1L; // 새로 생성된 메트릭의 버전(0)보다 큰 버전
+        
+        when(productMetricsRepository.findByProductIdForUpdate(productId))
+            .thenReturn(Optional.empty());
+        when(productMetricsRepository.save(any(ProductMetrics.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        productMetricsService.incrementLikeCount(productId, eventVersion);
+
+        // assert
+        verify(productMetricsRepository).findByProductIdForUpdate(productId);
+        // findOrCreate에서 1번, incrementLikeCount에서 1번 총 2번 호출됨
+        verify(productMetricsRepository, atLeast(1)).save(any(ProductMetrics.class));
+    }
+
+    @DisplayName("판매량 증가 시 null이나 0 이하의 수량은 무시된다.")
+    @Test
+    void ignoresInvalidQuantity_whenIncrementingSalesCount() {
+        // arrange
+        Long productId = 1L;
+        ProductMetrics existingMetrics = new ProductMetrics(productId);
+        Long initialSalesCount = existingMetrics.getSalesCount();
+        Long initialVersion = existingMetrics.getVersion();
+        
+        when(productMetricsRepository.findByProductIdForUpdate(productId))
+            .thenReturn(Optional.of(existingMetrics));
+        when(productMetricsRepository.save(any(ProductMetrics.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        productMetricsService.incrementSalesCount(productId, null, existingMetrics.getVersion() + 1L);
+        productMetricsService.incrementSalesCount(productId, 0, existingMetrics.getVersion() + 1L);
+        productMetricsService.incrementSalesCount(productId, -1, existingMetrics.getVersion() + 1L);
+
+        // assert
+        // 유효하지 않은 수량은 무시되므로 값이 변경되지 않음
+        assertThat(existingMetrics.getSalesCount()).isEqualTo(initialSalesCount);
+        assertThat(existingMetrics.getVersion()).isEqualTo(initialVersion);
+        // save()는 호출되지만 메트릭 값은 변경되지 않음
+        verify(productMetricsRepository, times(3)).findByProductIdForUpdate(productId);
+        verify(productMetricsRepository, times(3)).save(existingMetrics);
+    }
+
+    @DisplayName("오래된 이벤트는 스킵하여 메트릭을 업데이트하지 않는다.")
+    @Test
+    void skipsOldEvent_whenEventIsOlderThanMetrics() {
+        // arrange
+        Long productId = 1L;
+        ProductMetrics existingMetrics = new ProductMetrics(productId);
+        existingMetrics.incrementLikeCount(); // 초기값: 1, version = 1
+        
+        Long oldEventVersion = existingMetrics.getVersion() - 1L; // 이전 버전 이벤트
+        
+        Long initialLikeCount = existingMetrics.getLikeCount();
+        Long initialVersion = existingMetrics.getVersion();
+        
+        when(productMetricsRepository.findByProductIdForUpdate(productId))
+            .thenReturn(Optional.of(existingMetrics));
+
+        // act
+        productMetricsService.incrementLikeCount(productId, oldEventVersion);
+
+        // assert
+        // 오래된 이벤트는 스킵되므로 값이 변경되지 않음
+        assertThat(existingMetrics.getLikeCount()).isEqualTo(initialLikeCount);
+        assertThat(existingMetrics.getVersion()).isEqualTo(initialVersion);
+        verify(productMetricsRepository).findByProductIdForUpdate(productId);
+        verify(productMetricsRepository, never()).save(any(ProductMetrics.class));
+    }
+
+    @DisplayName("최신 이벤트는 메트릭을 업데이트한다.")
+    @Test
+    void updatesMetrics_whenEventIsNewerThanMetrics() {
+        // arrange
+        Long productId = 1L;
+        ProductMetrics existingMetrics = new ProductMetrics(productId);
+        existingMetrics.incrementLikeCount(); // 초기값: 1, version = 1
+        
+        Long newEventVersion = existingMetrics.getVersion() + 1L; // 최신 버전 이벤트
+        
+        when(productMetricsRepository.findByProductIdForUpdate(productId))
+            .thenReturn(Optional.of(existingMetrics));
+        when(productMetricsRepository.save(any(ProductMetrics.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // act
+        productMetricsService.incrementLikeCount(productId, newEventVersion);
+
+        // assert
+        // 최신 이벤트는 반영됨
+        assertThat(existingMetrics.getLikeCount()).isEqualTo(2L);
+        verify(productMetricsRepository).findByProductIdForUpdate(productId);
+        verify(productMetricsRepository).save(existingMetrics);
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/domain/metrics/ProductMetricsTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/domain/metrics/ProductMetricsTest.java
@@ -1,0 +1,155 @@
+package com.loopers.domain.metrics;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProductMetricsTest {
+
+    @DisplayName("ProductMetrics는 상품 ID로 생성되며 초기값이 0으로 설정된다.")
+    @Test
+    void createsProductMetricsWithInitialValues() {
+        // arrange
+        Long productId = 1L;
+
+        // act
+        ProductMetrics metrics = new ProductMetrics(productId);
+
+        // assert
+        assertThat(metrics.getProductId()).isEqualTo(productId);
+        assertThat(metrics.getLikeCount()).isEqualTo(0L);
+        assertThat(metrics.getSalesCount()).isEqualTo(0L);
+        assertThat(metrics.getViewCount()).isEqualTo(0L);
+        assertThat(metrics.getVersion()).isEqualTo(0L);
+        assertThat(metrics.getUpdatedAt()).isNotNull();
+    }
+
+    @DisplayName("좋아요 수를 증가시킬 수 있다.")
+    @Test
+    void canIncrementLikeCount() throws InterruptedException {
+        // arrange
+        ProductMetrics metrics = new ProductMetrics(1L);
+        Long initialLikeCount = metrics.getLikeCount();
+        Long initialVersion = metrics.getVersion();
+        LocalDateTime initialUpdatedAt = metrics.getUpdatedAt();
+
+        // act
+        Thread.sleep(1); // 시간 차이를 보장하기 위한 작은 지연
+        metrics.incrementLikeCount();
+
+        // assert
+        assertThat(metrics.getLikeCount()).isEqualTo(initialLikeCount + 1);
+        assertThat(metrics.getVersion()).isEqualTo(initialVersion + 1);
+        assertThat(metrics.getUpdatedAt()).isAfter(initialUpdatedAt);
+    }
+
+    @DisplayName("좋아요 수를 감소시킬 수 있다.")
+    @Test
+    void canDecrementLikeCount() {
+        // arrange
+        ProductMetrics metrics = new ProductMetrics(1L);
+        metrics.incrementLikeCount(); // 먼저 증가시킴
+        Long initialLikeCount = metrics.getLikeCount();
+        Long initialVersion = metrics.getVersion();
+
+        // act
+        metrics.decrementLikeCount();
+
+        // assert
+        assertThat(metrics.getLikeCount()).isEqualTo(initialLikeCount - 1);
+        assertThat(metrics.getVersion()).isEqualTo(initialVersion + 1);
+    }
+
+    @DisplayName("좋아요 수가 0일 때 감소해도 음수가 되지 않는다 (멱등성 보장).")
+    @Test
+    void preventsNegativeLikeCount_whenDecrementingFromZero() {
+        // arrange
+        ProductMetrics metrics = new ProductMetrics(1L);
+        assertThat(metrics.getLikeCount()).isEqualTo(0L);
+        Long initialVersion = metrics.getVersion();
+
+        // act
+        metrics.decrementLikeCount();
+
+        // assert
+        assertThat(metrics.getLikeCount()).isEqualTo(0L);
+        assertThat(metrics.getVersion()).isEqualTo(initialVersion); // version도 변경되지 않음
+    }
+
+    @DisplayName("판매량을 증가시킬 수 있다.")
+    @Test
+    void canIncrementSalesCount() {
+        // arrange
+        ProductMetrics metrics = new ProductMetrics(1L);
+        Long initialSalesCount = metrics.getSalesCount();
+        Long initialVersion = metrics.getVersion();
+        Integer quantity = 5;
+
+        // act
+        metrics.incrementSalesCount(quantity);
+
+        // assert
+        assertThat(metrics.getSalesCount()).isEqualTo(initialSalesCount + quantity);
+        assertThat(metrics.getVersion()).isEqualTo(initialVersion + 1);
+    }
+
+    @DisplayName("판매량 증가 시 null이나 0 이하의 수량은 무시된다.")
+    @Test
+    void ignoresInvalidQuantity_whenIncrementingSalesCount() {
+        // arrange
+        ProductMetrics metrics = new ProductMetrics(1L);
+        Long initialSalesCount = metrics.getSalesCount();
+        Long initialVersion = metrics.getVersion();
+
+        // act
+        metrics.incrementSalesCount(null);
+        metrics.incrementSalesCount(0);
+        metrics.incrementSalesCount(-1);
+
+        // assert
+        assertThat(metrics.getSalesCount()).isEqualTo(initialSalesCount);
+        assertThat(metrics.getVersion()).isEqualTo(initialVersion); // version도 변경되지 않음
+    }
+
+    @DisplayName("상세 페이지 조회 수를 증가시킬 수 있다.")
+    @Test
+    void canIncrementViewCount() throws InterruptedException {
+        // arrange
+        ProductMetrics metrics = new ProductMetrics(1L);
+        Long initialViewCount = metrics.getViewCount();
+        Long initialVersion = metrics.getVersion();
+        LocalDateTime initialUpdatedAt = metrics.getUpdatedAt();
+
+        // act
+        Thread.sleep(1); // 시간 차이를 보장하기 위한 작은 지연
+        metrics.incrementViewCount();
+
+        // assert
+        assertThat(metrics.getViewCount()).isEqualTo(initialViewCount + 1);
+        assertThat(metrics.getVersion()).isEqualTo(initialVersion + 1);
+        assertThat(metrics.getUpdatedAt()).isAfter(initialUpdatedAt);
+    }
+
+    @DisplayName("여러 메트릭을 연속으로 업데이트할 수 있다.")
+    @Test
+    void canUpdateMultipleMetrics() {
+        // arrange
+        ProductMetrics metrics = new ProductMetrics(1L);
+
+        // act
+        metrics.incrementLikeCount();
+        metrics.incrementLikeCount();
+        metrics.incrementSalesCount(10);
+        metrics.incrementViewCount();
+        metrics.decrementLikeCount();
+
+        // assert
+        assertThat(metrics.getLikeCount()).isEqualTo(1L);
+        assertThat(metrics.getSalesCount()).isEqualTo(10L);
+        assertThat(metrics.getViewCount()).isEqualTo(1L);
+        assertThat(metrics.getVersion()).isEqualTo(5L); // 5번 업데이트됨
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/ProductMetricsConsumerIntegrationTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/ProductMetricsConsumerIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.loopers.interfaces.consumer;
+
+import com.loopers.domain.event.LikeEvent;
+import com.loopers.testcontainers.KafkaTestContainersConfig;
+import com.loopers.utils.KafkaCleanUp;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ProductMetricsConsumer 통합 테스트.
+ * <p>
+ * 실제 Kafka를 사용하여 이벤트 처리 동작을 검증합니다.
+ * </p>
+ * <p>
+ * <b>Kafka 컨테이너:</b>
+ * {@link KafkaTestContainersConfig}가 테스트 실행 시 자동으로 Kafka 컨테이너를 시작합니다.
+ * </p>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(KafkaTestContainersConfig.class)
+class ProductMetricsConsumerIntegrationTest {
+
+    @Autowired
+    private KafkaCleanUp kafkaCleanUp;
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Autowired
+    private KafkaProperties kafkaProperties;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 전에 토픽의 모든 메시지 삭제 및 재생성
+        kafkaCleanUp.resetAllTestTopics();
+    }
+
+    /**
+     * offset.reset: latest 설정이 제대로 적용되는지 확인하는 테스트.
+     * <p>
+     * <b>테스트 목적:</b>
+     * kafka.yml에 설정된 `offset.reset: latest`가 실제로 동작하는지 검증합니다.
+     * </p>
+     * <p>
+     * <b>동작 원리:</b>
+     * 1. 이전 메시지를 Kafka에 발행 (이 메시지는 나중에 읽히지 않아야 함)
+     * 2. Consumer Group을 삭제하여 offset 정보 제거
+     * 3. 새로운 메시지를 Kafka에 발행
+     * 4. 새로운 Consumer Group으로 Consumer를 시작
+     * 5. offset.reset: latest 설정으로 인해 Consumer는 최신 메시지(새로운 메시지)부터 읽기 시작해야 함
+     * </p>
+     * <p>
+     * <b>검증 내용:</b>
+     * - Consumer의 현재 position이 최신 offset(endOffset)과 같거나 가까운지 확인
+     * - 이는 Consumer가 이전 메시지를 건너뛰고 최신 메시지부터 읽기 시작했다는 의미
+     * </p>
+     */
+    @DisplayName("offset.reset: latest 설정이 적용되어 새로운 Consumer Group은 최신 메시지만 읽는다.")
+    @Test
+    void offsetResetLatest_shouldOnlyReadLatestMessages() throws Exception {
+        // 이 메시지는 나중에 Consumer가 읽지 않아야 함 (offset.reset: latest 때문)
+        String topic = "like-events";
+        String partitionKey = "product-1";
+        LikeEvent.LikeAdded oldMessage = new LikeEvent.LikeAdded(100L, 1L, LocalDateTime.now());
+        kafkaTemplate.send(topic, partitionKey, oldMessage).get();
+
+        // Consumer Group을 삭제하면 offset 정보가 사라짐
+        // 다음에 같은 Consumer Group으로 시작할 때 offset.reset 설정이 적용됨
+        String testGroupId = "test-offset-reset-" + System.currentTimeMillis();
+        kafkaCleanUp.resetConsumerGroup(testGroupId);
+
+        // 이 메시지는 Consumer가 읽어야 함 (최신 메시지이므로)
+        LikeEvent.LikeAdded newMessage = new LikeEvent.LikeAdded(200L, 1L, LocalDateTime.now());
+        kafkaTemplate.send(topic, partitionKey, newMessage).get();
+
+        // 프로젝트의 kafka.yml 설정을 사용하여 Consumer 생성
+        // 이 설정에는 offset.reset: latest가 포함되어 있음
+        Map<String, Object> consumerProps = kafkaProperties.buildConsumerProperties();
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, testGroupId);
+        
+        try (KafkaConsumer<String, Object> consumer = new KafkaConsumer<>(consumerProps)) {
+            // 특정 파티션에 할당 (테스트용)
+            TopicPartition partition = new TopicPartition(topic, 0);
+            consumer.assign(Collections.singletonList(partition));
+
+            // endOffset: 토픽의 마지막 메시지 다음 offset (현재는 2개 메시지가 있으므로 2)
+            // currentPosition: Consumer가 현재 읽을 위치 (offset.reset: latest면 endOffset과 같아야 함)
+            Long endOffset = consumer.endOffsets(Collections.singletonList(partition)).get(partition);
+            long currentPosition = consumer.position(partition);
+
+            // offset.reset: latest 설정이 적용되었다면:
+            // - currentPosition은 endOffset과 같거나 가까워야 함
+            // - 이는 Consumer가 이전 메시지(oldMessage)를 건너뛰고 최신 메시지(newMessage)부터 읽기 시작했다는 의미
+            // 예: endOffset=2, currentPosition=2 → 이전 메시지(offset 0)를 건너뛰고 최신 메시지(offset 1)부터 시작
+            assertThat(currentPosition)
+                .isGreaterThanOrEqualTo(endOffset);
+        }
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/ProductMetricsConsumerTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/ProductMetricsConsumerTest.java
@@ -1,0 +1,393 @@
+package com.loopers.interfaces.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.eventhandled.EventHandledService;
+import com.loopers.application.metrics.ProductMetricsService;
+import com.loopers.domain.event.LikeEvent;
+import com.loopers.domain.event.OrderEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * ProductMetricsConsumer 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProductMetricsConsumerTest {
+
+    @Mock
+    private ProductMetricsService productMetricsService;
+
+    @Mock
+    private EventHandledService eventHandledService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    @InjectMocks
+    private ProductMetricsConsumer productMetricsConsumer;
+
+    @DisplayName("LikeAdded 이벤트를 처리할 수 있다.")
+    @Test
+    void canConsumeLikeAddedEvent() {
+        // arrange
+        String eventId = "test-event-id";
+        Long productId = 1L;
+        Long userId = 100L;
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(userId, productId, LocalDateTime.now());
+        
+        Headers headers = new RecordHeaders();
+        headers.add(new RecordHeader("eventId", eventId.getBytes(StandardCharsets.UTF_8)));
+        headers.add(new RecordHeader("version", "1".getBytes(StandardCharsets.UTF_8)));
+        
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+            "like-events", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event, headers, Optional.empty()
+        );
+        List<ConsumerRecord<String, Object>> records = List.of(record);
+
+        when(eventHandledService.isAlreadyHandled(eventId)).thenReturn(false);
+
+        // act
+        productMetricsConsumer.consumeLikeEvents(records, acknowledgment);
+
+        // assert
+        verify(eventHandledService).isAlreadyHandled(eventId);
+        verify(productMetricsService).incrementLikeCount(eq(productId), eq(1L));
+        verify(eventHandledService).markAsHandled(eventId, "LikeAdded", "like-events");
+        verify(acknowledgment).acknowledge();
+    }
+
+    @DisplayName("LikeRemoved 이벤트를 처리할 수 있다.")
+    @Test
+    void canConsumeLikeRemovedEvent() {
+        // arrange
+        String eventId = "test-event-id-2";
+        Long productId = 1L;
+        Long userId = 100L;
+        LikeEvent.LikeRemoved event = new LikeEvent.LikeRemoved(userId, productId, LocalDateTime.now());
+        
+        Headers headers = new RecordHeaders();
+        headers.add(new RecordHeader("eventId", eventId.getBytes(StandardCharsets.UTF_8)));
+        headers.add(new RecordHeader("version", "2".getBytes(StandardCharsets.UTF_8)));
+        
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+            "like-events", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event, headers, Optional.empty()
+        );
+        List<ConsumerRecord<String, Object>> records = List.of(record);
+
+        when(eventHandledService.isAlreadyHandled(eventId)).thenReturn(false);
+
+        // act
+        productMetricsConsumer.consumeLikeEvents(records, acknowledgment);
+
+        // assert
+        verify(eventHandledService).isAlreadyHandled(eventId);
+        verify(productMetricsService).decrementLikeCount(eq(productId), eq(2L));
+        verify(eventHandledService).markAsHandled(eventId, "LikeRemoved", "like-events");
+        verify(acknowledgment).acknowledge();
+    }
+
+    @DisplayName("OrderCreated 이벤트를 처리할 수 있다.")
+    @Test
+    void canConsumeOrderCreatedEvent() {
+        // arrange
+        String eventId = "test-event-id-3";
+        Long orderId = 1L;
+        Long userId = 100L;
+        Long productId1 = 1L;
+        Long productId2 = 2L;
+        
+        List<OrderEvent.OrderCreated.OrderItemInfo> orderItems = List.of(
+            new OrderEvent.OrderCreated.OrderItemInfo(productId1, 3),
+            new OrderEvent.OrderCreated.OrderItemInfo(productId2, 2)
+        );
+        
+        OrderEvent.OrderCreated event = new OrderEvent.OrderCreated(
+            orderId, userId, null, 10000, 0L, orderItems, LocalDateTime.now()
+        );
+        
+        Headers headers = new RecordHeaders();
+        headers.add(new RecordHeader("eventId", eventId.getBytes(StandardCharsets.UTF_8)));
+        headers.add(new RecordHeader("version", "3".getBytes(StandardCharsets.UTF_8)));
+        
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+            "order-events", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event, headers, Optional.empty()
+        );
+        List<ConsumerRecord<String, Object>> records = List.of(record);
+
+        when(eventHandledService.isAlreadyHandled(eventId)).thenReturn(false);
+
+        // act
+        productMetricsConsumer.consumeOrderEvents(records, acknowledgment);
+
+        // assert
+        verify(eventHandledService).isAlreadyHandled(eventId);
+        verify(productMetricsService).incrementSalesCount(eq(productId1), eq(3), eq(3L));
+        verify(productMetricsService).incrementSalesCount(eq(productId2), eq(2), eq(3L));
+        verify(eventHandledService).markAsHandled(eventId, "OrderCreated", "order-events");
+        verify(acknowledgment).acknowledge();
+    }
+
+    @DisplayName("배치로 여러 이벤트를 처리할 수 있다.")
+    @Test
+    void canConsumeMultipleEvents() {
+        // arrange
+        String eventId1 = "test-event-id-4";
+        String eventId2 = "test-event-id-5";
+        Long productId = 1L;
+        Long userId = 100L;
+        
+        LikeEvent.LikeAdded event1 = new LikeEvent.LikeAdded(userId, productId, LocalDateTime.now());
+        LikeEvent.LikeRemoved event2 = new LikeEvent.LikeRemoved(userId, productId, LocalDateTime.now());
+        
+        Headers headers1 = new RecordHeaders();
+        headers1.add(new RecordHeader("eventId", eventId1.getBytes(StandardCharsets.UTF_8)));
+        headers1.add(new RecordHeader("version", "4".getBytes(StandardCharsets.UTF_8)));
+        Headers headers2 = new RecordHeaders();
+        headers2.add(new RecordHeader("eventId", eventId2.getBytes(StandardCharsets.UTF_8)));
+        headers2.add(new RecordHeader("version", "5".getBytes(StandardCharsets.UTF_8)));
+        
+        List<ConsumerRecord<String, Object>> records = List.of(
+            new ConsumerRecord<>("like-events", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event1, headers1, Optional.empty()),
+            new ConsumerRecord<>("like-events", 0, 1L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event2, headers2, Optional.empty())
+        );
+
+        when(eventHandledService.isAlreadyHandled(eventId1)).thenReturn(false);
+        when(eventHandledService.isAlreadyHandled(eventId2)).thenReturn(false);
+
+        // act
+        productMetricsConsumer.consumeLikeEvents(records, acknowledgment);
+
+        // assert
+        verify(eventHandledService).isAlreadyHandled(eventId1);
+        verify(eventHandledService).isAlreadyHandled(eventId2);
+        verify(productMetricsService).incrementLikeCount(eq(productId), eq(4L));
+        verify(productMetricsService).decrementLikeCount(eq(productId), eq(5L));
+        verify(eventHandledService).markAsHandled(eventId1, "LikeAdded", "like-events");
+        verify(eventHandledService).markAsHandled(eventId2, "LikeRemoved", "like-events");
+        verify(acknowledgment, times(1)).acknowledge();
+    }
+
+    @DisplayName("개별 이벤트 처리 실패 시에도 배치 처리를 계속한다.")
+    @Test
+    void continuesProcessing_whenIndividualEventFails() {
+        // arrange
+        String eventId1 = "test-event-id-6";
+        String eventId2 = "test-event-id-7";
+        Long productId = 1L;
+        Long userId = 100L;
+        
+        LikeEvent.LikeAdded validEvent = new LikeEvent.LikeAdded(userId, productId, LocalDateTime.now());
+        Object invalidEvent = "invalid-event";
+        
+        Headers headers1 = new RecordHeaders();
+        headers1.add(new RecordHeader("eventId", eventId1.getBytes(StandardCharsets.UTF_8)));
+        headers1.add(new RecordHeader("version", "6".getBytes(StandardCharsets.UTF_8)));
+        Headers headers2 = new RecordHeaders();
+        headers2.add(new RecordHeader("eventId", eventId2.getBytes(StandardCharsets.UTF_8)));
+        headers2.add(new RecordHeader("version", "7".getBytes(StandardCharsets.UTF_8)));
+        
+        when(eventHandledService.isAlreadyHandled(eventId1)).thenReturn(false);
+        when(eventHandledService.isAlreadyHandled(eventId2)).thenReturn(false);
+        doThrow(new RuntimeException("처리 실패"))
+            .when(productMetricsService).incrementLikeCount(any(), anyLong());
+        
+        List<ConsumerRecord<String, Object>> records = List.of(
+            new ConsumerRecord<>("like-events", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", invalidEvent, headers1, Optional.empty()),
+            new ConsumerRecord<>("like-events", 0, 1L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", validEvent, headers2, Optional.empty())
+        );
+
+        // act
+        productMetricsConsumer.consumeLikeEvents(records, acknowledgment);
+
+        // assert
+        verify(eventHandledService).isAlreadyHandled(eventId1);
+        verify(eventHandledService).isAlreadyHandled(eventId2);
+        verify(productMetricsService, atLeastOnce()).incrementLikeCount(any(), anyLong());
+        verify(acknowledgment).acknowledge();
+    }
+
+    @DisplayName("개별 이벤트 처리 실패 시에도 acknowledgment를 수행한다.")
+    @Test
+    void acknowledgesEvenWhenIndividualEventFails() {
+        // arrange
+        String eventId = "test-event-id-8";
+        Long productId = 1L;
+        Long userId = 100L;
+        
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(userId, productId, LocalDateTime.now());
+        
+        Headers headers = new RecordHeaders();
+        headers.add(new RecordHeader("eventId", eventId.getBytes(StandardCharsets.UTF_8)));
+        headers.add(new RecordHeader("version", "8".getBytes(StandardCharsets.UTF_8)));
+        
+        // 서비스 호출 시 예외 발생
+        when(eventHandledService.isAlreadyHandled(eventId)).thenReturn(false);
+        doThrow(new RuntimeException("서비스 처리 실패"))
+            .when(productMetricsService).incrementLikeCount(eq(productId), anyLong());
+        
+        List<ConsumerRecord<String, Object>> records = List.of(
+            new ConsumerRecord<>("like-events", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event, headers, Optional.empty())
+        );
+
+        // act
+        productMetricsConsumer.consumeLikeEvents(records, acknowledgment);
+
+        // assert
+        // 개별 이벤트 실패는 내부 catch 블록에서 처리되고 계속 진행되므로 acknowledgment는 호출됨
+        verify(eventHandledService).isAlreadyHandled(eventId);
+        verify(productMetricsService).incrementLikeCount(eq(productId), anyLong());
+        // 예외 발생 시 markAsHandled는 호출되지 않음
+        verify(eventHandledService, never()).markAsHandled(any(), any(), any());
+        verify(acknowledgment).acknowledge();
+    }
+
+    @DisplayName("이미 처리된 이벤트는 스킵한다.")
+    @Test
+    void skipsAlreadyHandledEvent() {
+        // arrange
+        String eventId = "test-event-id";
+        Long productId = 1L;
+        Long userId = 100L;
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(userId, productId, LocalDateTime.now());
+        
+        Headers headers = new RecordHeaders();
+        headers.add(new RecordHeader("eventId", eventId.getBytes(StandardCharsets.UTF_8)));
+        
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+            "like-events", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event, headers, Optional.empty()
+        );
+        List<ConsumerRecord<String, Object>> records = List.of(record);
+
+        when(eventHandledService.isAlreadyHandled(eventId)).thenReturn(true);
+
+        // act
+        productMetricsConsumer.consumeLikeEvents(records, acknowledgment);
+
+        // assert
+        verify(eventHandledService).isAlreadyHandled(eventId);
+        verify(productMetricsService, never()).incrementLikeCount(any(), anyLong());
+        verify(eventHandledService, never()).markAsHandled(any(), any(), any());
+        verify(acknowledgment).acknowledge();
+    }
+
+    @DisplayName("eventId가 없는 메시지는 건너뛴다.")
+    @Test
+    void skipsEventWithoutEventId() {
+        // arrange
+        Long productId = 1L;
+        Long userId = 100L;
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(userId, productId, LocalDateTime.now());
+        
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+            "like-events", 0, 0L, "key", event
+        );
+        List<ConsumerRecord<String, Object>> records = List.of(record);
+
+        // act
+        productMetricsConsumer.consumeLikeEvents(records, acknowledgment);
+
+        // assert
+        verify(eventHandledService, never()).isAlreadyHandled(any());
+        verify(productMetricsService, never()).incrementLikeCount(any(), anyLong());
+        verify(acknowledgment).acknowledge();
+    }
+
+    @DisplayName("동시성 상황에서 DataIntegrityViolationException이 발생하면 정상 처리로 간주한다.")
+    @Test
+    void handlesDataIntegrityViolationException() {
+        // arrange
+        String eventId = "test-event-id";
+        Long productId = 1L;
+        Long userId = 100L;
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(userId, productId, LocalDateTime.now());
+        
+        Headers headers = new RecordHeaders();
+        headers.add(new RecordHeader("eventId", eventId.getBytes(StandardCharsets.UTF_8)));
+        headers.add(new RecordHeader("version", "9".getBytes(StandardCharsets.UTF_8)));
+        
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+            "like-events", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event, headers, Optional.empty()
+        );
+        List<ConsumerRecord<String, Object>> records = List.of(record);
+
+        when(eventHandledService.isAlreadyHandled(eventId)).thenReturn(false);
+        doThrow(new DataIntegrityViolationException("UNIQUE constraint violation"))
+            .when(eventHandledService).markAsHandled(eventId, "LikeAdded", "like-events");
+
+        // act
+        productMetricsConsumer.consumeLikeEvents(records, acknowledgment);
+
+        // assert
+        verify(eventHandledService).isAlreadyHandled(eventId);
+        verify(productMetricsService).incrementLikeCount(eq(productId), anyLong());
+        verify(eventHandledService).markAsHandled(eventId, "LikeAdded", "like-events");
+        verify(acknowledgment).acknowledge();
+    }
+
+    @DisplayName("중복 메시지 재전송 시 한 번만 처리되어 멱등성이 보장된다.")
+    @Test
+    void handlesDuplicateMessagesIdempotently() {
+        // arrange
+        String eventId = "duplicate-event-id";
+        Long productId = 1L;
+        Long userId = 100L;
+        Long eventVersion = 1L;
+        LikeEvent.LikeAdded event = new LikeEvent.LikeAdded(userId, productId, LocalDateTime.now());
+        
+        Headers headers = new RecordHeaders();
+        headers.add(new RecordHeader("eventId", eventId.getBytes(StandardCharsets.UTF_8)));
+        headers.add(new RecordHeader("version", String.valueOf(eventVersion).getBytes(StandardCharsets.UTF_8)));
+        
+        // 동일한 eventId를 가진 메시지 3개 생성
+        List<ConsumerRecord<String, Object>> records = List.of(
+            new ConsumerRecord<>("like-events", 0, 0L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event, headers, Optional.empty()),
+            new ConsumerRecord<>("like-events", 0, 1L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event, headers, Optional.empty()),
+            new ConsumerRecord<>("like-events", 0, 2L, 0L, TimestampType.CREATE_TIME, 0, 0, "key", event, headers, Optional.empty())
+        );
+
+        // 첫 번째 메시지는 처리되지 않았으므로 false, 나머지는 이미 처리되었으므로 true
+        when(eventHandledService.isAlreadyHandled(eventId))
+            .thenReturn(false)  // 첫 번째: 처리됨
+            .thenReturn(true)    // 두 번째: 이미 처리됨 (스킵)
+            .thenReturn(true);   // 세 번째: 이미 처리됨 (스킵)
+
+        // act
+        productMetricsConsumer.consumeLikeEvents(records, acknowledgment);
+
+        // assert
+        // isAlreadyHandled는 3번 호출됨 (각 메시지마다)
+        verify(eventHandledService, times(3)).isAlreadyHandled(eventId);
+        
+        // incrementLikeCount는 한 번만 호출되어야 함 (첫 번째 메시지만 처리)
+        verify(productMetricsService, times(1)).incrementLikeCount(eq(productId), eq(eventVersion));
+        
+        // markAsHandled는 한 번만 호출되어야 함 (첫 번째 메시지만 처리)
+        verify(eventHandledService, times(1)).markAsHandled(eventId, "LikeAdded", "like-events");
+        
+        // acknowledgment는 한 번만 호출되어야 함 (배치 처리 완료)
+        verify(acknowledgment, times(1)).acknowledge();
+    }
+}

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -15,6 +15,10 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       retries: 3
+      properties:
+        acks: all                    # 모든 리플리카에 쓰기 확인 (At Least Once 보장)
+        enable.idempotence: true     # 중복 방지 (At Least Once 보장)
+        max.in.flight.requests.per.connection: 5  # idempotence=true일 때 필수
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
@@ -29,11 +33,13 @@ spring.config.activate.on-profile: local, test
 
 spring:
   kafka:
-    bootstrap-servers: localhost:19092
+    # Testcontainers를 사용하는 경우 BOOTSTRAP_SERVERS가 자동으로 설정됨
+    # 로컬 개발 환경에서는 localhost:19092 사용
+    bootstrap-servers: ${BOOTSTRAP_SERVERS:localhost:19092}
     admin:
       properties:
-        bootstrap.servers: kafka:9092
-
+        bootstrap.servers: ${BOOTSTRAP_SERVERS:localhost:19092}
+      auto-create: true
 ---
 spring.config.activate.on-profile: dev
 

--- a/modules/kafka/src/testFixtures/java/com/loopers/testcontainers/KafkaTestContainersConfig.java
+++ b/modules/kafka/src/testFixtures/java/com/loopers/testcontainers/KafkaTestContainersConfig.java
@@ -1,0 +1,35 @@
+package com.loopers.testcontainers;
+
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+
+/**
+ * Kafka Testcontainers 설정.
+ * <p>
+ * 테스트 실행 시 자동으로 Kafka 컨테이너를 시작하고,
+ * Spring Boot의 Kafka 설정에 동적으로 포트를 주입합니다.
+ * </p>
+ * <p>
+ * <b>동작 방식:</b>
+ * 1. Kafka 컨테이너를 시작
+ * 2. 동적으로 할당된 포트를 System Property로 설정
+ * 3. kafka.yml의 ${BOOTSTRAP_SERVERS}가 이 값을 사용
+ * </p>
+ */
+@Configuration
+public class KafkaTestContainersConfig {
+
+    private static final ConfluentKafkaContainer kafkaContainer;
+
+    static {
+        // Kafka 컨테이너 생성 및 시작
+        // ConfluentKafkaContainer는 confluentinc/cp-kafka 이미지를 사용
+        kafkaContainer = new ConfluentKafkaContainer("confluentinc/cp-kafka:7.5.0");
+        kafkaContainer.start();
+
+        // Spring Boot의 Kafka 설정에 동적으로 포트 주입
+        // kafka.yml의 ${BOOTSTRAP_SERVERS}가 이 값을 사용
+        String bootstrapServers = kafkaContainer.getBootstrapServers();
+        System.setProperty("BOOTSTRAP_SERVERS", bootstrapServers);
+    }
+}

--- a/modules/kafka/src/testFixtures/java/com/loopers/utils/KafkaCleanUp.java
+++ b/modules/kafka/src/testFixtures/java/com/loopers/utils/KafkaCleanUp.java
@@ -1,0 +1,194 @@
+package com.loopers.utils;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
+import org.apache.kafka.clients.admin.DeleteTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Kafka 테스트 정리 유틸리티.
+ * <p>
+ * 테스트 간 Kafka 메시지 격리를 위해 토픽을 삭제하고 재생성합니다.
+ * </p>
+ * <p>
+ * <b>사용 방법:</b>
+ * <ul>
+ *   <li>통합 테스트에서 `@BeforeEach` 또는 `@AfterEach`에서 호출하여 테스트 간 격리 보장</li>
+ *   <li>단위 테스트는 Mock을 사용하므로 불필요</li>
+ * </ul>
+ * </p>
+ * <p>
+ * <b>주의:</b>
+ * 프로덕션 환경에서는 사용하지 마세요. 테스트 환경에서만 사용해야 합니다.
+ * </p>
+ */
+@Component
+public class KafkaCleanUp {
+
+    private static final List<String> TEST_TOPICS = List.of(
+        "like-events",
+        "order-events",
+        "product-events",
+        "payment-events",
+        "coupon-events",
+        "user-events"
+    );
+
+    private final KafkaAdmin kafkaAdmin;
+
+    public KafkaCleanUp(KafkaAdmin kafkaAdmin) {
+        this.kafkaAdmin = kafkaAdmin;
+    }
+
+    /**
+     * 테스트용 토픽의 모든 메시지를 삭제합니다.
+     * <p>
+     * 토픽을 삭제하고 재생성하여 모든 메시지를 제거합니다.
+     * </p>
+     * <p>
+     * <b>주의:</b> 프로덕션 환경에서는 사용하지 마세요.
+     * </p>
+     */
+    public void deleteAllTestTopics() {
+        try (AdminClient adminClient = createAdminClient()) {
+            // 존재하는 토픽만 삭제
+            Set<String> existingTopics = adminClient.listTopics()
+                .names()
+                .get(5, TimeUnit.SECONDS);
+
+            List<String> topicsToDelete = TEST_TOPICS.stream()
+                .filter(existingTopics::contains)
+                .toList();
+
+            if (topicsToDelete.isEmpty()) {
+                return;
+            }
+
+            // 토픽 삭제 (모든 메시지 제거)
+            DeleteTopicsResult deleteResult = adminClient.deleteTopics(topicsToDelete);
+            deleteResult.all().get(10, TimeUnit.SECONDS);
+
+            // 토픽 삭제 후 재생성 대기 (Kafka가 토픽 삭제를 완료할 때까지)
+            Thread.sleep(1000);
+        } catch (Exception e) {
+            // 토픽이 없거나 이미 삭제된 경우 무시
+            // 테스트 환경에서는 토픽이 없을 수 있음
+        }
+    }
+
+    /**
+     * 테스트용 토픽을 재생성합니다.
+     * <p>
+     * 삭제된 토픽을 원래 설정으로 재생성합니다.
+     * </p>
+     */
+    public void recreateTestTopics() {
+        try (AdminClient adminClient = createAdminClient()) {
+            for (String topicName : TEST_TOPICS) {
+                try {
+                    // 토픽이 이미 존재하는지 확인
+                    adminClient.describeTopics(Collections.singletonList(topicName))
+                        .allTopicNames()
+                        .get(2, TimeUnit.SECONDS);
+                    // 이미 존재하면 스킵
+                    continue;
+                } catch (Exception e) {
+                    // 토픽이 없으면 생성
+                }
+
+                // 토픽 생성
+                NewTopic newTopic = TopicBuilder.name(topicName)
+                    .partitions(3)
+                    .replicas(1)
+                    .config("min.insync.replicas", "1")
+                    .build();
+
+                adminClient.createTopics(Collections.singletonList(newTopic))
+                    .all()
+                    .get(5, TimeUnit.SECONDS);
+            }
+        } catch (Exception e) {
+            // 토픽 생성 실패는 무시 (이미 존재할 수 있음)
+        }
+    }
+
+    /**
+     * 테스트용 토픽을 삭제하고 재생성합니다.
+     * <p>
+     * 모든 메시지를 제거하고 깨끗한 상태로 시작합니다.
+     * </p>
+     */
+    public void resetAllTestTopics() {
+        deleteAllTestTopics();
+        recreateTestTopics();
+    }
+
+    /**
+     * 모든 Consumer Group을 삭제하여 offset을 리셋합니다.
+     * <p>
+     * 테스트 간 격리를 위해 사용합니다.
+     * </p>
+     * <p>
+     * <b>주의:</b> 모든 Consumer Group을 삭제하므로 프로덕션 환경에서는 사용하지 마세요.
+     * </p>
+     */
+    public void resetAllConsumerGroups() {
+        try (AdminClient adminClient = createAdminClient()) {
+            // 모든 Consumer Group 목록 조회
+            Set<String> consumerGroups = adminClient.listConsumerGroups()
+                .all()
+                .get(5, TimeUnit.SECONDS)
+                .stream()
+                .map(group -> group.groupId())
+                .collect(java.util.stream.Collectors.toSet());
+
+            if (consumerGroups.isEmpty()) {
+                return;
+            }
+
+            // Consumer Group 삭제 (offset 리셋)
+            DeleteConsumerGroupsResult deleteResult = adminClient.deleteConsumerGroups(consumerGroups);
+            deleteResult.all().get(5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            // Consumer Group이 없거나 이미 삭제된 경우 무시
+            // 테스트 환경에서는 Consumer Group이 없을 수 있음
+        }
+    }
+
+    /**
+     * 특정 Consumer Group을 삭제합니다.
+     *
+     * @param groupId 삭제할 Consumer Group ID
+     */
+    public void resetConsumerGroup(String groupId) {
+        try (AdminClient adminClient = createAdminClient()) {
+            DeleteConsumerGroupsResult deleteResult = adminClient.deleteConsumerGroups(
+                Collections.singletonList(groupId)
+            );
+            deleteResult.all().get(5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            // Consumer Group이 없거나 이미 삭제된 경우 무시
+        }
+    }
+
+    /**
+     * AdminClient를 생성합니다.
+     */
+    private AdminClient createAdminClient() {
+        Properties props = new Properties();
+        Object bootstrapServers = kafkaAdmin.getConfigurationProperties()
+            .getOrDefault(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19092");
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        return AdminClient.create(props);
+    }
+}


### PR DESCRIPTION
## 📌 Summary
API 서비스(`commerce-api`)와 독립된 집계 서비스(`commerce-streamer`)를 추가하고, 두 서비스 간 느슨한 연결을 Kafka 기반 이벤트 파이프라인으로 구현했습니다.

**주요 구현 내용:**
- **Producer (commerce-api)**: Transactional Outbox Pattern을 통한 이벤트 발행 (도메인 트랜잭션과 동일 트랜잭션에서 Outbox 저장, 별도 스케줄러가 Kafka로 발행)
- **Consumer (commerce-streamer)**: 이벤트 수취 및 상품 메트릭 집계 (좋아요 수, 판매량, 조회 수)
- **멱등성 보장**: `event_handled` 테이블(UUID 기반 eventId)과 `version` 필드(aggregateId별 순차적 버전)를 통한 중복 처리 방지
- **순서 보장**: 파티션 키 기반 이벤트 순서 보장 및 `offset.reset: latest` 설정으로 불필요한 과거 메시지 처리 방지

**구현된 이벤트:**
- `like-events`: `LikeAdded`, `LikeRemoved` → 좋아요 수 집계
- `order-events`: `OrderCreated` → 판매량 집계
- `product-events`: `ProductViewed` → 조회 수 집계

## 💬 Review Points

#### 1. Transactional Outbox Pattern 구현 방식의 적절성

**배경 및 문제 상황:**
외부 시스템(Kafka)과의 통신이 필요한 상황에서, 도메인 트랜잭션과 Kafka 발행을 동일 트랜잭션으로 묶을 수 없기 때문에 이벤트 유실 가능성이 있었습니다. 예를 들어, 주문 생성 트랜잭션이 성공했지만 Kafka 발행이 실패하면, 집계 서비스는 해당 주문 이벤트를 받지 못하게 됩니다. 반대로 Kafka 발행은 성공했지만 도메인 트랜잭션이 롤백되면, 실제로는 주문이 생성되지 않았는데 집계 서비스는 주문 이벤트를 받게 되는 문제가 발생합니다.

**해결 방안:**
이러한 문제를 해결하기 위해 Transactional Outbox Pattern을 적용했습니다. 도메인 트랜잭션과 같은 트랜잭션에서 `OutboxEvent`를 DB에 먼저 저장하고, 별도 스케줄러가 주기적으로 PENDING 상태의 이벤트를 읽어 Kafka로 발행하는 구조입니다. 이렇게 하면 도메인 트랜잭션이 성공하면 Outbox에 이벤트가 저장되고, 트랜잭션이 롤백되면 Outbox 저장도 함께 롤백되어 일관성이 보장됩니다.

**구현 세부사항:**
1. **ApplicationEvent → OutboxEvent 변환**: `OutboxBridgeEventListener`가 `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`로 설정되어, 도메인 트랜잭션이 커밋된 후에만 Outbox에 저장합니다. 이렇게 하면 도메인 로직이 실패하여 트랜잭션이 롤백되면 Outbox 저장도 롤백되어 불필요한 이벤트가 저장되지 않습니다.

2. **스케줄러 기반 발행**: `OutboxEventPublisher`가 1초마다 실행되어 PENDING 상태의 이벤트를 최대 100개씩 읽어 Kafka로 발행합니다. 발행 성공 시 `PUBLISHED` 상태로 변경하고, 실패 시 `FAILED` 상태로 변경하여 다음 스케줄에서 재시도할 수 있도록 했습니다.

**관련 코드:**
```java
// OutboxBridgeEventListener.java - 도메인 트랜잭션 커밋 후에만 Outbox에 저장
@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
public void handleLikeAdded(LikeEvent.LikeAdded event) {
    outboxEventService.saveEvent(/* ... */);
}

// OutboxEventPublisher.java - 1초마다 PENDING 이벤트를 읽어 Kafka로 발행
@Scheduled(fixedDelay = 1000)
public void publishPendingEvents() {
    List<OutboxEvent> pendingEvents = outboxEventRepository.findPendingEvents(BATCH_SIZE);
    for (OutboxEvent event : pendingEvents) {
        publishEvent(event);
        event.markAsPublished();  // PUBLISHED 상태로 변경
    }
}
```

**고민한 점:**
- `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`를 사용한 이유는, 도메인 트랜잭션이 성공적으로 커밋된 후에만 Outbox에 저장하여 일관성을 보장하기 위함입니다. 만약 `AFTER_COMMIT`이 아닌 다른 시점에 저장하면, 도메인 로직이 실패하여 롤백되었는데도 Outbox에 이벤트가 저장될 수 있습니다. 하지만 `AFTER_COMMIT`은 트랜잭션이 완전히 커밋된 후에 실행되므로, Outbox 저장 실패 시 도메인 트랜잭션을 롤백할 수 없다는 단점이 있습니다. 이 부분에 대한 검토가 필요합니다.

- 스케줄러 주기(1초)와 배치 크기(100)는 현재 트래픽을 고려하여 설정했지만, 실제 운영 환경에서는 이벤트 발생 빈도와 Kafka 처리 속도를 고려하여 조정이 필요할 수 있습니다. 너무 짧은 주기(예: 100ms)는 DB 부하를 증가시킬 수 있고, 너무 긴 주기(예: 10초)는 이벤트 발행 지연이 발생할 수 있습니다.

- 개별 이벤트 발행 실패 시 `FAILED` 상태로 변경하고 계속 진행하도록 했는데, 이렇게 하면 일부 이벤트만 실패해도 다음 스케줄에서 재시도할 수 있습니다. 하지만 `FAILED` 상태의 이벤트를 별도로 모니터링하거나, 재시도 횟수 제한을 두는 등의 추가 로직이 필요할 수 있습니다.

---

#### 2. 멱등성 처리 전략: event_handled 테이블과 version 필드의 조합

**배경 및 문제 상황:**
Kafka는 기본적으로 At Least Once 보장을 제공하므로, 네트워크 오류나 Consumer 재시작 등의 상황에서 동일한 메시지가 여러 번 전달될 수 있습니다. 또한 Producer 측에서도 `acks=all`, `enable.idempotence=true` 설정으로 At Least Once를 보장하므로, 동일한 이벤트가 중복 발행될 수 있습니다. 이러한 중복 메시지를 그대로 처리하면 좋아요 수나 판매량이 중복 집계되어 잘못된 메트릭이 생성됩니다.

**해결 방안:**
중복 처리를 방지하기 위해 두 가지 전략을 조합했습니다:
1. **event_handled 테이블**: 동일 `eventId`의 중복 처리 방지 (동일 이벤트의 완전 중복 방지)
2. **version 필드**: 오래된 이벤트가 최신 상태를 덮어쓰는 것 방지 (순서가 뒤바뀐 이벤트 처리 방지)

**구현 세부사항:**

**1) event_handled 테이블을 통한 중복 처리 방지:**
- 각 이벤트에 UUID 기반의 고유한 `eventId`를 부여합니다.
- Consumer에서 이벤트를 처리하기 전에 `event_handled` 테이블에서 해당 `eventId`가 이미 처리되었는지 확인합니다.
- 이미 처리된 경우 스킵하고, 처리되지 않은 경우에만 비즈니스 로직을 실행한 후 `event_handled` 테이블에 기록을 저장합니다.
- `event_handled` 테이블의 `event_id` 컬럼에 UNIQUE 제약조건을 설정하여, 동시성 상황에서도 중복 처리를 방지합니다. 만약 두 개의 Consumer 인스턴스가 동시에 같은 이벤트를 처리하려고 하면, 하나는 성공하고 다른 하나는 UNIQUE 제약조건 위반 예외가 발생하여 중복 처리가 방지됩니다.

**2) version 필드를 통한 오래된 이벤트 처리 방지:**
- `OutboxEvent`에 `aggregateId`별로 순차적으로 증가하는 `version` 필드를 부여합니다. 예를 들어, `productId=1`에 대한 첫 번째 이벤트는 `version=1`, 두 번째 이벤트는 `version=2`가 됩니다.
- 이 `version`은 Kafka 메시지 헤더에 포함되어 Consumer로 전달됩니다.
- Consumer에서 이벤트를 처리할 때, `ProductMetrics`의 현재 `version`과 이벤트의 `version`을 비교합니다. 이벤트의 `version`이 메트릭의 `version`보다 크면 업데이트하고, 그렇지 않으면 스킵합니다.
- 이렇게 하면 네트워크 지연이나 파티션 순서 문제로 인해 오래된 이벤트가 나중에 도착하더라도, 이미 더 최신 버전의 메트릭이 존재하면 오래된 이벤트는 무시됩니다.

**관련 코드:**
```java
// OutboxEventService.java - eventId(UUID)와 version(aggregateId별 순차 증가) 부여
public void saveEvent(...) {
    String eventId = UUID.randomUUID().toString();
    Long nextVersion = outboxEventRepository.findLatestVersionByAggregateId(...) + 1L;
    // OutboxEvent에 eventId와 version 저장
}

// OutboxEventPublisher.java - Kafka 헤더에 eventId와 version 포함
private void publishEvent(OutboxEvent event) {
    messageBuilder
        .setHeader("eventId", event.getEventId())
        .setHeader("version", event.getVersion());
}

// ProductMetricsConsumer.java - 멱등성 체크 및 버전 비교
public void consumeLikeEvents(...) {
    String eventId = extractEventId(record);
    if (eventHandledService.isAlreadyHandled(eventId)) continue;  // 중복 체크
    
    Long eventVersion = extractVersion(record);
    productMetricsService.incrementLikeCount(productId, eventVersion);  // version 비교 포함
    eventHandledService.markAsHandled(eventId, ...);
}

// ProductMetricsService.java - version 비교로 최신 이벤트만 반영
public void incrementLikeCount(Long productId, Long eventVersion) {
    if (!metrics.shouldUpdate(eventVersion)) return;  // 오래된 이벤트 스킵
    metrics.incrementLikeCount();
}
```

**고민한 점:**
- `event_handled` 테이블의 UNIQUE 제약조건으로 동시성 상황에서도 중복 처리를 방지했지만, 이 테이블이 계속 증가하는 문제가 있습니다. 시간이 지나면서 이 테이블의 데이터가 무한정 증가하게 되는데, 이는 스토리지 비용과 조회 성능에 영향을 줄 수 있습니다. TTL(Time To Live)을 설정하여 일정 기간이 지난 레코드를 자동으로 삭제하거나, 아카이빙 전략을 수립하여 오래된 데이터를 별도 테이블로 이동시키는 등의 방안이 필요할 수 있습니다.

- `version` 필드는 `aggregateId`별로 자동 증가하도록 구현했는데, 이 방식의 장점은 간단하고 순차적인 버전 관리가 가능하다는 것입니다. 하지만 `updatedAt` 기반 방식과 비교했을 때, `updatedAt`은 시간 기반이므로 네트워크 지연이나 시스템 시간 불일치 문제가 발생할 수 있습니다. 반면 `version`은 순차적으로 증가하므로 이러한 문제가 없습니다. 다만, `aggregateId`별로 별도의 버전을 관리해야 하므로 복잡도가 증가합니다. 이 방식이 적절한지, 또는 다른 방식(예: `updatedAt` 기반, 또는 이벤트 발생 시점의 타임스탬프 기반)이 더 나은지 검토가 필요합니다.

- `event_handled` 테이블과 `version` 필드를 모두 사용하는 것이 중복일 수 있다는 의문도 있습니다. 하지만 두 가지는 서로 다른 목적을 가지고 있습니다. `event_handled`는 동일한 이벤트의 완전 중복을 방지하고, `version`은 순서가 뒤바뀐 이벤트를 처리하지 않도록 합니다. 예를 들어, 네트워크 문제로 인해 `version=3` 이벤트가 먼저 도착하고 `version=2` 이벤트가 나중에 도착하는 경우, `event_handled`로는 중복을 감지할 수 없지만 `version`으로는 오래된 이벤트임을 감지할 수 있습니다.

---

#### 3. 파티션 키 기반 순서 보장과 offset.reset: latest 설정의 조합

**배경 및 문제 상황:**
Kafka는 기본적으로 파티션 내에서만 순서를 보장하고, 서로 다른 파티션 간의 순서는 보장하지 않습니다. 또한 Consumer가 재시작되거나 새로운 Consumer Group이 시작될 때, 과거의 모든 메시지를 다시 처리하게 되면 이미 처리된 오래된 메시지를 중복 처리하거나, 테스트 환경에서 이전 테스트의 메시지가 다음 테스트에 영향을 줄 수 있습니다.

**해결 방안:**

**1) 파티션 키 기반 순서 보장:**
- 같은 도메인에서 발생한 이벤트는 동일한 파티션에서 처리되도록 파티션 키를 설정했습니다.
- `like-events`와 `product-events`는 `productId`를 파티션 키로 사용하여, 같은 상품에 대한 이벤트는 항상 같은 파티션에서 순서대로 처리됩니다.
- `order-events`는 `orderId`를 파티션 키로 사용하여, 같은 주문에 대한 이벤트는 항상 같은 파티션에서 순서대로 처리됩니다.
- 이렇게 하면 같은 aggregate root에 대한 이벤트는 순서가 보장되어, 예를 들어 `LikeAdded` → `LikeRemoved` 순서로 이벤트가 발생했을 때 Consumer도 같은 순서로 처리할 수 있습니다.

**2) offset.reset: latest 설정:**
- Consumer가 새로운 Consumer Group으로 시작할 때(offset이 없을 때), 최신 메시지부터 읽기 시작하도록 `offset.reset: latest`를 설정했습니다.
- 이렇게 하면 Consumer가 재시작되거나 새로운 Consumer Group이 시작될 때, 과거의 오래된 메시지를 처리하지 않고 최신 메시지부터 처리할 수 있습니다.
- 특히 테스트 환경에서는 이전 테스트에서 발행한 메시지가 다음 테스트에 영향을 주지 않도록 하는 데 유용합니다.

**다른 옵션과의 비교:**
- `offset.reset: latest` 설정은 새로운 Consumer Group이 시작할 때 최신 메시지부터 읽기 시작하므로, `earliest`를 사용할 경우 발생하는 문제(이전 테스트의 메시지가 다음 테스트에 영향을 주어 테스트 격리 실패)를 방지하고, `manual` 방식처럼 복잡한 offset 관리 로직 없이도 테스트 격리를 보장할 수 있습니다.
- 그러나 `latest` 설정은 새로운 Consumer Group이 시작할 때만 적용되므로, 같은 Consumer Group을 계속 사용하는 경우 이미 커밋된 offset이 있으면 `latest`는 적용되지 않고 기존 offset부터 계속 읽게 됩니다.
- 따라서 통합 테스트에서는 `KafkaCleanUp.resetAllTestTopics()`로 토픽을 삭제하고 재생성하여 Consumer Group을 초기화함으로써, 매 테스트마다 `offset.reset: latest` 설정이 적용되도록 하고, 이전 테스트의 메시지가 완전히 제거되어 테스트 간 격리를 보장합니다.

**구현 세부사항:**

**파티션 키 설정:**
```java
// OutboxBridgeEventListener.java
// productId를 파티션 키로 사용
public void handleLikeAdded(LikeEvent.LikeAdded event) {
    outboxEventService.saveEvent(
        "LikeAdded",
        event.productId().toString(),  // aggregateId
        "Product",
        event,
        "like-events",
        event.productId().toString()  // partitionKey
    );
}

// OutboxEventPublisher.java
// Kafka 메시지에 파티션 키 설정
private void publishEvent(OutboxEvent event) {
    Object payload = objectMapper.readValue(event.getPayload(), Object.class);
    
    var messageBuilder = MessageBuilder
        .withPayload(payload)
        .setHeader(KafkaHeaders.KEY, event.getPartitionKey())  // 파티션 키 설정
        .setHeader("eventId", event.getEventId())
        .setHeader("version", event.getVersion());
    
    kafkaTemplate.send(event.getTopic(), message);
}
```

**offset.reset: latest 설정:**
```yaml
# modules/kafka/src/main/resources/kafka.yml
spring:
  kafka:
    properties:
      auto.offset.reset: latest  # 새로운 Consumer Group 시작 시 최신 메시지부터
    producer:
      properties:
        acks: all                    # 모든 리플리카에 쓰기 확인
        enable.idempotence: true     # 중복 방지
    consumer:
      properties:
        enable-auto-commit: false    # 수동 커밋 사용
    listener:
      ack-mode: manual               # 수동 커밋 모드
```

**테스트 환경에서의 토픽 및 Consumer Group 초기화:**
```java
// KafkaCleanUp.java
// 테스트 실행 전에 토픽과 Consumer Group을 초기화하여 offset.reset: latest가 적용되도록 함
public void resetAllTestTopics() {
    deleteAllTestTopics();
    recreateTestTopics();
}

public void resetAllConsumerGroups() {
    try (AdminClient adminClient = createAdminClient()) {
        Set<String> consumerGroups = adminClient.listConsumerGroups()
            .all()
            .get(5, TimeUnit.SECONDS)
            .stream()
            .map(group -> group.groupId())
            .collect(java.util.stream.Collectors.toSet());
        
        if (!consumerGroups.isEmpty()) {
            DeleteConsumerGroupsResult deleteResult = adminClient.deleteConsumerGroups(consumerGroups);
            deleteResult.all().get(5, TimeUnit.SECONDS);
        }
    } catch (Exception e) {
        // Consumer Group이 없거나 이미 삭제된 경우 무시
    }
}
```

**테스트 환경에서의 격리 보장:**
- `offset.reset: latest`는 새로운 Consumer Group이 시작할 때만 적용되므로, 이미 offset이 커밋된 Consumer Group에서는 적용되지 않습니다. 따라서 테스트 환경에서는 각 테스트 실행 전에 `KafkaCleanUp.resetAllTestTopics()`와 `resetAllConsumerGroups()`를 호출하여 토픽과 Consumer Group을 초기화했습니다.
- 이렇게 하면 매 테스트마다 `offset.reset: latest` 설정이 적용되어, 이전 테스트의 메시지가 다음 테스트에 영향을 주지 않습니다.
- 또한 테스트 프로파일에서 Consumer Group ID를 동적으로 생성(`${spring.application.name}-test-${random.uuid}`)하여, 각 테스트마다 다른 Consumer Group을 사용하도록 했습니다. 이렇게 하면 이전 테스트의 offset이 다음 테스트에 영향을 주지 않습니다.

**관련 코드:**
```java
// KafkaCleanUp.java - 테스트 격리를 위한 초기화
public void resetAllTestTopics() {
    deleteAllTestTopics();  // 모든 메시지 제거
    recreateTestTopics();   // 깨끗한 상태로 재생성
}

// ProductMetricsConsumerIntegrationTest.java
@BeforeEach
void setUp() {
    kafkaCleanUp.resetAllTestTopics();      // 토픽 초기화
    kafkaCleanUp.resetAllConsumerGroups();  // Consumer Group 초기화
}
```

**고민한 점:**
- `offset.reset: latest`는 새로운 Consumer Group이 시작할 때만 적용되므로, 이미 offset이 커밋된 Consumer Group에서는 적용되지 않습니다. 따라서 테스트 환경에서는 각 테스트 실행 전에 `KafkaCleanUp.resetAllTestTopics()`와 `resetAllConsumerGroups()`를 호출하여 토픽과 Consumer Group을 초기화했습니다. 이렇게 하면 매 테스트마다 `offset.reset: latest` 설정이 적용되어, 이전 테스트의 메시지가 다음 테스트에 영향을 주지 않습니다. 하지만 이 방식은 테스트 실행 시간을 증가시킬 수 있고, 프로덕션 환경에서는 사용할 수 없습니다. 다른 테스트 격리 전략(예: 각 테스트마다 고유한 Consumer Group ID 사용, 또는 테스트용 별도 토픽 사용)이 더 나은지 검토가 필요합니다.

- 파티션 키를 `productId` 또는 `orderId`로 설정했는데, 이로 인한 파티션 불균형 문제가 발생할 수 있습니다. 예를 들어, 특정 상품에 대한 이벤트가 매우 많으면 해당 상품의 파티션에만 메시지가 집중되어 다른 파티션은 비어있을 수 있습니다. 하지만 현재 구현에서는 파티션 키를 사용하여 순서를 보장하는 것이 더 중요하다고 판단했습니다. 만약 파티션 불균형이 심각한 문제가 된다면, 파티션 키를 해시 함수로 변환하거나, 복합 키를 사용하는 등의 방안을 고려할 수 있습니다.

- 파티션 키를 사용하지 않고 랜덤 키를 사용하면 어떤 문제가 발생할까요? 예를 들어, 같은 상품에 대한 `LikeAdded`와 `LikeRemoved` 이벤트가 서로 다른 파티션에 발행되면, Consumer가 `LikeRemoved`를 먼저 처리하고 `LikeAdded`를 나중에 처리할 수 있습니다. 이 경우 좋아요 수가 음수가 되거나 잘못된 메트릭이 생성될 수 있습니다. 따라서 파티션 키를 사용하여 같은 aggregate root에 대한 이벤트는 항상 같은 파티션에서 순서대로 처리되도록 하는 것이 중요합니다.

---

### 구현 세부사항

#### 1. 내부 이벤트와 외부 이벤트의 구분

**배경:**
기존에는 JVM 내에서 처리 가능한 느슨한 연결을 위해 Spring Application Event를 사용했습니다. 예를 들어, 주문 생성 시 재고 차감이나 포인트 적립 등의 로직은 같은 애플리케이션 내에서 처리되므로 Application Event로 충분했습니다. 하지만 이번에는 외부 시스템(집계 서비스)과의 통신이 필요하므로, JVM을 벗어나 네트워크를 통해 메시지를 전달할 수 있는 Kafka를 사용하도록 구성했습니다.

**내부 이벤트 (Application Event):**
- 같은 JVM 내에서 처리되는 이벤트
- 예: 주문 생성 → 재고 차감, 포인트 적립 등
- Spring의 `ApplicationEventPublisher`를 통해 발행
- 동기 또는 비동기로 처리 가능
- 트랜잭션 내에서 처리되므로 일관성 보장이 상대적으로 쉬움

**외부 이벤트 (Kafka Event):**
- 다른 서비스(집계 서비스)로 전달되어야 하는 이벤트
- 예: 주문 생성 → 판매량 집계, 좋아요 추가 → 좋아요 수 집계 등
- Kafka를 통해 네트워크로 전달
- 비동기로 처리되며, 네트워크 오류나 서비스 다운 등의 상황을 고려해야 함
- 트랜잭션 경계를 넘어서므로 일관성 보장이 복잡함 (Outbox 패턴 필요)

**구조:**
```
도메인 로직 (예: 주문 생성)
    ↓
ApplicationEvent 발행 (JVM 내부)
    ↓
OutboxBridgeEventListener (ApplicationEvent → OutboxEvent 변환)
    - @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
    - 도메인 트랜잭션과 같은 트랜잭션에서 OutboxEvent 저장
    ↓
OutboxEvent (DB 저장, PENDING 상태)
    ↓
OutboxEventPublisher (스케줄러가 주기적으로 PENDING 이벤트 읽기)
    - @Scheduled(fixedDelay = 1000)
    - Kafka로 발행 후 PUBLISHED 상태로 변경
    ↓
Kafka Topic (like-events, order-events, product-events)
    ↓
ProductMetricsConsumer (집계 서비스, 다른 JVM)
    - 이벤트 수취 및 메트릭 집계
    - event_handled 테이블로 멱등성 보장
    - version 필드로 최신 이벤트만 반영
```

**관련 코드:**
```java
// 내부 이벤트: ApplicationEvent (JVM 내부)
applicationEventPublisher.publishEvent(new OrderEvent.OrderCreated(...));

// 외부 이벤트: ApplicationEvent → OutboxEvent → Kafka
@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
public void handleOrderCreated(OrderEvent.OrderCreated event) {
    outboxEventService.saveEvent(/* OutboxEvent로 변환하여 DB 저장 */);
}

@Scheduled(fixedDelay = 1000)
public void publishPendingEvents() {
    // PENDING 이벤트를 읽어 Kafka로 발행
}
```

#### 2. Producer 설정: At Least Once 보장 및 이벤트 생성 실패 처리

**배경:**
외부 시스템과의 통신이기 때문에 DB에서 데이터를 직접 조회하거나, 기존의 서비스 로직을 사용하여 검증처리하기는 어려운 상황입니다. 따라서 이벤트 publisher 자체의 설정을 통해 메시지 유실을 방지하고, Consumer 측에서 멱등 처리를 통해 중복을 방지하는 구조로 구성했습니다.

**설정 내용:**
- `acks=all`: Producer가 메시지를 발행할 때, 모든 리플리카에 쓰기가 완료될 때까지 대기합니다. 이렇게 하면 리플리카 중 하나가 실패하더라도 다른 리플리카에 메시지가 저장되어 유실을 방지할 수 있습니다.
- `enable.idempotence=true`: Producer가 동일한 메시지를 여러 번 발행하더라도 Kafka 브로커가 중복을 제거하여 한 번만 저장하도록 합니다. 이를 통해 네트워크 오류로 인한 재시도 시 중복 메시지가 저장되는 것을 방지합니다.
- `max.in.flight.requests.per.connection=5`: `idempotence=true`일 때 필수 설정입니다. 동시에 전송할 수 있는 미확인 요청의 최대 개수를 제한합니다.

**관련 코드:**
```yaml
# modules/kafka/src/main/resources/kafka.yml
spring:
  kafka:
    producer:
      key-serializer: org.apache.kafka.common.serialization.StringSerializer
      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
      retries: 3
      properties:
        acks: all                    # 모든 리플리카에 쓰기 확인 (At Least Once 보장)
        enable.idempotence: true     # 중복 방지 (At Least Once 보장)
        max.in.flight.requests.per.connection: 5  # idempotence=true일 때 필수
```

**고민한 점:**
- `acks=all`은 메시지 유실을 방지하지만, 모든 리플리카에 쓰기가 완료될 때까지 대기하므로 지연 시간이 증가할 수 있습니다. 하지만 메시지 유실을 방지하는 것이 더 중요하다고 판단하여 `acks=all`을 선택했습니다.
- `enable.idempotence=true`는 Producer 측에서 중복을 제거하지만, 네트워크 오류나 Consumer 재시작 등의 상황에서 동일한 메시지가 여러 번 전달될 수 있습니다. 따라서 Consumer 측에서도 멱등 처리가 필요합니다.

#### 3. Consumer 설정: Manual Ack 처리

**배경:**
Consumer가 이벤트를 처리하는 과정에서 오류가 발생할 수 있습니다. 만약 자동 커밋을 사용하면, 이벤트를 처리하기 전에 offset이 커밋되어 이벤트가 유실될 수 있습니다. 반대로 이벤트 처리 실패 시에도 offset이 커밋되지 않도록 하여 재처리가 가능하도록 해야 합니다.

**설정 내용:**
- `enable-auto-commit: false`: 자동 커밋을 비활성화하여 수동 커밋을 사용합니다.
- `ack-mode: manual`: 수동 커밋 모드를 사용하여, 이벤트 처리 성공 후에만 `Acknowledgment.acknowledge()`를 호출하여 offset을 커밋합니다.

**처리 흐름:**
1. Consumer가 메시지를 수신합니다.
2. 각 메시지를 처리합니다 (멱등성 체크, 비즈니스 로직 실행, event_handled 테이블에 기록).
3. 모든 메시지 처리 완료 후 `acknowledgment.acknowledge()`를 호출하여 offset을 커밋합니다.
4. 만약 처리 중 오류가 발생하면 `acknowledgment.acknowledge()`를 호출하지 않아 offset이 커밋되지 않으므로, Consumer가 재시작되거나 다음 poll 시 동일한 메시지를 다시 받아 재처리할 수 있습니다.

**관련 코드:**
```yaml
# modules/kafka/src/main/resources/kafka.yml
spring:
  kafka:
    consumer:
      group-id: loopers-default-consumer
      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
      properties:
        enable-auto-commit: false    # 자동 커밋 비활성화
    listener:
      ack-mode: manual                # 수동 커밋 모드
```

```java
// ProductMetricsConsumer.java - 처리 성공 후에만 수동 커밋
@KafkaListener(topics = "like-events")
public void consumeLikeEvents(..., Acknowledgment acknowledgment) {
    // 이벤트 처리 로직
    acknowledgment.acknowledge();  // 성공 시에만 커밋
}
```

**고민한 점:**
- Manual Ack를 사용하면 이벤트 처리 성공 후에만 offset이 커밋되므로, 처리 실패 시 재처리가 가능합니다. 하지만 Consumer가 재시작되거나 장애가 발생하면 처리 중이던 메시지들이 다시 처리될 수 있습니다. 따라서 멱등 처리가 필수적입니다.
- 배치 처리 시 모든 메시지 처리 완료 후 한 번에 커밋하는 방식과, 각 메시지 처리 후 개별적으로 커밋하는 방식 중 선택할 수 있습니다. 현재는 배치 처리 후 한 번에 커밋하는 방식을 사용했는데, 이는 성능상 유리하지만 일부 메시지 처리 실패 시 전체 배치가 재처리됩니다. 개별 커밋 방식은 성능이 떨어지지만 실패한 메시지만 재처리할 수 있습니다.

#### 4. 멱등성 처리: event_handled 테이블

**배경:**
Kafka의 At Least Once 보장과 Manual Ack 처리로 인해, 동일한 이벤트가 여러 번 전달될 수 있습니다. 또한 Consumer가 여러 인스턴스로 실행되는 경우, 동시에 같은 이벤트를 처리하려고 할 수 있습니다. 이러한 상황에서 중복 처리를 방지하기 위해 `event_handled` 테이블을 사용합니다.

**구현 방식:**
- 각 이벤트에 고유한 UUID 기반 `eventId`를 부여합니다.
- Consumer에서 이벤트를 처리하기 전에 `event_handled` 테이블에서 해당 `eventId`가 이미 처리되었는지 확인합니다.
- 이미 처리된 경우 스킵하고, 처리되지 않은 경우에만 비즈니스 로직을 실행한 후 `event_handled` 테이블에 기록을 저장합니다.
- `event_handled` 테이블의 `event_id` 컬럼에 UNIQUE 제약조건을 설정하여, 동시성 상황에서도 중복 처리를 방지합니다.

**관련 코드:**
```java
// EventHandled.java - eventId에 UNIQUE 제약조건
@Entity
public class EventHandled {
    @Id
    @Column(unique = true)
    private String eventId;  // UNIQUE 제약조건으로 동시성 보장
}

// ProductMetricsConsumer.java - 중복 체크
if (eventHandledService.isAlreadyHandled(eventId)) continue;
productMetricsService.incrementLikeCount(...);
eventHandledService.markAsHandled(eventId, ...);  // UNIQUE 제약조건으로 중복 방지
```

**고민한 점:**
- `event_handled` 테이블을 DB로 구현했지만, Redis를 사용하는 것도 고려할 수 있습니다. Redis는 TTL을 쉽게 설정할 수 있고 조회 성능이 빠르지만, 영속성이 보장되지 않습니다. DB는 영속성이 보장되지만 TTL 설정이 복잡하고 조회 성능이 상대적으로 느릴 수 있습니다. 현재는 DB를 선택했는데, 이는 영속성이 중요하고 TTL은 별도 아카이빙 전략으로 해결할 수 있다고 판단했기 때문입니다.
- `event_handled` 테이블이 계속 증가하는 문제가 있습니다. 시간이 지나면서 이 테이블의 데이터가 무한정 증가하게 되는데, 이는 스토리지 비용과 조회 성능에 영향을 줄 수 있습니다. TTL을 설정하여 일정 기간이 지난 레코드를 자동으로 삭제하거나, 아카이빙 전략을 수립하여 오래된 데이터를 별도 테이블로 이동시키는 등의 방안이 필요할 수 있습니다.

#### 5. 버전 기반 최신 이벤트만 반영

**배경:**
네트워크 지연이나 파티션 순서 문제로 인해, 이벤트가 발생한 순서와 Consumer가 받는 순서가 다를 수 있습니다. 예를 들어, `version=3` 이벤트가 먼저 도착하고 `version=2` 이벤트가 나중에 도착하는 경우, `version=2` 이벤트를 처리하면 이미 `version=3`으로 업데이트된 메트릭을 덮어쓰게 되어 잘못된 상태가 됩니다.

**해결 방안:**
- `OutboxEvent`에 `aggregateId`별로 순차적으로 증가하는 `version` 필드를 부여합니다.
- 이 `version`은 Kafka 메시지 헤더에 포함되어 Consumer로 전달됩니다.
- Consumer에서 이벤트를 처리할 때, `ProductMetrics`의 현재 `version`과 이벤트의 `version`을 비교합니다.
- 이벤트의 `version`이 메트릭의 `version`보다 크면 업데이트하고, 그렇지 않으면 스킵합니다.

**구현 방식:**
- `OutboxEventService.saveEvent()`에서 `aggregateId`별 최신 버전을 조회한 후 +1하여 새로운 버전을 부여합니다.
- `ProductMetrics`에도 `version` 필드를 두고, 업데이트할 때마다 증가시킵니다.
- `ProductMetrics.shouldUpdate()` 메서드로 이벤트 버전과 메트릭 버전을 비교하여, 이벤트가 최신인 경우에만 업데이트합니다.

**전체 플로우 다이어그램:**
```
[도메인 이벤트 발생]
    ↓
[OutboxBridgeEventListener]
    ↓
[OutboxEventService.saveEvent()]
    ├─ aggregateId별 최신 버전 조회 (DB)
    ├─ 버전 +1 계산
    └─ OutboxEvent에 version 저장 (DB)
    ↓
[OutboxEventPublisher (스케줄러, 1초마다)]
    ├─ PENDING 이벤트 조회
    ├─ Kafka 메시지 헤더에 version 추가
    └─ Kafka로 발행
    ↓
[ProductMetricsConsumer]
    ├─ Kafka 헤더에서 version 추출
    ├─ ProductMetricsService에 version 전달
    └─ version 비교로 최신 이벤트만 반영
```

**핵심 코드 위치:**

**1) 버전 생성: OutboxEventService.saveEvent() (59-60줄)**
```java
// 집계 ID별 최신 버전 조회 후 +1
Long latestVersion = outboxEventRepository.findLatestVersionByAggregateId(aggregateId, aggregateType);
Long nextVersion = latestVersion + 1L;
```

**2) Kafka 헤더에 추가: OutboxEventPublisher.publishEvent() (99-102줄)**
```java
// version이 있으면 헤더에 추가
if (event.getVersion() != null) {
    messageBuilder.setHeader("version", event.getVersion());
}
```

**3) Consumer에서 추출: ProductMetricsConsumer.extractVersion() (374-387줄)**
```java
// Kafka 헤더에서 version 추출
Header header = record.headers().lastHeader(VERSION_HEADER);
return Long.parseLong(new String(header.value(), StandardCharsets.UTF_8));
```

**4) 버전 비교: ProductMetricsService에서 eventVersion과 metrics.version 비교하여 최신 이벤트만 반영**

이렇게 `aggregateId`별로 순차적인 버전이 생성되어 Kafka 헤더로 전달되고, Consumer에서 최신 이벤트만 반영하는 데 사용됩니다.

**관련 코드:**
```java
// OutboxEventService.java - aggregateId별 순차적 version 부여
Long nextVersion = findLatestVersionByAggregateId(...) + 1L;

// ProductMetrics.java - version 비교로 최신 이벤트만 반영
public boolean shouldUpdate(Long eventVersion) {
    return eventVersion > this.version;  // 이벤트 버전이 더 크면 업데이트
}

// ProductMetricsService.java
if (!metrics.shouldUpdate(eventVersion)) return;  // 오래된 이벤트 스킵
metrics.incrementLikeCount();
```

**고민한 점:**
- `version` 필드는 `aggregateId`별로 자동 증가하도록 구현했는데, 이 방식의 장점은 간단하고 순차적인 버전 관리가 가능하다는 것입니다. 하지만 `updatedAt` 기반 방식과 비교했을 때, `updatedAt`은 시간 기반이므로 네트워크 지연이나 시스템 시간 불일치 문제가 발생할 수 있습니다. 반면 `version`은 순차적으로 증가하므로 이러한 문제가 없습니다. 다만, `aggregateId`별로 별도의 버전을 관리해야 하므로 복잡도가 증가합니다.
- `version` 필드가 `aggregateId`별로 관리되므로, 같은 `aggregateId`에 대한 이벤트는 순차적으로 처리되어야 합니다. 하지만 파티션 키를 `aggregateId`로 설정했으므로, 같은 `aggregateId`에 대한 이벤트는 같은 파티션에서 순서대로 처리되므로 이 문제는 해결됩니다.

#### 6. 파티션 키 설정

**배경:**
Kafka는 기본적으로 파티션 내에서만 순서를 보장하고, 서로 다른 파티션 간의 순서는 보장하지 않습니다. 따라서 같은 aggregate root에 대한 이벤트는 같은 파티션에서 처리되어야 순서가 보장됩니다.

#### 7. 퍼블리셔와 컨슈머가 동일 이벤트를 판단하는 기준 설정

**배경 및 문제 상황:**
aggregate root id(예: `productId`, `orderId`)만으로는 해당 event가 동일한 항목을 지정하는지 보장하기 어렵습니다. 예를 들어, 같은 `productId`에 대해 여러 번 좋아요가 추가되면, 각각은 서로 다른 이벤트이지만 `productId`만으로는 구분할 수 없습니다. 또한 네트워크 오류나 Consumer 재시작으로 인해 동일한 이벤트가 여러 번 전달될 수 있는데, `productId`만으로는 이것이 중복인지 새로운 이벤트인지 판단할 수 없습니다.

**해결 방안:**
이러한 문제를 해결하기 위해 두 가지 식별자를 조합하여 사용합니다:
1. **eventId (UUID)**: 각 이벤트에 고유한 UUID를 부여하여, 동일한 이벤트는 한 번만 처리될 수 있도록 합니다.
2. **version**: 같은 aggregate root에 대한 이벤트의 순서를 보장하고, 오래된 이벤트가 최신 상태를 덮어쓰는 것을 방지합니다.

**구현 세부사항:**

**1) eventId를 통한 동일 이벤트 판단:**
- `OutboxEventService.saveEvent()`에서 각 이벤트에 UUID 기반의 고유한 `eventId`를 부여합니다.
- 이 `eventId`는 Kafka 메시지 헤더에 포함되어 Consumer로 전달됩니다.
- Consumer에서 이벤트를 처리하기 전에 `event_handled` 테이블에서 해당 `eventId`가 이미 처리되었는지 확인합니다.
- 이미 처리된 경우 스킵하고, 처리되지 않은 경우에만 비즈니스 로직을 실행한 후 `event_handled` 테이블에 기록을 저장합니다.
- 이렇게 하면 동일한 이벤트가 여러 번 전달되더라도 한 번만 처리됩니다.

**2) version을 통한 불필요한 이벤트 처리 방지:**
- `OutboxEventService.saveEvent()`에서 `aggregateId`별로 순차적으로 증가하는 `version`을 부여합니다.
- 이 `version`은 Kafka 메시지 헤더에 포함되어 Consumer로 전달됩니다.
- Consumer에서 이벤트를 처리할 때, `ProductMetrics`의 현재 `version`과 이벤트의 `version`을 비교합니다.
- 이벤트의 `version`이 메트릭의 `version`보다 크면 업데이트하고, 그렇지 않으면 스킵합니다.
- 이렇게 하면 네트워크 지연이나 파티션 순서 문제로 인해 오래된 이벤트가 나중에 도착하더라도, 이미 더 최신 버전의 메트릭이 존재하면 오래된 이벤트는 무시됩니다.

**관련 코드:**
```java
// OutboxEventService.java - eventId(UUID)와 version(aggregateId별 순차 증가) 부여
String eventId = UUID.randomUUID().toString();
Long nextVersion = findLatestVersionByAggregateId(...) + 1L;

// OutboxEventPublisher.java - Kafka 헤더에 eventId와 version 포함
messageBuilder.setHeader("eventId", event.getEventId())
              .setHeader("version", event.getVersion());

// ProductMetricsConsumer.java - eventId로 중복 체크, version으로 최신 이벤트만 반영
String eventId = extractEventId(record);
if (eventHandledService.isAlreadyHandled(eventId)) continue;
Long eventVersion = extractVersion(record);
productMetricsService.incrementLikeCount(productId, eventVersion);  // version 비교 포함
```

**고민한 점:**
- `eventId`와 `version`을 모두 사용하는 것이 중복일 수 있다는 의문이 있습니다. 하지만 두 가지는 서로 다른 목적을 가지고 있습니다. `eventId`는 동일한 이벤트의 완전 중복을 방지하고, `version`은 순서가 뒤바뀐 이벤트를 처리하지 않도록 합니다. 예를 들어, 네트워크 문제로 인해 `version=3` 이벤트가 먼저 도착하고 `version=2` 이벤트가 나중에 도착하는 경우, `eventId`로는 중복을 감지할 수 없지만 `version`으로는 오래된 이벤트임을 감지할 수 있습니다. 반대로, 동일한 이벤트가 네트워크 오류로 인해 여러 번 전달되는 경우, `version`으로는 중복을 감지할 수 없지만 `eventId`로는 중복을 감지할 수 있습니다.

- `aggregateId`만으로는 동일 이벤트를 판단할 수 없는 이유는, 같은 `aggregateId`에 대해 여러 번 이벤트가 발생할 수 있기 때문입니다. 예를 들어, 같은 상품에 대해 좋아요가 여러 번 추가되면, 각각은 서로 다른 이벤트이지만 `productId`만으로는 구분할 수 없습니다. 따라서 각 이벤트에 고유한 `eventId`를 부여하여 구분해야 합니다.

- `version`은 `aggregateId`별로 관리되므로, 같은 `aggregateId`에 대한 이벤트는 순차적으로 처리되어야 합니다. 하지만 파티션 키를 `aggregateId`로 설정했으므로, 같은 `aggregateId`에 대한 이벤트는 같은 파티션에서 순서대로 처리되므로 이 문제는 해결됩니다.

#### 6. 파티션 키 설정

**배경:**
Kafka는 기본적으로 파티션 내에서만 순서를 보장하고, 서로 다른 파티션 간의 순서는 보장하지 않습니다. 따라서 같은 aggregate root에 대한 이벤트는 같은 파티션에서 처리되어야 순서가 보장됩니다.

**설정 내용:**
- `like-events`, `product-events`: `productId`를 파티션 키로 사용하여, 같은 상품에 대한 이벤트는 항상 같은 파티션에서 순서대로 처리됩니다.
- `order-events`: `orderId`를 파티션 키로 사용하여, 같은 주문에 대한 이벤트는 항상 같은 파티션에서 순서대로 처리됩니다.

**관련 코드:**
```java
// OutboxBridgeEventListener.java - 파티션 키 설정
outboxEventService.saveEvent(..., partitionKey: productId.toString());  // like-events, product-events
outboxEventService.saveEvent(..., partitionKey: orderId.toString());     // order-events

// OutboxEventPublisher.java - Kafka 메시지에 파티션 키 설정
messageBuilder.setHeader(KafkaHeaders.KEY, event.getPartitionKey());
```

**고민한 점:**
- 파티션 키를 `productId` 또는 `orderId`로 설정했는데, 이로 인한 파티션 불균형 문제가 발생할 수 있습니다. 예를 들어, 특정 상품에 대한 이벤트가 매우 많으면 해당 상품의 파티션에만 메시지가 집중되어 다른 파티션은 비어있을 수 있습니다. 하지만 현재 구현에서는 파티션 키를 사용하여 순서를 보장하는 것이 더 중요하다고 판단했습니다. 만약 파티션 불균형이 심각한 문제가 된다면, 파티션 키를 해시 함수로 변환하거나, 복합 키를 사용하는 등의 방안을 고려할 수 있습니다.
- 파티션 키를 사용하지 않고 랜덤 키를 사용하면 어떤 문제가 발생할까요? 예를 들어, 같은 상품에 대한 `LikeAdded`와 `LikeRemoved` 이벤트가 서로 다른 파티션에 발행되면, Consumer가 `LikeRemoved`를 먼저 처리하고 `LikeAdded`를 나중에 처리할 수 있습니다. 이 경우 좋아요 수가 음수가 되거나 잘못된 메트릭이 생성될 수 있습니다. 따라서 파티션 키를 사용하여 같은 aggregate root에 대한 이벤트는 항상 같은 파티션에서 순서대로 처리되도록 하는 것이 중요합니다.


## ✅ Checklist
- [x] **도메인(애플리케이션) 이벤트 설계**
  - `apps/commerce-api/src/main/java/com/loopers/domain/like/LikeEvent.java`
  - `apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEvent.java`
  - `apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEvent.java`
  - 이벤트 타입: `LikeAdded`, `LikeRemoved`, `OrderCreated`, `ProductViewed`

- [x] **Producer 앱에서 도메인 이벤트 발행**
  - `apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxBridgeEventListener.java`
  - `apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventPublisher.java`
  - 토픽: `like-events`, `order-events`, `product-events`

- [x] **PartitionKey 기반의 이벤트 순서 보장**
  - `apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxEvent.java` (partitionKey 필드)
  - `apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventPublisher.java` (KafkaHeaders.KEY 설정)
  - 파티션 키: `like-events`, `product-events` → `productId`, `order-events` → `orderId`

- [x] **At Least Once 보장 (acks=all, idempotence=true)**
  - `modules/kafka/src/main/resources/kafka.yml` (19-21줄)
  - 설정: `acks: all`, `enable.idempotence: true`, `max.in.flight.requests.per.connection: 5`

- [x] **Transactional Outbox Pattern 구현**
  - `apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxEvent.java`
  - `apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxEventService.java`
  - `apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventPublisher.java`
  - `apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxBridgeEventListener.java`

- [x] **메시지 발행 실패 처리**
  - `apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventPublisher.java` (63-69줄)
  - 개별 이벤트 발행 실패 시 `FAILED` 상태로 변경하고 다음 스케줄에서 재시도

### ⚾ Consumer (7/7)

- [x] **Consumer가 Metrics 집계 처리**
  - `apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ProductMetricsConsumer.java`
  - `apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java`
  - 집계 대상: 좋아요 수, 판매량, 조회 수

- [x] **Manual Ack 처리**
  - `modules/kafka/src/main/resources/kafka.yml` (27, 29줄)
  - `apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ProductMetricsConsumer.java` (141, 217줄)
  - 설정: `enable-auto-commit: false`, `ack-mode: manual`

- [x] **`event_handled` 테이블 기반 멱등 처리**
  - `apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandled.java`
  - `apps/commerce-streamer/src/main/java/com/loopers/application/eventhandled/EventHandledService.java`
  - `apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ProductMetricsConsumer.java` (91, 275줄)
  - UNIQUE 제약조건으로 동시성 상황에서도 중복 방지

- [x] **`version` 기준 최신 이벤트만 반영**
  - `apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxEvent.java` (56줄, version 필드)
  - `apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxEventService.java` (59-60줄, 버전 생성)
  - `apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxEventPublisher.java` (99-102줄, 헤더에 추가)
  - `apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ProductMetricsConsumer.java` (100, 284줄, 헤더에서 추출)
  - `apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java` (100, 126줄, 버전 비교)
  - `apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java` (shouldUpdate 메서드)

- [x] **`product_metrics` 테이블에 upsert**
  - `apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java`
  - `apps/commerce-streamer/src/main/java/com/loopers/application/metrics/ProductMetricsService.java`
  - `apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java`

- [x] **중복 메시지 재전송 테스트**
  - `apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/ProductMetricsConsumerTest.java` (352줄, `handlesDuplicateMessagesIdempotently()`)
  - 동일한 `eventId`를 가진 메시지가 한 번만 처리되는지 검증

- [x] **재고 소진 시 상품 캐시 갱신**
  - `apps/commerce-api/src/main/java/com/loopers/application/product/ProductEventHandler.java` (147-151줄)
  - `apps/commerce-api/src/main/java/com/loopers/application/product/ProductCacheService.java` (evictProductDetailCache 메서드)
  - 재고 차감 후 `stock == 0` 체크하여 캐시 무효화

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상품 조회, 좋아요, 주문 이벤트에 대한 실시간 메트릭 추적 시스템 추가
  * 신뢰할 수 있는 이벤트 기반 아키텍처로 데이터 처리 안정성 향상
  * 중복 이벤트 처리 방지를 위한 멱등성 보장 메커니즘 구현

* **테스트**
  * 이벤트 처리 및 메트릭 추적 관련 종합 테스트 스위트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->