### PR TITLE
[volume - 8] Decoupling with Kafka 

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
     implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeEvent.java
@@ -3,18 +3,20 @@ package com.loopers.application.like;
 public class LikeEvent {
 
     public record LikeRecorded(
-            Long productId
+            Long productId,
+            Long userId
     ) {
-        public static LikeRecorded from(Long productId) {
-            return new LikeRecorded(productId);
+        public static LikeRecorded from(Long productId, Long userId) {
+            return new LikeRecorded(productId, userId);
         }
     }
 
     public record LikeCancelled(
-            Long productId
+            Long productId,
+            Long userId
     ) {
-        public static LikeCancelled from(Long productId) {
-            return new LikeCancelled(productId);
+        public static LikeCancelled from(Long productId, Long userId) {
+            return new LikeCancelled(productId, userId);
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -47,7 +47,7 @@ public class LikeFacade {
         boolean wasCreated = likeService.recordLikeIfAbsent(user.getId(), command.productId());
 
         if (wasCreated) {
-            eventPublisher.publishEvent(LikeEvent.LikeRecorded.from(command.productId()));
+            eventPublisher.publishEvent(LikeEvent.LikeRecorded.from(command.productId(), user.getId()));
             eventPublisher.publishEvent(UserBehaviorEvent.LikeRecorded.from(user.getId(), command.productId()));
         }
 
@@ -82,7 +82,7 @@ public class LikeFacade {
         boolean wasDeleted = likeService.cancelLikeIfPresent(user.getId(), command.productId());
 
         if (wasDeleted) {
-            eventPublisher.publishEvent(LikeEvent.LikeCancelled.from(command.productId()));
+            eventPublisher.publishEvent(LikeEvent.LikeCancelled.from(command.productId(), user.getId()));
             eventPublisher.publishEvent(UserBehaviorEvent.LikeCancelled.from(user.getId(), command.productId()));
         }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEvent.java
@@ -1,6 +1,7 @@
 package com.loopers.application.order;
 
 import com.loopers.domain.order.Order;
+import java.util.List;
 
 public class OrderEvent {
 
@@ -40,16 +41,35 @@ public class OrderEvent {
             String orderKey,
             Long orderId,
             Long userId,
-            Integer totalPrice
+            Integer totalPrice,
+            List<OrderItemInfo> orderItems
     ) {
         public static OrderPaid from(Order order) {
+            List<OrderItemInfo> orderItemInfos = order.getOrderItems().stream()
+                    .map(item -> new OrderItemInfo(
+                            item.getProductId(),
+                            item.getProductName(),
+                            item.getPrice(),
+                            item.getQuantity()
+                    ))
+                    .toList();
+            
             return new OrderPaid(
                     order.getOrderKey(),
                     order.getId(),
                     order.getUserId(),
-                    order.getOriginalTotalPrice() - (order.getDiscountPrice() != null ? order.getDiscountPrice() : 0)
+                    order.getOriginalTotalPrice() - (order.getDiscountPrice() != null ? order.getDiscountPrice() : 0),
+                    orderItemInfos
             );
         }
+    }
+
+    public record OrderItemInfo(
+            Long productId,
+            String productName,
+            Integer price,
+            Integer quantity
+    ) {
     }
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEvent.java
@@ -19,6 +19,8 @@ public class OrderEvent {
     public record OrderCreated(
             String loginId,
             String orderKey,
+            Long orderId,
+            Long userId,
             Integer originalTotalPrice,
             Integer discountPrice
     ) {
@@ -26,8 +28,26 @@ public class OrderEvent {
             return new OrderCreated(
                     loginId,
                     order.getOrderKey(),
+                    order.getId(),
+                    order.getUserId(),
                     order.getOriginalTotalPrice(),
                     order.getDiscountPrice()
+            );
+        }
+    }
+
+    public record OrderPaid(
+            String orderKey,
+            Long orderId,
+            Long userId,
+            Integer totalPrice
+    ) {
+        public static OrderPaid from(Order order) {
+            return new OrderPaid(
+                    order.getOrderKey(),
+                    order.getId(),
+                    order.getUserId(),
+                    order.getOriginalTotalPrice() - (order.getDiscountPrice() != null ? order.getDiscountPrice() : 0)
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductEvent.java
@@ -1,0 +1,21 @@
+package com.loopers.application.product;
+
+import java.time.ZonedDateTime;
+
+public class ProductEvent {
+
+    public record StockDepleted(
+            Long productId,
+            Integer remainingStock,
+            ZonedDateTime timestamp
+    ) {
+        public static StockDepleted from(Long productId, Integer remainingStock) {
+            return new StockDepleted(
+                    productId,
+                    remainingStock,
+                    ZonedDateTime.now()
+            );
+        }
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/outbox/Outbox.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/outbox/Outbox.java
@@ -1,0 +1,63 @@
+package com.loopers.domain.outbox;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "outbox")
+@Getter
+public class Outbox extends BaseEntity {
+
+    @Column(nullable = false, length = 100)
+    private String topic;
+
+    @Column(nullable = false, length = 100)
+    private String partitionKey;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OutboxStatus status;
+
+    @Column(length = 500)
+    private String errorMessage;
+
+    @Column(nullable = false)
+    private Integer retryCount;
+
+    @Builder
+    private Outbox(String topic, String partitionKey, String payload, OutboxStatus status, Integer retryCount) {
+        this.topic = topic;
+        this.partitionKey = partitionKey;
+        this.payload = payload;
+        this.status = status;
+        this.retryCount = retryCount != null ? retryCount : 0;
+    }
+
+    public Outbox() {
+        this.retryCount = 0;
+    }
+
+    public static Outbox create(String topic, String partitionKey, String payload) {
+        return Outbox.builder()
+                .topic(topic)
+                .partitionKey(partitionKey)
+                .payload(payload)
+                .status(OutboxStatus.PENDING)
+                .retryCount(0)
+                .build();
+    }
+
+    public boolean hasExceededMaxRetries(int maxRetries) {
+        return this.retryCount >= maxRetries;
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.outbox;
+
+import java.util.List;
+
+public interface OutboxRepository {
+    void saveOutbox(Outbox outbox);
+
+    List<Outbox> findPendingOutboxes(int limit);
+
+    List<Outbox> findFailedAndRetryableOutboxes(int limit, int maxRetries);
+
+    void markAsPublished(Long id);
+
+    void markAsFailed(Long id, String message);
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxService.java
@@ -1,0 +1,81 @@
+package com.loopers.domain.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class OutboxService {
+
+    private static final int MAX_RETRIES = 3;
+
+    private final OutboxRepository outboxRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void saveOutbox(String topic, String partitionKey, Object event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            Outbox outbox = Outbox.create(topic, partitionKey, payload);
+            outboxRepository.saveOutbox(outbox);
+        } catch (Exception e) {
+            throw new CoreException(ErrorType.INTERNAL_ERROR, "이벤트 저장에 실패했습니다.");
+        }
+    }
+
+    public void publishPendingOutboxes(int batchSize) {
+        List<Outbox> pendingOutboxes = outboxRepository.findPendingOutboxes(batchSize);
+
+        for (Outbox outbox : pendingOutboxes) {
+            kafkaTemplate
+                    .send(
+                            outbox.getTopic(),
+                            outbox.getPartitionKey(),
+                            outbox.getPayload()
+                    )
+                    .whenComplete((result, exception) -> {
+                        if (exception == null) {
+                            outboxRepository.markAsPublished(outbox.getId());
+                        } else {
+                            outboxRepository.markAsFailed(outbox.getId(), exception.getMessage());
+                        }
+                    });
+        }
+    }
+
+    public void retryFailedOutboxes(int batchSize) {
+        List<Outbox> failedOutboxes = outboxRepository.findFailedAndRetryableOutboxes(batchSize, MAX_RETRIES);
+
+        for (Outbox outbox : failedOutboxes) {
+            if (outbox.hasExceededMaxRetries(MAX_RETRIES)) {
+                log.warn("Outbox 재시도 횟수 초과: outboxId={}, retryCount={}, topic={}",
+                        outbox.getId(), outbox.getRetryCount(), outbox.getTopic());
+                continue;
+            }
+
+            kafkaTemplate
+                    .send(
+                            outbox.getTopic(),
+                            outbox.getPartitionKey(),
+                            outbox.getPayload()
+                    )
+                    .whenComplete((result, exception) -> {
+                        if (exception == null) {
+                            outboxRepository.markAsPublished(outbox.getId());
+                        } else {
+                            outboxRepository.markAsFailed(outbox.getId(), exception.getMessage());
+                        }
+                    });
+        }
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxStatus.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.outbox;
+
+public enum OutboxStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -5,7 +5,6 @@ import com.loopers.support.error.ErrorType;
 import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -14,7 +13,6 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final PaymentClient paymentClient;
-    private final ApplicationEventPublisher eventPublisher;
 
     public void createPayment(Integer amount, String orderKey) {
         Payment payment = Payment.createPayment(amount, orderKey);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -134,4 +134,8 @@ public class Product extends BaseEntity {
             throw new CoreException(ErrorType.BAD_REQUEST, "재고는 필수입니다.");
         }
     }
+
+    public boolean isStockZero() {
+        return this.stock.getQuantity() != null && this.stock.getQuantity().equals(0);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -54,18 +54,20 @@ public class ProductService {
     }
 
     @Transactional
-    public void increaseLikeCount(Long productId) {
+    public Product increaseLikeCount(Long productId) {
         Product product = productRepository.findProductById(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
         product.increaseLikeCount();
         productRepository.saveProduct(product);
+        return product;
     }
 
     @Transactional
-    public void decreaseLikeCount(Long productId) {
+    public Product decreaseLikeCount(Long productId) {
         Product product = productRepository.findProductById(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
         product.decreaseLikeCount();
         productRepository.saveProduct(product);
+        return product;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,10 +1,12 @@
 package com.loopers.domain.product;
 
+import com.loopers.application.product.ProductEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public Optional<Product> findProductById(Long productId) {
@@ -28,7 +31,10 @@ public class ProductService {
     public void decreaseStock(Long productId, Integer quantity) {
         Product product = getProductById(productId);
         product.reduceStock(quantity);
-        productRepository.saveProduct(product);
+
+        if (product.isStockZero()) {
+            eventPublisher.publishEvent(ProductEvent.StockDepleted.from(productId, 0));
+        }
     }
 
     public void restoreStock(Product product, Integer quantity) {
@@ -48,20 +54,18 @@ public class ProductService {
     }
 
     @Transactional
-    public Product increaseLikeCount(Long productId) {
+    public void increaseLikeCount(Long productId) {
         Product product = productRepository.findProductById(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
         product.increaseLikeCount();
         productRepository.saveProduct(product);
-        return product;
     }
 
     @Transactional
-    public Product decreaseLikeCount(Long productId) {
+    public void decreaseLikeCount(Long productId) {
         Product product = productRepository.findProductById(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
         product.decreaseLikeCount();
         productRepository.saveProduct(product);
-        return product;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxJpaRepository.java
@@ -3,6 +3,7 @@ package com.loopers.infrastructure.outbox;
 import com.loopers.domain.outbox.Outbox;
 import com.loopers.domain.outbox.OutboxStatus;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,10 +11,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface OutboxJpaRepository extends JpaRepository<Outbox, Long> {
     @Query("SELECT o FROM Outbox o WHERE o.status = :status ORDER BY o.createdAt ASC")
-    List<Outbox> findByStatusOrderByCreatedAtAsc(@Param("status") OutboxStatus status);
+    List<Outbox> findByStatusOrderByCreatedAtAsc(@Param("status") OutboxStatus status, Pageable pageable);
 
     @Query("SELECT o FROM Outbox o WHERE o.status = :status AND o.retryCount < :maxRetries ORDER BY o.createdAt ASC")
-    List<Outbox> findFailedOutboxesForRetry(@Param("status") OutboxStatus status, @Param("maxRetries") int maxRetries);
+    List<Outbox> findFailedOutboxesForRetry(@Param("status") OutboxStatus status, @Param("maxRetries") int maxRetries, Pageable pageable);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Outbox o SET o.status = 'PUBLISHED', o.errorMessage = NULL WHERE o.id = :id")

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxJpaRepository.java
@@ -1,0 +1,27 @@
+package com.loopers.infrastructure.outbox;
+
+import com.loopers.domain.outbox.Outbox;
+import com.loopers.domain.outbox.OutboxStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OutboxJpaRepository extends JpaRepository<Outbox, Long> {
+    @Query("SELECT o FROM Outbox o WHERE o.status = :status ORDER BY o.createdAt ASC")
+    List<Outbox> findByStatusOrderByCreatedAtAsc(@Param("status") OutboxStatus status);
+
+    @Query("SELECT o FROM Outbox o WHERE o.status = :status AND o.retryCount < :maxRetries ORDER BY o.createdAt ASC")
+    List<Outbox> findFailedOutboxesForRetry(@Param("status") OutboxStatus status, @Param("maxRetries") int maxRetries);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Outbox o SET o.status = 'PUBLISHED', o.errorMessage = NULL WHERE o.id = :id")
+    void updateOutboxPublishedStatus(@Param("id") Long id);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Outbox o SET o.status = 'FAILED', o.errorMessage = :message, o.retryCount = o.retryCount + 1 WHERE o.id = :id")
+    void updateOutboxFailedStatusAndErrorMessageAndRetryCount(@Param("id") Long id,
+                                                              @Param("message") String message);
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.loopers.domain.outbox.OutboxRepository;
 import com.loopers.domain.outbox.OutboxStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,18 +22,12 @@ public class OutboxRepositoryImpl implements OutboxRepository {
 
     @Override
     public List<Outbox> findPendingOutboxes(int limit) {
-        return outboxJpaRepository.findByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING)
-                .stream()
-                .limit(limit)
-                .toList();
+        return outboxJpaRepository.findByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING, PageRequest.of(0, limit));
     }
 
     @Override
     public List<Outbox> findFailedAndRetryableOutboxes(int limit, int maxRetries) {
-        return outboxJpaRepository.findFailedOutboxesForRetry(OutboxStatus.FAILED, maxRetries)
-                .stream()
-                .limit(limit)
-                .toList();
+        return outboxJpaRepository.findFailedOutboxesForRetry(OutboxStatus.FAILED, maxRetries, PageRequest.of(0, limit));
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.loopers.infrastructure.outbox;
+
+import com.loopers.domain.outbox.Outbox;
+import com.loopers.domain.outbox.OutboxRepository;
+import com.loopers.domain.outbox.OutboxStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public void saveOutbox(Outbox outbox) {
+        outboxJpaRepository.save(outbox);
+    }
+
+    @Override
+    public List<Outbox> findPendingOutboxes(int limit) {
+        return outboxJpaRepository.findByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING)
+                .stream()
+                .limit(limit)
+                .toList();
+    }
+
+    @Override
+    public List<Outbox> findFailedAndRetryableOutboxes(int limit, int maxRetries) {
+        return outboxJpaRepository.findFailedOutboxesForRetry(OutboxStatus.FAILED, maxRetries)
+                .stream()
+                .limit(limit)
+                .toList();
+    }
+
+    @Override
+    public void markAsPublished(Long id) {
+        outboxJpaRepository.updateOutboxPublishedStatus(id);
+    }
+
+    @Override
+    public void markAsFailed(Long id, String message) {
+        outboxJpaRepository.updateOutboxFailedStatusAndErrorMessageAndRetryCount(id, message);
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/OutboxRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.loopers.domain.outbox.OutboxStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Repository
@@ -35,11 +36,13 @@ public class OutboxRepositoryImpl implements OutboxRepository {
     }
 
     @Override
+    @Transactional
     public void markAsPublished(Long id) {
         outboxJpaRepository.updateOutboxPublishedStatus(id);
     }
 
     @Override
+    @Transactional
     public void markAsFailed(Long id, String message) {
         outboxJpaRepository.updateOutboxFailedStatusAndErrorMessageAndRetryCount(id, message);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/KafkaOutboxEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/KafkaOutboxEventListener.java
@@ -1,0 +1,81 @@
+package com.loopers.interfaces.listener;
+
+import com.loopers.application.kafka.KafkaEvent;
+import com.loopers.application.like.LikeEvent;
+import com.loopers.application.order.OrderEvent;
+import com.loopers.application.product.ProductEvent;
+import com.loopers.application.userbehavior.UserBehaviorEvent;
+import com.loopers.domain.outbox.OutboxService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaOutboxEventListener {
+
+    private final OutboxService outboxService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCreated(OrderEvent.OrderCreated event) {
+        KafkaEvent.OrderCreated kafkaEvent = KafkaEvent.OrderCreated.from(
+                event.orderKey(),
+                event.userId(),
+                event.orderId(),
+                event.originalTotalPrice(),
+                event.discountPrice()
+        );
+        outboxService.saveOutbox("order-created-events", event.orderKey(), kafkaEvent);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderPaid(OrderEvent.OrderPaid event) {
+        KafkaEvent.OrderPaid kafkaEvent = KafkaEvent.OrderPaid.from(
+                event.orderKey(),
+                event.userId(),
+                event.orderId(),
+                event.totalPrice()
+        );
+        outboxService.saveOutbox("order-paid-events", event.orderKey(), kafkaEvent);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeRecorded(LikeEvent.LikeRecorded event) {
+        KafkaEvent.ProductLiked kafkaEvent = KafkaEvent.ProductLiked.from(
+                event.productId(),
+                event.userId()
+        );
+        outboxService.saveOutbox("product-liked-events", event.productId().toString(), kafkaEvent);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeCancelled(LikeEvent.LikeCancelled event) {
+        KafkaEvent.ProductUnliked kafkaEvent = KafkaEvent.ProductUnliked.from(
+                event.productId(),
+                event.userId()
+        );
+        outboxService.saveOutbox("product-unliked-events", event.productId().toString(), kafkaEvent);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductViewed(UserBehaviorEvent.ProductViewed event) {
+        KafkaEvent.ProductViewed kafkaEvent = KafkaEvent.ProductViewed.from(
+                event.productId(),
+                event.userId()
+        );
+        outboxService.saveOutbox("product-viewed-events", event.productId().toString(), kafkaEvent);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockDepleted(ProductEvent.StockDepleted event) {
+        KafkaEvent.ProductStockDepleted kafkaEvent = KafkaEvent.ProductStockDepleted.from(
+                event.productId(),
+                event.remainingStock()
+        );
+        outboxService.saveOutbox("product-stock-depleted-events", event.productId().toString(), kafkaEvent);
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/KafkaOutboxEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/KafkaOutboxEventListener.java
@@ -20,7 +20,7 @@ public class KafkaOutboxEventListener {
 
     private final OutboxService outboxService;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleOrderCreated(OrderEvent.OrderCreated event) {
         KafkaEvent.OrderEvent.OrderCreated kafkaEvent = KafkaEvent.OrderEvent.OrderCreated.from(
                 event.orderKey(),
@@ -32,7 +32,7 @@ public class KafkaOutboxEventListener {
         outboxService.saveOutbox("order-created-events", event.orderKey(), kafkaEvent);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleOrderPaid(OrderEvent.OrderPaid event) {
         List<KafkaEvent.OrderEvent.OrderItemInfo> orderItemInfos = event.orderItems().stream()
                 .map(item -> new KafkaEvent.OrderEvent.OrderItemInfo(
@@ -53,7 +53,7 @@ public class KafkaOutboxEventListener {
         outboxService.saveOutbox("order-paid-events", event.orderKey(), kafkaEvent);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleLikeRecorded(LikeEvent.LikeRecorded event) {
         KafkaEvent.ProductEvent.ProductLiked kafkaEvent = KafkaEvent.ProductEvent.ProductLiked.from(
                 event.productId(),
@@ -62,7 +62,7 @@ public class KafkaOutboxEventListener {
         outboxService.saveOutbox("product-liked-events", event.productId().toString(), kafkaEvent);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleLikeCancelled(LikeEvent.LikeCancelled event) {
         KafkaEvent.ProductEvent.ProductUnliked kafkaEvent = KafkaEvent.ProductEvent.ProductUnliked.from(
                 event.productId(),
@@ -71,7 +71,7 @@ public class KafkaOutboxEventListener {
         outboxService.saveOutbox("product-unliked-events", event.productId().toString(), kafkaEvent);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleProductViewed(UserBehaviorEvent.ProductViewed event) {
         KafkaEvent.ProductEvent.ProductViewed kafkaEvent = KafkaEvent.ProductEvent.ProductViewed.from(
                 event.productId(),
@@ -80,7 +80,7 @@ public class KafkaOutboxEventListener {
         outboxService.saveOutbox("product-viewed-events", event.productId().toString(), kafkaEvent);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleStockDepleted(ProductEvent.StockDepleted event) {
         KafkaEvent.ProductEvent.ProductStockDepleted kafkaEvent = KafkaEvent.ProductEvent.ProductStockDepleted.from(
                 event.productId(),

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/KafkaOutboxEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/KafkaOutboxEventListener.java
@@ -21,7 +21,7 @@ public class KafkaOutboxEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleOrderCreated(OrderEvent.OrderCreated event) {
-        KafkaEvent.OrderCreated kafkaEvent = KafkaEvent.OrderCreated.from(
+        KafkaEvent.OrderEvent.OrderCreated kafkaEvent = KafkaEvent.OrderEvent.OrderCreated.from(
                 event.orderKey(),
                 event.userId(),
                 event.orderId(),
@@ -32,8 +32,8 @@ public class KafkaOutboxEventListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleOrderPaid(OrderEvent.OrderPaid event) {
-        KafkaEvent.OrderPaid kafkaEvent = KafkaEvent.OrderPaid.from(
+    public void handleOrderPaid(com.loopers.application.order.OrderEvent.OrderPaid event) {
+        KafkaEvent.OrderEvent.OrderPaid kafkaEvent = KafkaEvent.OrderEvent.OrderPaid.from(
                 event.orderKey(),
                 event.userId(),
                 event.orderId(),
@@ -44,7 +44,7 @@ public class KafkaOutboxEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLikeRecorded(LikeEvent.LikeRecorded event) {
-        KafkaEvent.ProductLiked kafkaEvent = KafkaEvent.ProductLiked.from(
+        KafkaEvent.ProductEvent.ProductLiked kafkaEvent = KafkaEvent.ProductEvent.ProductLiked.from(
                 event.productId(),
                 event.userId()
         );
@@ -53,7 +53,7 @@ public class KafkaOutboxEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLikeCancelled(LikeEvent.LikeCancelled event) {
-        KafkaEvent.ProductUnliked kafkaEvent = KafkaEvent.ProductUnliked.from(
+        KafkaEvent.ProductEvent.ProductUnliked kafkaEvent = KafkaEvent.ProductEvent.ProductUnliked.from(
                 event.productId(),
                 event.userId()
         );
@@ -62,7 +62,7 @@ public class KafkaOutboxEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleProductViewed(UserBehaviorEvent.ProductViewed event) {
-        KafkaEvent.ProductViewed kafkaEvent = KafkaEvent.ProductViewed.from(
+        KafkaEvent.ProductEvent.ProductViewed kafkaEvent = KafkaEvent.ProductEvent.ProductViewed.from(
                 event.productId(),
                 event.userId()
         );
@@ -71,7 +71,7 @@ public class KafkaOutboxEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStockDepleted(ProductEvent.StockDepleted event) {
-        KafkaEvent.ProductStockDepleted kafkaEvent = KafkaEvent.ProductStockDepleted.from(
+        KafkaEvent.ProductEvent.ProductStockDepleted kafkaEvent = KafkaEvent.ProductEvent.ProductStockDepleted.from(
                 event.productId(),
                 event.remainingStock()
         );

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/PaymentSuccessListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/listener/PaymentSuccessListener.java
@@ -1,5 +1,6 @@
 package com.loopers.interfaces.listener;
 
+import com.loopers.application.order.OrderEvent;
 import com.loopers.application.payment.PaymentEvent;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
@@ -8,6 +9,7 @@ import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.payment.PaymentStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -19,6 +21,7 @@ public class PaymentSuccessListener {
 
     private final PaymentService paymentService;
     private final OrderService orderService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(PaymentEvent.PaymentCompleted event) {
@@ -31,6 +34,8 @@ public class PaymentSuccessListener {
         Payment payment = paymentService.getPaymentByOrderKey(event.orderKey());
         payment.updateStatus(PaymentStatus.COMPLETED);
         payment.updateTransactionKey(event.transactionKey());
+
+        eventPublisher.publishEvent(OrderEvent.OrderPaid.from(order));
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/scheduler/OutboxRelayScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/scheduler/OutboxRelayScheduler.java
@@ -2,11 +2,13 @@ package com.loopers.interfaces.scheduler;
 
 import com.loopers.domain.outbox.OutboxService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class OutboxRelayScheduler {
 
     private final OutboxService outboxService;
@@ -14,12 +16,24 @@ public class OutboxRelayScheduler {
 
     @Scheduled(fixedDelay = 3000)
     public void relayOutboxEvents() {
-        outboxService.publishPendingOutboxes(BATCH_SIZE);
+        try {
+            log.debug("Outbox 이벤트 릴레이 시작 - batchSize: {}", BATCH_SIZE);
+            outboxService.publishPendingOutboxes(BATCH_SIZE);
+            log.debug("Outbox 이벤트 릴레이 완료");
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 릴레이 중 오류 발생", e);
+        }
     }
 
     @Scheduled(fixedDelay = 5000)
     public void retryFailedOutboxEvents() {
-        outboxService.retryFailedOutboxes(BATCH_SIZE);
+        try {
+            log.debug("실패한 Outbox 이벤트 재시도 시작 - batchSize: {}", BATCH_SIZE);
+            outboxService.retryFailedOutboxes(BATCH_SIZE);
+            log.debug("실패한 Outbox 이벤트 재시도 완료");
+        } catch (Exception e) {
+            log.error("실패한 Outbox 이벤트 재시도 중 오류 발생", e);
+        }
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/scheduler/OutboxRelayScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/scheduler/OutboxRelayScheduler.java
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.scheduler;
+
+import com.loopers.domain.outbox.OutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class OutboxRelayScheduler {
+
+    private final OutboxService outboxService;
+    private static final int BATCH_SIZE = 100;
+
+    @Scheduled(fixedDelay = 3000)
+    public void relayOutboxEvents() {
+        outboxService.publishPendingOutboxes(BATCH_SIZE);
+    }
+
+    @Scheduled(fixedDelay = 5000)
+    public void retryFailedOutboxEvents() {
+        outboxService.retryFailedOutboxes(BATCH_SIZE);
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/CommerceApiContextTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/CommerceApiContextTest.java
@@ -1,10 +1,11 @@
 package com.loopers;
 
+import com.loopers.support.IntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class CommerceApiContextTest {
+class CommerceApiContextTest extends IntegrationTest {
 
     @Test
     void contextLoads() {

--- a/apps/commerce-api/src/test/java/com/loopers/application/brand/BrandFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/brand/BrandFacadeIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandService;
+import com.loopers.support.IntegrationTest;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.util.Optional;
@@ -22,7 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class BrandFacadeIntegrationTest {
+class BrandFacadeIntegrationTest extends IntegrationTest {
 
     @Autowired
     private BrandFacade brandFacade;

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeConcurrencyTest.java
@@ -11,6 +11,7 @@ import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.product.Stock;
 import com.loopers.domain.user.UserService;
+import com.loopers.support.IntegrationTest;
 import com.loopers.utils.DatabaseCleanUp;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +29,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class LikeFacadeConcurrencyTest {
+class LikeFacadeConcurrencyTest extends IntegrationTest {
 
     @Autowired
     private LikeFacade likeFacade;
@@ -122,9 +123,6 @@ class LikeFacadeConcurrencyTest {
         // assert
         assertThat(successCount.get()).isEqualTo(concurrentRequestCount);
         assertThat(failCount.get()).isEqualTo(0);
-
-        Product finalProduct = productService.findProductById(productId).orElseThrow();
-        assertThat(finalProduct.getLikeCount().getCount()).isEqualTo(initialLikeCount + concurrentRequestCount);
     }
 
     @DisplayName("동일한 상품에 대해 여러 사용자가 동시에 좋아요를 취소하면, 좋아요 수가 정확히 반영되어야 한다.")
@@ -232,9 +230,6 @@ class LikeFacadeConcurrencyTest {
         // assert
         assertThat(successCount.get()).isEqualTo(concurrentRequestCount);
         assertThat(failCount.get()).isEqualTo(0);
-
-        Product finalProduct = productService.findProductById(productId).orElseThrow();
-        assertThat(finalProduct.getLikeCount().getCount()).isEqualTo(halfCount);
     }
 }
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeIntegrationTest.java
@@ -23,6 +23,7 @@ import com.loopers.domain.product.Stock;
 import com.loopers.domain.user.LoginId;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
+import com.loopers.support.IntegrationTest;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.util.HashMap;
@@ -37,7 +38,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class LikeFacadeIntegrationTest {
+class LikeFacadeIntegrationTest extends IntegrationTest {
 
     @Autowired
     private LikeFacade likeFacade;

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeConcurrencyTest.java
@@ -19,6 +19,7 @@ import com.loopers.domain.product.ProductService;
 import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.product.Stock;
 import com.loopers.domain.user.UserService;
+import com.loopers.support.IntegrationTest;
 import com.loopers.utils.DatabaseCleanUp;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +38,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class OrderFacadeConcurrencyTest {
+class OrderFacadeConcurrencyTest extends IntegrationTest {
 
     @Autowired
     private OrderFacade orderFacade;

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -19,6 +19,7 @@ import com.loopers.domain.product.Price;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.product.Stock;
+import com.loopers.support.IntegrationTest;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.RedisCleanUp;
@@ -35,7 +36,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class ProductFacadeIntegrationTest {
+class ProductFacadeIntegrationTest extends IntegrationTest {
 
     @Autowired
     private ProductFacade productFacade;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.loopers.support.IntegrationTest;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -17,7 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class CouponServiceIntegrationTest {
+class CouponServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
     private CouponService couponService;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.loopers.support.IntegrationTest;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,7 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class LikeServiceIntegrationTest {
+class LikeServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
     private LikeService likeService;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import com.loopers.domain.coupon.Discount;
 import com.loopers.domain.product.Price;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.Stock;
+import com.loopers.support.IntegrationTest;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.util.ArrayList;
@@ -28,7 +29,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class OrderServiceIntegrationTest {
+class OrderServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
     private OrderService orderService;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import com.loopers.application.point.PointFacade;
 import com.loopers.application.point.PointInfo;
 import com.loopers.application.user.UserCommand.SignupCommand;
 import com.loopers.domain.user.UserService;
+import com.loopers.support.IntegrationTest;
 import java.util.Optional;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -23,7 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class PointServiceIntegrationTest {
+class PointServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
     private PointFacade pointFacade;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.loopers.domain.product;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.loopers.support.IntegrationTest;
 import com.loopers.utils.DatabaseCleanUp;
 import java.lang.reflect.Field;
 import java.util.List;
@@ -16,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
-class ProductServiceIntegrationTest {
+class ProductServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
     private ProductService productService;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.loopers.application.user.UserCommand.SignupCommand;
+import com.loopers.support.IntegrationTest;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -20,7 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
-class UserServiceIntegrationTest {
+class UserServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
     private UserService userService;

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/cache/ProductCacheServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/cache/ProductCacheServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.loopers.infrastructure.cache;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.application.product.ProductInfo;
 import com.loopers.application.product.ProductSort;
+import com.loopers.support.IntegrationTest;
 import com.loopers.utils.DatabaseCleanUp;
 import com.loopers.utils.RedisCleanUp;
 import org.junit.jupiter.api.AfterEach;
@@ -21,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-class ProductCacheServiceIntegrationTest {
+class ProductCacheServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
     private ProductCacheService productCacheService;

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/payment/PgPaymentClientResilienceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/payment/PgPaymentClientResilienceTest.java
@@ -13,6 +13,7 @@ import com.loopers.domain.payment.PaymentClient.PaymentResponse;
 import com.loopers.infrastructure.gateway.PgPaymentClient;
 import com.loopers.infrastructure.gateway.PgPaymentDto;
 import com.loopers.infrastructure.gateway.PgPaymentFeignClient;
+import com.loopers.support.IntegrationTest;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
@@ -28,7 +29,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest
 @DisplayName("PgPaymentClient Resilience4j 동작 테스트")
-class PgPaymentClientResilienceTest {
+class PgPaymentClientResilienceTest extends IntegrationTest {
 
     @Autowired
     private PgPaymentClient pgPaymentClient;

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -6,6 +6,7 @@ import com.loopers.application.user.UserCommand.SignupCommand;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.IntegrationTest;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class PointV1ApiE2ETest {
+class PointV1ApiE2ETest extends IntegrationTest {
 
     private static final String ENDPOINT_CHARGE_POINT = "/api/v1/point";
 

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.IntegrationTest;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +23,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class UserV1ApiE2ETest {
+class UserV1ApiE2ETest extends IntegrationTest {
 
     private static final String ENDPOINT_SIGNUP = "/api/v1/users";
 

--- a/apps/commerce-api/src/test/java/com/loopers/support/IntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/support/IntegrationTest.java
@@ -6,5 +6,5 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 public abstract class IntegrationTest {
 
     @MockitoBean
-    protected KafkaTemplate<String, Object> kafkaTemplate;
+    protected KafkaTemplate<String, String> kafkaTemplate;
 }

--- a/apps/commerce-api/src/test/java/com/loopers/support/IntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/support/IntegrationTest.java
@@ -1,0 +1,10 @@
+package com.loopers.support;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+public abstract class IntegrationTest {
+
+    @MockitoBean
+    protected KafkaTemplate<String, Object> kafkaTemplate;
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/cache/ProductCacheService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/cache/ProductCacheService.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.cache;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ProductCacheService {
+
+    private static final String PRODUCT_DETAIL_PREFIX = "product:detail:";
+
+    private final RedisTemplate<String, Object> redisTemplateMaster;
+
+    public ProductCacheService(
+            @Qualifier("redisTemplateObjectMaster") RedisTemplate<String, Object> redisTemplateMaster
+    ) {
+        this.redisTemplateMaster = redisTemplateMaster;
+    }
+
+    public void invalidateProductCache(Long productId) {
+        String productDetailKey = getProductDetailKey(productId);
+        Boolean deleted = redisTemplateMaster.delete(productDetailKey);
+        log.info("상품 상세 캐시 삭제: productId={}, deleted={}", productId, deleted);
+    }
+
+    private String getProductDetailKey(Long productId) {
+        return PRODUCT_DETAIL_PREFIX + productId;
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandled.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandled.java
@@ -1,0 +1,42 @@
+package com.loopers.domain.eventhandled;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "event_handled")
+@Getter
+public class EventHandled extends BaseEntity {
+
+    @Column(nullable = false, unique = true, length = 200)
+    private String eventId;
+
+    @Column(nullable = false, length = 100)
+    private String eventType;
+
+    @Column(nullable = false, length = 100)
+    private String aggregateKey;
+
+    @Builder
+    private EventHandled(String eventId, String eventType, String aggregateKey) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.aggregateKey = aggregateKey;
+    }
+
+    public EventHandled() {
+    }
+
+    public static EventHandled create(String eventId, String eventType, String aggregateKey) {
+        return EventHandled.builder()
+                .eventId(eventId)
+                .eventType(eventType)
+                .aggregateKey(aggregateKey)
+                .build();
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandledRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandledRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.eventhandled;
+
+public interface EventHandledRepository {
+    void saveEventHandled(EventHandled eventHandled);
+
+    boolean existsByEventId(String eventId);
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandledService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandledService.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.eventhandled;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class EventHandledService {
+
+    private final EventHandledRepository eventHandledRepository;
+
+    @Transactional
+    public boolean isAlreadyHandled(String eventId) {
+        return eventHandledRepository.existsByEventId(eventId);
+    }
+
+    @Transactional
+    public void markAsHandled(String eventId, String eventType, String aggregateKey) {
+        if (!eventHandledRepository.existsByEventId(eventId)) {
+            EventHandled eventHandled = EventHandled.create(eventId, eventType, aggregateKey);
+            eventHandledRepository.saveEventHandled(eventHandled);
+        }
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandledService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/eventhandled/EventHandledService.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.eventhandled;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,10 +18,8 @@ public class EventHandledService {
 
     @Transactional
     public void markAsHandled(String eventId, String eventType, String aggregateKey) {
-        if (!eventHandledRepository.existsByEventId(eventId)) {
-            EventHandled eventHandled = EventHandled.create(eventId, eventType, aggregateKey);
-            eventHandledRepository.saveEventHandled(eventHandled);
-        }
+        EventHandled eventHandled = EventHandled.create(eventId, eventType, aggregateKey);
+        eventHandledRepository.saveEventHandled(eventHandled);
     }
 }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -62,5 +62,11 @@ public class ProductMetrics extends BaseEntity {
     public void incrementViewCount() {
         this.viewCount++;
     }
+
+    public void incrementSalesCount(Integer quantity) {
+        if (quantity != null && quantity > 0) {
+            this.salesCount += quantity;
+        }
+    }
 }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -1,0 +1,66 @@
+package com.loopers.domain.metrics;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "product_metrics")
+@Getter
+public class ProductMetrics extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private Long productId;
+
+    @Column(nullable = false)
+    private Long likeCount;
+
+    @Column(nullable = false)
+    private Long salesCount;
+
+    @Column(nullable = false)
+    private Long viewCount;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    @Builder
+    private ProductMetrics(Long productId, Long likeCount, Long salesCount, Long viewCount) {
+        this.productId = productId;
+        this.likeCount = likeCount;
+        this.salesCount = salesCount;
+        this.viewCount = viewCount;
+    }
+
+    public ProductMetrics() {
+    }
+
+    public static ProductMetrics create(Long productId) {
+        return ProductMetrics.builder()
+                .productId(productId)
+                .likeCount(0L)
+                .salesCount(0L)
+                .viewCount(0L)
+                .build();
+    }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
@@ -6,5 +6,7 @@ public interface ProductMetricsRepository {
     void saveProductMetrics(ProductMetrics productMetrics);
 
     Optional<ProductMetrics> findByProductId(Long productId);
+
+    int incrementLikeCount(Long productId);
 }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.metrics;
+
+import java.util.Optional;
+
+public interface ProductMetricsRepository {
+    void saveProductMetrics(ProductMetrics productMetrics);
+
+    Optional<ProductMetrics> findByProductId(Long productId);
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsService.java
@@ -1,0 +1,46 @@
+package com.loopers.domain.metrics;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ProductMetricsService {
+
+    private final ProductMetricsRepository productMetricsRepository;
+
+    @Transactional
+    public void incrementLikeCount(Long productId) {
+        ProductMetrics metrics = productMetricsRepository.findByProductId(productId)
+                .orElseGet(() -> {
+                    ProductMetrics newMetrics = ProductMetrics.create(productId);
+                    productMetricsRepository.saveProductMetrics(newMetrics);
+                    return newMetrics;
+                });
+        metrics.incrementLikeCount();
+        productMetricsRepository.saveProductMetrics(metrics);
+    }
+
+    @Transactional
+    public void decrementLikeCount(Long productId) {
+        productMetricsRepository.findByProductId(productId)
+                .ifPresent(metrics -> {
+                    metrics.decrementLikeCount();
+                    productMetricsRepository.saveProductMetrics(metrics);
+                });
+    }
+
+    @Transactional
+    public void incrementViewCount(Long productId) {
+        ProductMetrics metrics = productMetricsRepository.findByProductId(productId)
+                .orElseGet(() -> {
+                    ProductMetrics newMetrics = ProductMetrics.create(productId);
+                    productMetricsRepository.saveProductMetrics(newMetrics);
+                    return newMetrics;
+                });
+        metrics.incrementViewCount();
+        productMetricsRepository.saveProductMetrics(metrics);
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsService.java
@@ -42,5 +42,17 @@ public class ProductMetricsService {
         metrics.incrementViewCount();
         productMetricsRepository.saveProductMetrics(metrics);
     }
+
+    @Transactional
+    public void incrementSalesCount(Long productId, Integer quantity) {
+        ProductMetrics metrics = productMetricsRepository.findByProductId(productId)
+                .orElseGet(() -> {
+                    ProductMetrics newMetrics = ProductMetrics.create(productId);
+                    productMetricsRepository.saveProductMetrics(newMetrics);
+                    return newMetrics;
+                });
+        metrics.incrementSalesCount(quantity);
+        productMetricsRepository.saveProductMetrics(metrics);
+    }
 }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledJpaRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.eventhandled;
+
+import com.loopers.domain.eventhandled.EventHandled;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventHandledJpaRepository extends JpaRepository<EventHandled, Long> {
+    boolean existsByEventId(String eventId);
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.eventhandled;
+
+import com.loopers.domain.eventhandled.EventHandled;
+import com.loopers.domain.eventhandled.EventHandledRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class EventHandledRepositoryImpl implements EventHandledRepository {
+
+    private final EventHandledJpaRepository eventHandledJpaRepository;
+
+    @Override
+    public void saveEventHandled(EventHandled eventHandled) {
+        eventHandledJpaRepository.save(eventHandled);
+    }
+
+    @Override
+    public boolean existsByEventId(String eventId) {
+        return eventHandledJpaRepository.existsByEventId(eventId);
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/eventhandled/EventHandledRepositoryImpl.java
@@ -3,17 +3,24 @@ package com.loopers.infrastructure.eventhandled;
 import com.loopers.domain.eventhandled.EventHandled;
 import com.loopers.domain.eventhandled.EventHandledRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
+@Slf4j
 public class EventHandledRepositoryImpl implements EventHandledRepository {
 
     private final EventHandledJpaRepository eventHandledJpaRepository;
 
     @Override
     public void saveEventHandled(EventHandled eventHandled) {
-        eventHandledJpaRepository.save(eventHandled);
+        try {
+            eventHandledJpaRepository.save(eventHandled);
+        } catch (DataIntegrityViolationException e) {
+            log.debug("중복 이벤트 감지로 인해 처리를 생략함: {}", eventHandled.getEventId());
+        }
     }
 
     @Override

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
+    Optional<ProductMetrics> findByProductId(Long productId);
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -3,8 +3,15 @@ package com.loopers.infrastructure.metrics;
 import com.loopers.domain.metrics.ProductMetrics;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
     Optional<ProductMetrics> findByProductId(Long productId);
+
+    @Modifying
+    @Query("UPDATE ProductMetrics m SET m.likeCount = m.likeCount + 1 WHERE m.productId = :productId")
+    int incrementLikeCount(@Param("productId") Long productId);
 }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
+
+    private final ProductMetricsJpaRepository productMetricsJpaRepository;
+
+    @Override
+    public void saveProductMetrics(ProductMetrics productMetrics) {
+        productMetricsJpaRepository.save(productMetrics);
+    }
+
+    @Override
+    public Optional<ProductMetrics> findByProductId(Long productId) {
+        return productMetricsJpaRepository.findByProductId(productId);
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -21,5 +21,10 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
     public Optional<ProductMetrics> findByProductId(Long productId) {
         return productMetricsJpaRepository.findByProductId(productId);
     }
+
+    @Override
+    public int incrementLikeCount(Long productId) {
+        return productMetricsJpaRepository.incrementLikeCount(productId);
+    }
 }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/DemoKafkaConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/DemoKafkaConsumer.java
@@ -1,6 +1,6 @@
 package com.loopers.interfaces.consumer;
 
-import com.loopers.confg.kafka.KafkaConfig;
+import com.loopers.config.kafka.KafkaConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
@@ -1,0 +1,204 @@
+package com.loopers.interfaces.consumer;
+
+import com.loopers.application.kafka.KafkaEvent;
+import com.loopers.confg.kafka.KafkaConfig;
+import com.loopers.domain.cache.ProductCacheService;
+import com.loopers.domain.eventhandled.EventHandledService;
+import com.loopers.domain.metrics.ProductMetricsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MetricsConsumer {
+
+    private final EventHandledService eventHandledService;
+    private final ProductMetricsService productMetricsService;
+    private final ProductCacheService productCacheService;
+
+    @KafkaListener(
+            topics = {"product-liked-events"},
+            containerFactory = KafkaConfig.BATCH_LISTENER,
+            groupId = "metrics-consumer-group"
+    )
+    @Transactional
+    public void handleProductLikedEvents(
+            List<ConsumerRecord<String, Object>> messages,
+            Acknowledgment acknowledgment
+    ) {
+        for (ConsumerRecord<String, Object> record : messages) {
+            KafkaEvent.ProductEvent.ProductLiked event = (KafkaEvent.ProductEvent.ProductLiked) record.value();
+
+            if (eventHandledService.isAlreadyHandled(event.eventId())) {
+                continue;
+            }
+
+            productMetricsService.incrementLikeCount(event.productId());
+            eventHandledService.markAsHandled(
+                    event.eventId(),
+                    "ProductLiked",
+                    event.productId().toString()
+            );
+            log.info("상품 좋아요 수 집계 완료: productId={}", event.productId());
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    @KafkaListener(
+            topics = {"product-unliked-events"},
+            containerFactory = KafkaConfig.BATCH_LISTENER,
+            groupId = "metrics-consumer-group"
+    )
+    @Transactional
+    public void handleProductUnlikedEvents(
+            List<ConsumerRecord<String, Object>> messages,
+            Acknowledgment acknowledgment
+    ) {
+        for (ConsumerRecord<String, Object> record : messages) {
+            KafkaEvent.ProductEvent.ProductUnliked event = (KafkaEvent.ProductEvent.ProductUnliked) record.value();
+
+            if (eventHandledService.isAlreadyHandled(event.eventId())) {
+                continue;
+            }
+
+            productMetricsService.decrementLikeCount(event.productId());
+            eventHandledService.markAsHandled(
+                    event.eventId(),
+                    "ProductUnliked",
+                    event.productId().toString()
+            );
+            log.info("상품 좋아요 취소 수 집계 완료: productId={}", event.productId());
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    @KafkaListener(
+            topics = {"product-viewed-events"},
+            containerFactory = KafkaConfig.BATCH_LISTENER,
+            groupId = "metrics-consumer-group"
+    )
+    @Transactional
+    public void handleProductViewedEvents(
+            List<ConsumerRecord<String, Object>> messages,
+            Acknowledgment acknowledgment
+    ) {
+        for (ConsumerRecord<String, Object> record : messages) {
+            KafkaEvent.ProductEvent.ProductViewed event = (KafkaEvent.ProductEvent.ProductViewed) record.value();
+
+            if (eventHandledService.isAlreadyHandled(event.eventId())) {
+                continue;
+            }
+
+            productMetricsService.incrementViewCount(event.productId());
+            eventHandledService.markAsHandled(
+                    event.eventId(),
+                    "ProductViewed",
+                    event.productId().toString()
+            );
+            log.info("상품 조회 수 집계 완료: productId={}", event.productId());
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    @KafkaListener(
+            topics = {"order-created-events"},
+            containerFactory = KafkaConfig.BATCH_LISTENER,
+            groupId = "metrics-consumer-group"
+    )
+    @Transactional
+    public void handleOrderCreatedEvents(
+            List<ConsumerRecord<String, Object>> messages,
+            Acknowledgment acknowledgment
+    ) {
+        for (ConsumerRecord<String, Object> record : messages) {
+            KafkaEvent.OrderEvent.OrderCreated event = (KafkaEvent.OrderEvent.OrderCreated) record.value();
+
+            if (eventHandledService.isAlreadyHandled(event.eventId())) {
+                continue;
+            }
+
+            log.info("주문 생성 이벤트 수신: orderId={}, orderKey={}", event.orderId(), event.orderKey());
+            eventHandledService.markAsHandled(
+                    event.eventId(),
+                    "OrderCreated",
+                    event.orderKey()
+            );
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    @KafkaListener(
+            topics = {"order-paid-events"},
+            containerFactory = KafkaConfig.BATCH_LISTENER,
+            groupId = "metrics-consumer-group"
+    )
+    @Transactional
+    public void handleOrderPaidEvents(
+            List<ConsumerRecord<String, Object>> messages,
+            Acknowledgment acknowledgment
+    ) {
+        for (ConsumerRecord<String, Object> record : messages) {
+            KafkaEvent.OrderEvent.OrderPaid event = (KafkaEvent.OrderEvent.OrderPaid) record.value();
+
+            if (eventHandledService.isAlreadyHandled(event.eventId())) {
+                continue;
+            }
+
+            log.info("주문 결제 이벤트 수신: orderId={}, orderKey={}, orderItems={}", 
+                    event.orderId(), event.orderKey(), event.orderItems().size());
+            
+            for (KafkaEvent.OrderEvent.OrderItemInfo orderItem : event.orderItems()) {
+                productMetricsService.incrementSalesCount(orderItem.productId(), orderItem.quantity());
+            }
+            eventHandledService.markAsHandled(
+                    event.eventId(),
+                    "OrderPaid",
+                    event.orderKey()
+            );
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    @KafkaListener(
+            topics = {"product-stock-depleted-events"},
+            containerFactory = KafkaConfig.BATCH_LISTENER,
+            groupId = "metrics-consumer-group"
+    )
+    @Transactional
+    public void handleProductStockDepletedEvents(
+            List<ConsumerRecord<String, Object>> messages,
+            Acknowledgment acknowledgment
+    ) {
+        for (ConsumerRecord<String, Object> record : messages) {
+            KafkaEvent.ProductEvent.ProductStockDepleted event = (KafkaEvent.ProductEvent.ProductStockDepleted) record.value();
+
+            if (eventHandledService.isAlreadyHandled(event.eventId())) {
+                continue;
+            }
+
+            productCacheService.invalidateProductCache(event.productId());
+            eventHandledService.markAsHandled(
+                    event.eventId(),
+                    "ProductStockDepleted",
+                    event.productId().toString()
+            );
+            log.info("재고 소진으로 인한 상품 캐시 삭제 완료: productId={}, remainingStock={}", 
+                    event.productId(), event.remainingStock());
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.consumer;
 
 import com.loopers.application.kafka.KafkaEvent;
-import com.loopers.confg.kafka.KafkaConfig;
+import com.loopers.config.kafka.KafkaConfig;
 import com.loopers.domain.cache.ProductCacheService;
 import com.loopers.domain.eventhandled.EventHandledService;
 import com.loopers.domain.metrics.ProductMetricsService;

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/MetricsConsumerIdempotencyTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/MetricsConsumerIdempotencyTest.java
@@ -1,0 +1,276 @@
+package com.loopers.interfaces.consumer;
+
+import com.loopers.application.kafka.KafkaEvent;
+import com.loopers.domain.eventhandled.EventHandled;
+import com.loopers.infrastructure.eventhandled.EventHandledJpaRepository;
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.infrastructure.metrics.ProductMetricsJpaRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest
+@DisplayName("MetricsConsumer 중복 메시지 재전송 테스트")
+class MetricsConsumerIdempotencyTest {
+
+    @Autowired
+    private MetricsConsumer metricsConsumer;
+
+    @Autowired
+    private ProductMetricsJpaRepository productMetricsJpaRepository;
+
+    @Autowired
+    private EventHandledJpaRepository eventHandledJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("상품 좋아요 이벤트 중복 처리 시,")
+    @Nested
+    class ProductLikedEventIdempotency {
+
+        @DisplayName("동일한 이벤트를 여러 번 수신해도 좋아요 수가 한 번만 증가한다.")
+        @Test
+        void incrementsLikeCountOnlyOnce_whenDuplicateEventReceived() {
+            // arrange
+            Long productId = 1L;
+            Long userId = 100L;
+            String eventId = KafkaEvent.generateEventId("product-liked", productId.toString());
+
+            KafkaEvent.ProductEvent.ProductLiked event = new KafkaEvent.ProductEvent.ProductLiked(
+                    eventId,
+                    productId,
+                    userId,
+                    ZonedDateTime.now()
+            );
+
+            ConsumerRecord<String, Object> record1 = new ConsumerRecord<>("product-liked-events", 0, 0L, "key", event);
+            ConsumerRecord<String, Object> record2 = new ConsumerRecord<>("product-liked-events", 0, 1L, "key", event);
+            ConsumerRecord<String, Object> record3 = new ConsumerRecord<>("product-liked-events", 0, 2L, "key", event);
+
+            Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+            // act - 첫 번째 처리
+            metricsConsumer.handleProductLikedEvents(
+                    List.of(record1),
+                    acknowledgment
+            );
+
+            // assert - 첫 번째 처리 결과 확인
+            ProductMetrics metrics1 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            assertThat(metrics1.getLikeCount()).isEqualTo(1L);
+            assertThat(eventHandledJpaRepository.existsByEventId(eventId)).isTrue();
+
+            // act - 두 번째 처리 (중복)
+            metricsConsumer.handleProductLikedEvents(
+                    List.of(record2),
+                    acknowledgment
+            );
+
+            // assert - 두 번째 처리 후에도 좋아요 수가 증가하지 않음
+            ProductMetrics metrics2 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            assertThat(metrics2.getLikeCount()).isEqualTo(1L);
+
+            // act - 세 번째 처리 (중복)
+            metricsConsumer.handleProductLikedEvents(
+                    List.of(record3),
+                    acknowledgment
+            );
+
+            // assert - 세 번째 처리 후에도 좋아요 수가 증가하지 않음
+            ProductMetrics metrics3 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            assertThat(metrics3.getLikeCount()).isEqualTo(1L);
+
+            // verify - EventHandled는 한 번만 저장됨
+            List<EventHandled> eventHandledList = eventHandledJpaRepository.findAll();
+            assertThat(eventHandledList).hasSize(1);
+            assertThat(eventHandledList.get(0).getEventId()).isEqualTo(eventId);
+        }
+    }
+
+    @DisplayName("상품 조회 이벤트 중복 처리 시,")
+    @Nested
+    class ProductViewedEventIdempotency {
+
+        @DisplayName("동일한 이벤트를 여러 번 수신해도 조회 수가 한 번만 증가한다.")
+        @Test
+        void incrementsViewCountOnlyOnce_whenDuplicateEventReceived() {
+            // arrange
+            Long productId = 2L;
+            Long userId = 200L;
+            String eventId = KafkaEvent.generateEventId("product-viewed", productId.toString());
+
+            KafkaEvent.ProductEvent.ProductViewed event = new KafkaEvent.ProductEvent.ProductViewed(
+                    eventId,
+                    productId,
+                    userId,
+                    ZonedDateTime.now()
+            );
+
+            ConsumerRecord<String, Object> record1 = new ConsumerRecord<>("product-viewed-events", 0, 0L, "key", event);
+            ConsumerRecord<String, Object> record2 = new ConsumerRecord<>("product-viewed-events", 0, 1L, "key", event);
+
+            Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+            // act - 첫 번째 처리
+            metricsConsumer.handleProductViewedEvents(
+                    List.of(record1),
+                    acknowledgment
+            );
+
+            // assert - 첫 번째 처리 결과 확인
+            ProductMetrics metrics1 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            assertThat(metrics1.getViewCount()).isEqualTo(1L);
+
+            // act - 두 번째 처리 (중복)
+            metricsConsumer.handleProductViewedEvents(
+                    List.of(record2),
+                    acknowledgment
+            );
+
+            // assert - 두 번째 처리 후에도 조회 수가 증가하지 않음
+            ProductMetrics metrics2 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            assertThat(metrics2.getViewCount()).isEqualTo(1L);
+        }
+    }
+
+    @DisplayName("주문 결제 이벤트 중복 처리 시,")
+    @Nested
+    class OrderPaidEventIdempotency {
+
+        @DisplayName("동일한 이벤트를 여러 번 수신해도 판매량이 한 번만 증가한다.")
+        @Test
+        void incrementsSalesCountOnlyOnce_whenDuplicateEventReceived() {
+            // arrange
+            String orderKey = "ORDER-12345";
+            Long userId = 300L;
+            Long orderId = 1L;
+            Integer totalPrice = 10000;
+            String eventId = KafkaEvent.generateEventId("order-paid", orderKey);
+
+            KafkaEvent.OrderEvent.OrderItemInfo orderItem1 = new KafkaEvent.OrderEvent.OrderItemInfo(
+                    10L, "상품1", 5000, 2
+            );
+            KafkaEvent.OrderEvent.OrderItemInfo orderItem2 = new KafkaEvent.OrderEvent.OrderItemInfo(
+                    20L, "상품2", 3000, 1
+            );
+
+            KafkaEvent.OrderEvent.OrderPaid event = new KafkaEvent.OrderEvent.OrderPaid(
+                    eventId,
+                    orderKey,
+                    userId,
+                    orderId,
+                    totalPrice,
+                    List.of(orderItem1, orderItem2),
+                    ZonedDateTime.now()
+            );
+
+            ConsumerRecord<String, Object> record1 = new ConsumerRecord<>("order-paid-events", 0, 0L, orderKey, event);
+            ConsumerRecord<String, Object> record2 = new ConsumerRecord<>("order-paid-events", 0, 1L, orderKey, event);
+
+            Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+            // act - 첫 번째 처리
+            metricsConsumer.handleOrderPaidEvents(
+                    List.of(record1),
+                    acknowledgment
+            );
+
+            // assert - 첫 번째 처리 결과 확인
+            ProductMetrics metrics1_product1 = productMetricsJpaRepository.findByProductId(10L).orElseThrow();
+            ProductMetrics metrics1_product2 = productMetricsJpaRepository.findByProductId(20L).orElseThrow();
+            assertThat(metrics1_product1.getSalesCount()).isEqualTo(2L);
+            assertThat(metrics1_product2.getSalesCount()).isEqualTo(1L);
+
+            // act - 두 번째 처리 (중복)
+            metricsConsumer.handleOrderPaidEvents(
+                    List.of(record2),
+                    acknowledgment
+            );
+
+            // assert - 두 번째 처리 후에도 판매량이 증가하지 않음
+            ProductMetrics metrics2_product1 = productMetricsJpaRepository.findByProductId(10L).orElseThrow();
+            ProductMetrics metrics2_product2 = productMetricsJpaRepository.findByProductId(20L).orElseThrow();
+            assertThat(metrics2_product1.getSalesCount()).isEqualTo(2L);
+            assertThat(metrics2_product2.getSalesCount()).isEqualTo(1L);
+        }
+    }
+
+    @DisplayName("여러 이벤트 타입이 섞여 있을 때,")
+    @Nested
+    class MixedEventIdempotency {
+
+        @DisplayName("각 이벤트가 독립적으로 멱등하게 처리된다.")
+        @Test
+        void processesEachEventIdempotently_whenMixedEventsReceived() {
+            // arrange
+            Long productId = 3L;
+            Long userId = 400L;
+
+            String likedEventId = KafkaEvent.generateEventId("product-liked", productId.toString());
+            String viewedEventId = KafkaEvent.generateEventId("product-viewed", productId.toString());
+
+            KafkaEvent.ProductEvent.ProductLiked likedEvent = new KafkaEvent.ProductEvent.ProductLiked(
+                    likedEventId,
+                    productId,
+                    userId,
+                    ZonedDateTime.now()
+            );
+
+            KafkaEvent.ProductEvent.ProductViewed viewedEvent = new KafkaEvent.ProductEvent.ProductViewed(
+                    viewedEventId,
+                    productId,
+                    userId,
+                    ZonedDateTime.now()
+            );
+
+            ConsumerRecord<String, Object> likedRecord1 = new ConsumerRecord<>("product-liked-events", 0, 0L, "key", likedEvent);
+            ConsumerRecord<String, Object> likedRecord2 = new ConsumerRecord<>("product-liked-events", 0, 1L, "key", likedEvent);
+            ConsumerRecord<String, Object> viewedRecord1 = new ConsumerRecord<>("product-viewed-events", 0, 0L, "key", viewedEvent);
+            ConsumerRecord<String, Object> viewedRecord2 = new ConsumerRecord<>("product-viewed-events", 0, 1L, "key", viewedEvent);
+
+            Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+            // act - 첫 번째 처리 (좋아요 + 조회)
+            metricsConsumer.handleProductLikedEvents(List.of(likedRecord1), acknowledgment);
+            metricsConsumer.handleProductViewedEvents(List.of(viewedRecord1), acknowledgment);
+
+            // assert - 첫 번째 처리 결과 확인
+            ProductMetrics metrics1 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            assertThat(metrics1.getLikeCount()).isEqualTo(1L);
+            assertThat(metrics1.getViewCount()).isEqualTo(1L);
+
+            // act - 두 번째 처리 (중복)
+            metricsConsumer.handleProductLikedEvents(List.of(likedRecord2), acknowledgment);
+            metricsConsumer.handleProductViewedEvents(List.of(viewedRecord2), acknowledgment);
+
+            // assert - 두 번째 처리 후에도 증가하지 않음
+            ProductMetrics metrics2 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            assertThat(metrics2.getLikeCount()).isEqualTo(1L);
+            assertThat(metrics2.getViewCount()).isEqualTo(1L);
+
+            // verify - EventHandled는 각 이벤트당 한 번씩만 저장됨
+            List<EventHandled> eventHandledList = eventHandledJpaRepository.findAll();
+            assertThat(eventHandledList).hasSize(2);
+            assertThat(eventHandledList).extracting(EventHandled::getEventId)
+                    .containsExactlyInAnyOrder(likedEventId, viewedEventId);
+        }
+    }
+}

--- a/modules/kafka/src/main/java/com/loopers/application/kafka/KafkaEvent.java
+++ b/modules/kafka/src/main/java/com/loopers/application/kafka/KafkaEvent.java
@@ -2,6 +2,7 @@ package com.loopers.application.kafka;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
 public interface KafkaEvent {
@@ -48,18 +49,28 @@ public interface KafkaEvent {
                 Long userId,
                 Long orderId,
                 Integer totalPrice,
+                List<OrderItemInfo> orderItems,
                 ZonedDateTime timestamp
         ) implements OrderEvent {
-            public static OrderPaid from(String orderKey, Long userId, Long orderId, Integer totalPrice) {
+            public static OrderPaid from(String orderKey, Long userId, Long orderId, Integer totalPrice, List<OrderItemInfo> orderItems) {
                 return new OrderPaid(
                         KafkaEvent.generateEventId("order-paid", orderKey),
                         orderKey,
                         userId,
                         orderId,
                         totalPrice,
+                        orderItems,
                         ZonedDateTime.now()
                 );
             }
+        }
+
+        record OrderItemInfo(
+                Long productId,
+                String productName,
+                Integer price,
+                Integer quantity
+        ) {
         }
     }
 

--- a/modules/kafka/src/main/java/com/loopers/application/kafka/KafkaEvent.java
+++ b/modules/kafka/src/main/java/com/loopers/application/kafka/KafkaEvent.java
@@ -3,6 +3,7 @@ package com.loopers.application.kafka;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
 public interface KafkaEvent {
@@ -10,7 +11,7 @@ public interface KafkaEvent {
     ZonedDateTime timestamp();
 
     static String generateEventId(String eventType, String aggregateKey) {
-        return String.format("%s-%s-%d", eventType, aggregateKey, System.currentTimeMillis());
+        return String.format("%s-%s-%s", eventType, aggregateKey, UUID.randomUUID());
     }
 
     sealed interface OrderEvent extends KafkaEvent permits

--- a/modules/kafka/src/main/java/com/loopers/application/kafka/KafkaEvent.java
+++ b/modules/kafka/src/main/java/com/loopers/application/kafka/KafkaEvent.java
@@ -1,0 +1,138 @@
+package com.loopers.application.kafka;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.time.ZonedDateTime;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
+public interface KafkaEvent {
+    String eventId();
+    ZonedDateTime timestamp();
+
+    static String generateEventId(String eventType, String aggregateKey) {
+        return String.format("%s-%s-%d", eventType, aggregateKey, System.currentTimeMillis());
+    }
+
+    sealed interface OrderEvent extends KafkaEvent permits
+            OrderEvent.OrderCreated,
+            OrderEvent.OrderPaid {
+
+        String orderKey();
+        Long userId();
+        Long orderId();
+
+        record OrderCreated(
+                String eventId,
+                String orderKey,
+                Long userId,
+                Long orderId,
+                Integer totalPrice,
+                Integer discountPrice,
+                ZonedDateTime timestamp
+        ) implements OrderEvent {
+            public static OrderCreated from(String orderKey, Long userId, Long orderId, Integer totalPrice, Integer discountPrice) {
+                return new OrderCreated(
+                        KafkaEvent.generateEventId("order-created", orderKey),
+                        orderKey,
+                        userId,
+                        orderId,
+                        totalPrice,
+                        discountPrice,
+                        ZonedDateTime.now()
+                );
+            }
+        }
+
+        record OrderPaid(
+                String eventId,
+                String orderKey,
+                Long userId,
+                Long orderId,
+                Integer totalPrice,
+                ZonedDateTime timestamp
+        ) implements OrderEvent {
+            public static OrderPaid from(String orderKey, Long userId, Long orderId, Integer totalPrice) {
+                return new OrderPaid(
+                        KafkaEvent.generateEventId("order-paid", orderKey),
+                        orderKey,
+                        userId,
+                        orderId,
+                        totalPrice,
+                        ZonedDateTime.now()
+                );
+            }
+        }
+    }
+
+    sealed interface ProductEvent extends KafkaEvent permits
+            ProductEvent.ProductLiked,
+            ProductEvent.ProductUnliked,
+            ProductEvent.ProductViewed,
+            ProductEvent.ProductStockDepleted {
+
+        Long productId();
+
+        record ProductLiked(
+                String eventId,
+                Long productId,
+                Long userId,
+                ZonedDateTime timestamp
+        ) implements ProductEvent {
+            public static ProductLiked from(Long productId, Long userId) {
+                return new ProductLiked(
+                        KafkaEvent.generateEventId("product-liked", productId.toString()),
+                        productId,
+                        userId,
+                        ZonedDateTime.now()
+                );
+            }
+        }
+
+        record ProductUnliked(
+                String eventId,
+                Long productId,
+                Long userId,
+                ZonedDateTime timestamp
+        ) implements ProductEvent {
+            public static ProductUnliked from(Long productId, Long userId) {
+                return new ProductUnliked(
+                        KafkaEvent.generateEventId("product-unliked", productId.toString()),
+                        productId,
+                        userId,
+                        ZonedDateTime.now()
+                );
+            }
+        }
+
+        record ProductViewed(
+                String eventId,
+                Long productId,
+                Long userId,
+                ZonedDateTime timestamp
+        ) implements ProductEvent {
+            public static ProductViewed from(Long productId, Long userId) {
+                return new ProductViewed(
+                        KafkaEvent.generateEventId("product-viewed", productId.toString()),
+                        productId,
+                        userId,
+                        ZonedDateTime.now()
+                );
+            }
+        }
+
+        record ProductStockDepleted(
+                String eventId,
+                Long productId,
+                Integer remainingStock,
+                ZonedDateTime timestamp
+        ) implements ProductEvent {
+            public static ProductStockDepleted from(Long productId, Integer remainingStock) {
+                return new ProductStockDepleted(
+                        KafkaEvent.generateEventId("product-stock-depleted", productId.toString()),
+                        productId,
+                        remainingStock,
+                        ZonedDateTime.now()
+                );
+            }
+        }
+    }
+}

--- a/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
+++ b/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
@@ -1,4 +1,4 @@
-package com.loopers.confg.kafka;
+package com.loopers.config.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerConfig;

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -15,6 +15,10 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       retries: 3
+      properties:
+        acks: all
+        enable.idempotence: true
+        max.in.flight.requests.per.connection: 1
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
## 📌 Summary
- 도메인 이벤트를 카프카 이벤트로 변환하여 발행 
	- 주문 생성 이벤트
	- 주문 결제 완료 이벤트 
	- 상품 좋아요 등록 이벤트
	- 상품 좋아요 취소 이벤트
	- 상품 조회 이벤트
	- 재고 소진 이벤트 
- Outbox 패턴 적용 
- `event_handled` 테이블로 멱등 처리 
- 상품 메트릭스 집계 (좋아요 수, 조회 수, 판매 수)
- 재고 소진 시 상품 캐시 무효화 처리 

---

## 💬 Review Points

### 1. Outbox 저장 시 BEFORE_COMMIT 사용
현재 `KafkaOutboxEventListener`에서 모든 이벤트 핸들러에 `@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)`을 사용하여 Outbox에 저장하고 있습니다.

```java
@Component
public class KafkaOutboxEventListener {

    private final OutboxService outboxService;

    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
    public void handleOrderCreated(OrderEvent.OrderCreated event) {
        KafkaEvent.OrderEvent.OrderCreated kafkaEvent = KafkaEvent.OrderEvent.OrderCreated.from(
                event.orderKey(),
                event.userId(),
                event.orderId(),
                event.originalTotalPrice(),
                event.discountPrice()
        );
        outboxService.saveOutbox("order-created-events", event.orderKey(), kafkaEvent);
    }

    // ... 다른 이벤트 핸들러들도 동일하게 BEFORE_COMMIT 사용
}

@Service
public class OutboxService {

    @Transactional
    public void saveOutbox(String topic, String partitionKey, Object event) {
        try {
            String payload = objectMapper.writeValueAsString(event);
            Outbox outbox = Outbox.create(topic, partitionKey, payload);
            outboxRepository.saveOutbox(outbox);
        } catch (Exception e) {
            throw new CoreException(ErrorType.INTERNAL_ERROR, "이벤트 저장에 실패했습니다.");
        }
    }
}
```

비즈니스 로직이랑 Outbox 저장이 같은 트랜잭션에 포함되어야 한다고 생각했고, 
`AFTER_COMMIT`을 사용하면 트랜잭션이 이미 커밋된 후에 실행되니까 Outbox 저장 실패 시 비즈니스 로직은 이미 커밋된 상태가 되기 때문에 BEFORE_COMMIT을 선택했습니다. 

도메인 로직 내에서 직접 저장하지 않고, '도메인 이벤트 발행 → 리스너(BEFORE_COMMIT) → 아웃박스 저장'으로 이어지는 흐름이 맞는 방향인지 궁금합니다. 

---
 
### 2. KafkaEvent 구조 
프로듀서와 컨슈머 간에 주고받는 이벤트를 KafkaEvent로 정의했습니다. 
현재 `KafkaEvent`를 인터페이스로 두고, 내부에 `OrderEvent`와 `ProductEvent`를 sealed interface로 중첩하여 구현했습니다. 이렇게 하면 `KafkaEvent.OrderEvent.OrderCreated`와 같은 형태로 사용할 수 있어 이런 구조로 구현했습니다. 

```java
@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
public interface KafkaEvent {
    String eventId();
    ZonedDateTime timestamp();

    sealed interface OrderEvent extends KafkaEvent permits OrderEvent.OrderCreated, OrderEvent.OrderPaid {
        record OrderCreated(String eventId, String orderKey, Long userId, ...) implements OrderEvent {}
        record OrderPaid(String eventId, String orderKey, Long userId, ...) implements OrderEvent {}
    }

    sealed interface ProductEvent extends KafkaEvent permits ProductEvent.ProductLiked, ... {
        record ProductLiked(String eventId, Long productId, Long userId, ...) implements ProductEvent {}
        // ...
    }
}
```

이 구조가 유지보수성과 확장성 측면에서 적절한지 궁금합니다. 
만약 이벤트 타입이 더 많아진다면 이 구조를 어떻게 확장해야 할까요?



---

## ✅ Checklist

### 🎾 Producer
- [x]  도메인(애플리케이션) 이벤트 설계
- [x]  Producer 앱에서 도메인 이벤트 발행 (catalog-events, order-events, 등)
- [x]  **PartitionKey** 기반의 이벤트 순서 보장
- [x]  메세지 발행이 실패했을 경우에 대해 고민해보기

### ⚾ Consumer
- [x]  Consumer 가 Metrics 집계 처리
- [x]  `event_handled` 테이블을 통한 멱등 처리 구현
- [x]  재고 소진 시 상품 캐시 갱신
- [x]  중복 메세지 재전송 테스트 → 최종 결과가 한 번만 반영되는지 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 신뢰할 수 있는 이벤트 발행 시스템 도입으로 메시지 손실 방지
  * 상품 메트릭 추적 기능 추가 (좋아요, 조회, 판매 수 기록)
  * 중복 이벤트 처리 방지를 위한 멱등성 보장
  * 상품 캐시 자동 무효화 시스템 구현

* **인프라**
  * Kafka 기반 이벤트 스트리밍 아키텍처 구축
  * 실패한 이벤트 자동 재시도 메커니즘 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->