### PR TITLE
[volume - 8] Decoupling with Kafka

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))
+    implementation(project(":modules:kafka"))
 
     // web
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/apps/commerce-api/src/main/java/com/loopers/application/kafka/EventKafkaProducer.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/kafka/EventKafkaProducer.java
@@ -1,0 +1,59 @@
+package com.loopers.application.kafka;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.loopers.domain.outbox.OutboxEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventKafkaProducer {
+
+    private final KafkaTemplate<Object, Object> kafkaTemplate;
+
+    @Value("${kafka.topics.catalog-events}")
+    private String catalogEventsTopic;
+
+    @Value("${kafka.topics.order-events}")
+    private String orderEventsTopic;
+    /**
+     * Outbox 이벤트를 Kafka로 발행
+     */
+    public CompletableFuture<SendResult<Object, Object>> publish(OutboxEvent outbox) {
+        String topic = getTopicByAggregateType(outbox.getAggregateType());
+        String partitionKey = outbox.getAggregateId();
+
+        log.info("Kafka 발행 시작 - topic: {}, key: {}, eventType: {}",
+                topic, partitionKey, outbox.getEventType());
+
+        return kafkaTemplate.send(topic, partitionKey, outbox.getPayload())
+                .thenApply(result -> {
+                    log.info("Kafka 발행 성공 - topic: {}, partition: {}, offset: {}, eventId: {}",
+                            topic,
+                            result.getRecordMetadata().partition(),
+                            result.getRecordMetadata().offset(),
+                            outbox.getId());
+                    return result;
+                })
+                .exceptionally(ex -> {
+                    log.error("Kafka 발행 실패 - topic: {}, key: {}, eventId: {}, error: {}",
+                            topic, partitionKey, outbox.getId(), ex.getMessage(), ex);
+                    throw new RuntimeException("Kafka 발행 실패", ex);
+                });
+    }
+
+
+    private String getTopicByAggregateType(String aggregateType) {
+        return switch (aggregateType.toUpperCase()) {
+            case "ORDER", "PAYMENT" -> orderEventsTopic;
+            case "PRODUCT", "LIKE" -> catalogEventsTopic;
+            default -> throw new IllegalArgumentException("존재하지 않는 AggregateType: " + aggregateType);
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/kafka/EventKafkaProducer.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/kafka/EventKafkaProducer.java
@@ -2,7 +2,7 @@ package com.loopers.application.kafka;
 
 import java.util.concurrent.CompletableFuture;
 
-import com.loopers.domain.outbox.OutboxEvent;
+import com.loopers.domain.outbox.EventOutbox;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,9 +25,9 @@ public class EventKafkaProducer {
     /**
      * Outbox 이벤트를 Kafka로 발행
      */
-    public CompletableFuture<SendResult<Object, Object>> publish(OutboxEvent outbox) {
+    public CompletableFuture<SendResult<Object, Object>> publish(EventOutbox outbox) {
         String topic = getTopicByAggregateType(outbox.getAggregateType());
-        String partitionKey = outbox.getAggregateId();
+        String partitionKey = outbox.getEventKey();
 
         log.info("Kafka 발행 시작 - topic: {}, key: {}, eventType: {}",
                 topic, partitionKey, outbox.getEventType());

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -7,28 +7,25 @@ import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointRepository;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductRepository;
+import com.loopers.application.payment.PaymentFacade;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import jakarta.persistence.OptimisticLockException;
-import com.loopers.domain.order.event.OrderCreatedEvent;
+
 import java.math.BigDecimal;
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderFacade {
     private final OrderRepository orderRepository;
     private final PointRepository pointRepository;
     private final ProductRepository productRepository;
-    private final ApplicationEventPublisher eventPublisher;
-
+    private final PaymentFacade paymentFacade;
 
     @Transactional
     public Order createOrder(String userId, List<OrderItem> orderItems){
@@ -83,17 +80,8 @@ public class OrderFacade {
         point.usePoints(totalAmount);
         pointRepository.save(point);
 
-
-        // 5. 주문 생성
-        Order order = Order.createOrder(userId, orderItems);
-        orderRepository.save(order);
-
-        // 6. 주문 생성 이벤트 발행
-        OrderCreatedEvent event = OrderCreatedEvent.from(order);
-        eventPublisher.publishEvent(event);
-        log.info("주문 생성 이벤트 발행: {}", order.getId());
-
-        return order;
+        //5. 주문 생성
+        return Order.createOrder(userId, orderItems);
     }
 
     @Transactional(readOnly = true)

--- a/apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxEventPublisher.java
@@ -1,0 +1,56 @@
+package com.loopers.application.outbox;
+
+import com.loopers.application.kafka.EventKafkaProducer;
+import com.loopers.domain.outbox.EventOutbox;
+import com.loopers.domain.outbox.OutboxStatus;
+import com.loopers.domain.outbox.EventOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(value = "outbox.publisher.enabled", havingValue = "true")
+public class OutboxEventPublisher {
+
+    private final EventOutboxRepository outboxRepository;
+    private final EventKafkaProducer kafkaProducer;
+
+    @Scheduled(fixedDelay = 1000)
+    @Transactional
+    public void publishPendingEvents() {
+        // PENDING 이벤트 처리
+        List<EventOutbox> pending = outboxRepository.findPendingEvents();
+        for (EventOutbox event : pending) {
+            tryPublish(event);
+        }
+
+        // 재시도 대상 FAILED 이벤트 처리
+        List<EventOutbox> retryables = outboxRepository.findFailedEventsCanRetry();
+        for (EventOutbox event : retryables) {
+            tryPublish(event);
+        }
+    }
+
+    private void tryPublish(EventOutbox event) {
+        try {
+            kafkaProducer.publish(event).join();
+            event.setStatus(OutboxStatus.PUBLISHED);
+            event.setLastAttemptAt(LocalDateTime.now());
+        } catch (Exception ex) {
+            event.setStatus(OutboxStatus.FAILED);
+            event.setLastAttemptAt(LocalDateTime.now());
+            event.setAttemptCount(event.getAttemptCount() + 1);
+            log.error("Outbox 발행 실패 - eventId={}, error={}", event.getId(), ex.getMessage(), ex);
+        }
+    }
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxEventService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/outbox/OutboxEventService.java
@@ -1,0 +1,34 @@
+package com.loopers.application.outbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.outbox.EventOutbox;
+import com.loopers.domain.outbox.EventOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OutboxEventService {
+
+    private final ObjectMapper objectMapper;
+    private final EventOutboxRepository outboxRepository;
+
+    @Transactional
+    public EventOutbox saveEvent(String aggregateType,
+                                 String aggregateId,
+                                 String eventType,
+                                 String eventKey,
+                                 Object payload) {
+        try {
+            String json = objectMapper.writeValueAsString(payload);
+            EventOutbox outbox = EventOutbox.of(aggregateType, aggregateId, eventType, eventKey, json);
+            return outboxRepository.save(outbox);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Outbox payload 직렬화 실패", e);
+        }
+    }
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSyncScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSyncScheduler.java
@@ -52,3 +52,4 @@ public class PaymentSyncScheduler {
 
 
 
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSyncScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSyncScheduler.java
@@ -50,3 +50,5 @@ public class PaymentSyncScheduler {
 
 
 
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/outbox/EventOutbox.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/outbox/EventOutbox.java
@@ -1,0 +1,78 @@
+package com.loopers.domain.outbox;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "event_outbox")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class EventOutbox {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private String id;
+
+    @Column(nullable = false)
+    private String aggregateType;
+
+    @Column(nullable = false)
+    private String aggregateId;
+
+    @Column(nullable = false)
+    private String eventType;
+
+    @Column(nullable = false)
+    private String eventKey; // Kafka partition key
+
+    @Lob
+    @Column(nullable = false)
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Setter
+    private OutboxStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Setter
+    private LocalDateTime lastAttemptAt;
+
+    @Setter
+    @Column(nullable = false)
+    private int attemptCount;
+
+    public static EventOutbox of(String aggregateType, String aggregateId, String eventType, String eventKey, String payload) {
+        return EventOutbox.builder()
+                .id(UUID.randomUUID().toString())
+                .aggregateType(aggregateType)
+                .aggregateId(aggregateId)
+                .eventType(eventType)
+                .eventKey(eventKey)
+                .payload(payload)
+                .status(OutboxStatus.PENDING)
+                .createdAt(LocalDateTime.now())
+                .attemptCount(0)
+                .build();
+    }
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/outbox/EventOutboxRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/outbox/EventOutboxRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.outbox;
+
+import java.util.List;
+
+public interface EventOutboxRepository {
+    EventOutbox save(EventOutbox outbox);
+    List<EventOutbox> findPendingEvents();
+    List<EventOutbox> findFailedEventsCanRetry();
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/outbox/OutboxStatus.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.outbox;
+
+public enum OutboxStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/EventOutboxJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/EventOutboxJpaRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.outbox;
+
+import com.loopers.domain.outbox.EventOutbox;
+import com.loopers.domain.outbox.OutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface EventOutboxJpaRepository extends JpaRepository<EventOutbox, String> {
+    List<EventOutbox> findTop50ByStatusOrderByCreatedAtAsc(OutboxStatus status);
+    List<EventOutbox> findTop50ByStatusAndLastAttemptAtBeforeOrderByLastAttemptAtAsc(OutboxStatus status, LocalDateTime threshold);
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/EventOutboxRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/outbox/EventOutboxRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.loopers.infrastructure.outbox;
+
+import com.loopers.domain.outbox.EventOutbox;
+import com.loopers.domain.outbox.EventOutboxRepository;
+import com.loopers.domain.outbox.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class EventOutboxRepositoryImpl implements EventOutboxRepository {
+
+    private final EventOutboxJpaRepository jpaRepository;
+
+    @Override
+    public EventOutbox save(EventOutbox outbox) {
+        return jpaRepository.save(outbox);
+    }
+
+    @Override
+    public List<EventOutbox> findPendingEvents() {
+        return jpaRepository.findTop50ByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);
+    }
+
+    @Override
+    public List<EventOutbox> findFailedEventsCanRetry() {
+        // 간단한 재시도 정책: 마지막 시도 이후 1분 경과한 FAILED 이벤트
+        LocalDateTime threshold = LocalDateTime.now().minus(Duration.ofMinutes(1));
+        return jpaRepository.findTop50ByStatusAndLastAttemptAtBeforeOrderByLastAttemptAtAsc(
+                OutboxStatus.FAILED, threshold
+        );
+    }
+}
+
+

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -34,8 +34,18 @@ spring:
       - logging.yml
       - monitoring.yml
       - resilience4j.yml
+      - kafka.yml
 pg:
   base-url: http://localhost:8082
+
+kafka:
+  topics:
+    catalog-events: catalog-events
+    order-events: order-events
+
+outbox:
+  publisher:
+    enabled: true
 
 payment:
   callback-url: http://localhost:8080/api/v1/payments/callback

--- a/apps/commerce-api/src/main/resources/sql/insert_data.sql
+++ b/apps/commerce-api/src/main/resources/sql/insert_data.sql
@@ -31,3 +31,4 @@ INSERT INTO product (brand_id, name, price, stock_quantity, like_count, created_
 
 
 
+

--- a/apps/commerce-api/src/main/resources/sql/insert_data.sql
+++ b/apps/commerce-api/src/main/resources/sql/insert_data.sql
@@ -28,3 +28,6 @@ INSERT INTO product (brand_id, name, price, stock_quantity, like_count, created_
 
 
 
+
+
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/EventHandledService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/EventHandledService.java
@@ -1,0 +1,29 @@
+package com.loopers.application;
+
+import com.loopers.domain.event.EventHandled;
+import com.loopers.infrastructure.event.EventHandledJpaRepository;
+import com.loopers.infrastructure.event.EventHandledRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EventHandledService {
+
+    private final EventHandledJpaRepository repository;
+
+    /**
+     * @return true = 최초 처리, false = 이미 처리된 이벤트
+     */
+    @Transactional
+    public boolean tryMarkHandled(String eventId, String eventType) {
+        try {
+            repository.save(EventHandled.of(eventId, eventType));
+            return true;
+        } catch (DataIntegrityViolationException e) {
+            return false;
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ProductCacheService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ProductCacheService.java
@@ -1,0 +1,41 @@
+package com.loopers.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductCacheService {
+
+    @Qualifier("jsonRedisTemplate")
+    private final RedisTemplate<String, Object> jsonRedisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void invalidateAfterStockChange(Long productId) {
+        String detailKey = "product:detail:" + productId;
+        try {
+            jsonRedisTemplate.delete(detailKey);
+            log.info("상품 상세 캐시 무효화 - key={}", detailKey);
+        } catch (Exception e) {
+            log.warn("상품 상세 캐시 무효화 실패 - key={}, err={}", detailKey, e.getMessage());
+        }
+
+        try {
+            Set<String> keys = redisTemplate.keys("productList::*");
+            if (keys != null && !keys.isEmpty()) {
+                redisTemplate.delete(keys);
+                log.info("상품 리스트 캐시 무효화 - count={}", keys.size());
+            }
+        } catch (Exception e) {
+            log.warn("상품 리스트 캐시 무효화 실패 - err={}", e.getMessage());
+        }
+    }
+}
+
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ProductMetricsService.java
@@ -1,0 +1,18 @@
+package com.loopers.application;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ProductMetricsService {
+
+    public void incrementLikeCount(Long productId) {
+        log.info("👍 좋아요 증가 - productId: {}", productId);
+        // 실제로는 metrics 테이블 update
+    }
+
+    public void decrementLikeCount(Long productId) {
+        log.info("👎 좋아요 감소 - productId: {}", productId);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventHandled.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventHandled.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.event;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "event_handled")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class EventHandled {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private String eventId;
+
+    @Column(nullable = false)
+    private String eventType;
+
+    @Column(nullable = false)
+    private LocalDateTime handledAt;
+
+    public static EventHandled of(String eventId, String eventType) {
+        return EventHandled.builder()
+                .eventId(eventId)
+                .eventType(eventType)
+                .handledAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.domain.event.EventHandled;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventHandledJpaRepository extends JpaRepository<EventHandled, Long> {
+    boolean existsByEventId(String eventId);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaRepository.java
@@ -3,6 +3,6 @@ package com.loopers.infrastructure.event;
 import com.loopers.domain.event.EventHandled;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EventHandledJpaRepository extends JpaRepository<EventHandled, Long> {
+public interface EventHandledJpaRepository extends JpaRepository<EventHandled, String> {
     boolean existsByEventId(String eventId);
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.domain.event.EventHandled;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EventHandledRepositoryImpl {
+
+    private final EventHandledJpaRepository jpaRepository;
+
+    public boolean exists(String eventId) {
+        return jpaRepository.existsByEventId(eventId);
+    }
+
+    public void save(EventHandled eventHandled) {
+        jpaRepository.save(eventHandled);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/CatalogEventConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/CatalogEventConsumer.java
@@ -1,0 +1,60 @@
+package com.loopers.interfaces.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.ProductMetricsService;
+import com.loopers.application.EventHandledService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CatalogEventConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final EventHandledService eventHandledService;
+    private final ProductMetricsService productMetricsService;
+
+    @KafkaListener(
+            topics = "${kafka.topics.catalog-events}",
+            groupId = "commerce-streamer-catalog"
+    )
+    public void consume(ConsumerRecord<String, String> record) throws Exception {
+        Map<String, Object> event = objectMapper.readValue(record.value(), Map.class);
+
+        String eventId = (String) event.get("id");
+        String eventType = (String) event.get("eventType");
+        Map<String, Object> payload = (Map<String, Object>) event.get("payload");
+        if (eventId == null || eventType == null || payload == null) {
+            log.warn("잘못된 카탈로그 이벤트 - eventType 또는 payload 없음");
+            return;
+        }
+
+        // 멱등 처리
+        if (!eventHandledService.tryMarkHandled(eventId, eventType)) {
+            log.info("중복 이벤트 skip - {}", eventId);
+            return;
+        }
+
+        Long productId = Long.valueOf(payload.get("productId").toString());
+
+        switch (eventType) {
+            case "LIKE_CREATED" -> {
+                productMetricsService.incrementLikeCount(productId);
+                log.info("LIKE_CREATED 처리 완료 - productId={}", productId);
+            }
+            case "LIKE_DELETED" -> {
+                productMetricsService.decrementLikeCount(productId);
+                log.info("LIKE_DELETED 처리 완료 - productId={}", productId);
+            }
+            default -> log.debug("처리 대상 아님 - eventType={}", eventType);
+        }
+    }
+}
+
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/OrderEventConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/OrderEventConsumer.java
@@ -1,0 +1,72 @@
+package com.loopers.interfaces.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.EventHandledService;
+import com.loopers.application.ProductMetricsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderEventConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final EventHandledService eventHandledService;
+    private final ProductMetricsService productMetricsService;
+
+    @KafkaListener(
+            topics = "${kafka.topics.order-events}",
+            groupId = "commerce-streamer-order"
+    )
+    public void consume(ConsumerRecord<String, String> record) throws Exception {
+
+        Map<String, Object> event =
+                objectMapper.readValue(record.value(), Map.class);
+
+        String eventId = (String) event.get("id");
+        String eventType = (String) event.get("eventType");
+
+        if (eventId == null) {
+            log.warn("eventId 없음 → skip");
+            return;
+        }
+
+        // 멱등 처리
+        if (!eventHandledService.tryMarkHandled(eventId, eventType)) {
+            log.info("중복 이벤트 skip - {}", eventId);
+            return;
+        }
+
+        Map<String, Object> payload =
+                (Map<String, Object>) event.get("payload");
+
+        if (payload == null) {
+            log.warn("payload 없음 - eventId={}", eventId);
+            return;
+        }
+
+        Long productId = Long.valueOf(payload.get("productId").toString());
+        Integer quantity = Integer.valueOf(payload.get("quantity").toString());
+        BigDecimal amount =
+                new BigDecimal(payload.get("totalAmount").toString());
+
+        LocalDateTime occurredAt =
+                LocalDateTime.parse(event.get("occurredAt").toString());
+
+        log.info(
+                "Order 이벤트 처리 완료 - eventId={}, productId={}, quantity={}, amount={}",
+                eventId, productId, quantity, amount
+        );
+
+    }
+}
+
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/OrderEventConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/OrderEventConsumer.java
@@ -3,6 +3,7 @@ package com.loopers.interfaces.consumer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.application.EventHandledService;
 import com.loopers.application.ProductMetricsService;
+import com.loopers.application.ProductCacheService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -21,6 +22,7 @@ public class OrderEventConsumer {
     private final ObjectMapper objectMapper;
     private final EventHandledService eventHandledService;
     private final ProductMetricsService productMetricsService;
+    private final ProductCacheService productCacheService;
 
     @KafkaListener(
             topics = "${kafka.topics.order-events}",
@@ -60,6 +62,9 @@ public class OrderEventConsumer {
 
         LocalDateTime occurredAt =
                 LocalDateTime.parse(event.get("occurredAt").toString());
+
+        // 재고 변경으로 인한 캐시 무효화
+        productCacheService.invalidateAfterStockChange(productId);
 
         log.info(
                 "Order 이벤트 처리 완료 - eventId={}, productId={}, quantity={}, amount={}",

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   main:
     web-application-type: servlet
   application:
-    name: commerce-api
+    name: commerce-streamer
   profiles:
     active: local
   config:
@@ -24,6 +24,11 @@ spring:
       - kafka.yml
       - logging.yml
       - monitoring.yml
+
+kafka:
+  topics:
+    catalog-events: catalog-events
+    order-events: order-events
 
 demo-kafka:
   test:

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/CatalogEventConsumerTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/CatalogEventConsumerTest.java
@@ -1,0 +1,123 @@
+package com.loopers.interfaces.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.ProductMetricsService;
+import com.loopers.application.EventHandledService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class CatalogEventConsumerTest {
+
+    @InjectMocks
+    private CatalogEventConsumer consumer;
+
+    @Mock
+    private ProductMetricsService productMetricsService;
+
+    @Mock
+    private EventHandledService eventHandledService;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        consumer = new CatalogEventConsumer(
+                objectMapper,
+                eventHandledService,
+                productMetricsService
+        );
+    }
+
+    @Test
+    void LIKE_CREATED_이벤트면_like_증가() throws Exception {
+        when(eventHandledService.tryMarkHandled("e1", "LIKE_CREATED"))
+                .thenReturn(true);
+
+        Map<String, Object> event = Map.of(
+                "id", "e1",
+                "aggregateType", "LIKE",
+                "aggregateId", "1",
+                "eventType", "LIKE_CREATED",
+                "occurredAt", "2025-12-19T12:00:00",
+                "payload", Map.of(
+                        "userId", "u1",
+                        "productId", 1L
+                )
+        );
+        String message = objectMapper.writeValueAsString(event);
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("catalog-events", 0, 0L, null, message);
+
+        consumer.consume(record);
+
+        verify(productMetricsService, times(1)).incrementLikeCount(1L);
+    }
+
+    @Test
+    void LIKE_DELETED_이벤트면_like_감소() throws Exception {
+        when(eventHandledService.tryMarkHandled("e2", "LIKE_DELETED"))
+                .thenReturn(true);
+
+        Map<String, Object> event = Map.of(
+                "id", "e2",
+                "aggregateType", "LIKE",
+                "aggregateId", "1",
+                "eventType", "LIKE_DELETED",
+                "occurredAt", "2025-12-19T12:00:00",
+                "payload", Map.of(
+                        "userId", "u1",
+                        "productId", 1L
+                )
+        );
+        String message = objectMapper.writeValueAsString(event);
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("catalog-events", 0, 0L, null, message);
+
+        consumer.consume(record);
+
+        verify(productMetricsService, times(1)).decrementLikeCount(1L);
+    }
+
+    @Test
+    void 동일한_eventId_중복_전달시_첫_1회만_처리() throws Exception {
+        when(eventHandledService.tryMarkHandled("dup-1", "LIKE_CREATED"))
+                .thenReturn(true)  // first
+                .thenReturn(false) // second
+                .thenReturn(false);// third
+
+        Map<String, Object> event = Map.of(
+                "id", "dup-1",
+                "aggregateType", "LIKE",
+                "aggregateId", "1",
+                "eventType", "LIKE_CREATED",
+                "occurredAt", "2025-12-19T12:00:00",
+                "payload", Map.of(
+                        "userId", "u1",
+                        "productId", 1L
+                )
+        );
+        String message = objectMapper.writeValueAsString(event);
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("catalog-events", 0, 0L, null, message);
+
+        consumer.consume(record);
+        consumer.consume(record);
+        consumer.consume(record);
+
+        verify(productMetricsService, times(1)).incrementLikeCount(1L);
+        verifyNoMoreInteractions(productMetricsService);
+    }
+}
+
+

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/OrderEventConsumerTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/OrderEventConsumerTest.java
@@ -1,0 +1,119 @@
+package com.loopers.interfaces.consumer;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.EventHandledService;
+import com.loopers.application.ProductMetricsService;
+import com.loopers.interfaces.consumer.OrderEventConsumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderEventConsumerTest {
+
+    @InjectMocks
+    private OrderEventConsumer consumer;
+
+    @Mock
+    private EventHandledService eventHandledService;
+
+    @Mock
+    private ProductMetricsService productMetricsService;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        consumer = new OrderEventConsumer(
+                objectMapper,
+                eventHandledService,
+                productMetricsService
+        );
+    }
+
+    @Test
+    void 동일한_이벤트를_여러번_넣어도_한번만_처리된다() throws Exception {
+        // given
+        String eventId = "event-123";
+        String eventType = "ORDER_CREATED";
+
+        Map<String, Object> event = Map.of(
+                "id", eventId,
+                "eventType", eventType,
+                "occurredAt", LocalDateTime.now().toString(),
+                "payload", Map.of(
+                        "productId", 1L,
+                        "quantity", 2,
+                        "totalAmount", "10000"
+                )
+        );
+
+        String message = objectMapper.writeValueAsString(event);
+
+        ConsumerRecord<String, String> record =
+                new ConsumerRecord<>("order-events", 0, 0L, null, message);
+
+        // 첫 번째만 처리 성공, 이후는 중복
+        when(eventHandledService.tryMarkHandled(eventId, eventType))
+                .thenReturn(true)
+                .thenReturn(false)
+                .thenReturn(false);
+
+        // when
+        consumer.consume(record);
+        consumer.consume(record);
+        consumer.consume(record);
+
+        // then
+        verify(eventHandledService, times(3)).tryMarkHandled(eventId, eventType);
+        verifyNoInteractions(productMetricsService);
+    }
+
+    @Test
+    void 이미_처리된_이벤트는_즉시_skip된다() throws Exception {
+        // given
+        String eventId = "event-456";
+        String eventType = "ORDER_CREATED";
+
+        Map<String, Object> event = Map.of(
+                "id", eventId,
+                "eventType", eventType,
+                "occurredAt", LocalDateTime.now().toString(),
+                "payload", Map.of(
+                        "productId", 1L,
+                        "quantity", 1,
+                        "totalAmount", "5000"
+                )
+        );
+
+        String message = objectMapper.writeValueAsString(event);
+
+        ConsumerRecord<String, String> record =
+                new ConsumerRecord<>("order-events", 0, 0L, null, message);
+
+        when(eventHandledService.tryMarkHandled(eventId, eventType))
+                .thenReturn(false);
+
+        // when
+        consumer.consume(record);
+
+        // then
+        verify(eventHandledService, times(1)).tryMarkHandled(eventId, eventType);
+        verifyNoInteractions(productMetricsService);
+    }
+}
+

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/OrderEventConsumerTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/OrderEventConsumerTest.java
@@ -4,6 +4,7 @@ package com.loopers.interfaces.consumer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.application.EventHandledService;
 import com.loopers.application.ProductMetricsService;
+import com.loopers.application.ProductCacheService;
 import com.loopers.interfaces.consumer.OrderEventConsumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,9 @@ class OrderEventConsumerTest {
     @Mock
     private ProductMetricsService productMetricsService;
 
+    @Mock
+    private ProductCacheService productCacheService;
+
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -41,7 +45,8 @@ class OrderEventConsumerTest {
         consumer = new OrderEventConsumer(
                 objectMapper,
                 eventHandledService,
-                productMetricsService
+                productMetricsService,
+                productCacheService
         );
     }
 
@@ -81,6 +86,7 @@ class OrderEventConsumerTest {
         // then
         verify(eventHandledService, times(3)).tryMarkHandled(eventId, eventType);
         verifyNoInteractions(productMetricsService);
+        verify(productCacheService, times(1)).invalidateAfterStockChange(1L);
     }
 
     @Test
@@ -114,6 +120,7 @@ class OrderEventConsumerTest {
         // then
         verify(eventHandledService, times(1)).tryMarkHandled(eventId, eventType);
         verifyNoInteractions(productMetricsService);
+        verifyNoInteractions(productCacheService);
     }
 }
 

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -14,7 +14,12 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
       retries: 3
+      properties:
+        enable.idempotence: true
+        max.in.flight.requests.per.connection: 5
+        compression.type: snappy
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
## 📌 Summary

어............멘토님 제가 OutboxEventPublisher, Service, 등등 Outbox 관련해서 구현한 부분이 다 날라가서 다시 살려놓도록 하겠습니다....
<!--
    
-->
Kafka 기반 이벤트 발행/소비 구조를 적용하며 at-least-once 전달 보장과 Consumer 멱등 처리를 중심으로 구현을 진행했습니다.
## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->
중복처리 범위 명시 : Consumer 단에서 eventId 기반으로 중복을 처리하였습니다. 

1. acks=all일 때 실제 ACK는 각 브로커가 따로 프로듀서에게 보내는 게 아니라, ISR에 모두 복제된 이후 리더 브로커가 한 번만 보내는 걸로 이해하면 될까요? 
2. 추가적으로 다중 프로듀서가 존재하는 경우에도 동일한 브로커 클러스터를 공유하는 것으로 알고 있는데
예를 들어 아래와 같은 상황이 있다면,
```
Producer A → offset 5
Producer B → offset 6
Leader log:     0 1 2 3 4 5 6
Follower A:     0 1 2 3 4 5
Follower B:     0 1 2 3 4 5
HW = 5
```
이 경우 HW가 5이므로 Producer A가 보낸 레코드(offset 5)에 대해서는 ACK가 반환되고, Producer B(offset 6)는 HW가 더 증가할 때까지 ACK를 기다리게 된다고 이해했습니다. 그래서 사실 정확한 ACK 조건은 HW == Leader offset 이라기보다는 HW ≥ 해당 ProduceRequest에 포함된 record offset 이 되는 시점이라고 이해했는데, 이렇게 이해하는 게 맞을지 궁금합니다!
3. 실무에서는 대부분 단일 프로듀서가 아닌 다중 프로듀서를 사용한다는 글을 읽었는데 맞을까요? 

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

### 🎾 Producer

- [x]  도메인(애플리케이션) 이벤트 설계
- [x]  Producer 앱에서 도메인 이벤트 발행 (catalog-events, order-events, 등)
- [x]  **PartitionKey** 기반의 이벤트 순서 보장
- [x]  메세지 발행이 실패했을 경우에 대해 고민해보기 **(Outbox Pattern 사용하기)**

### ⚾ Consumer

- [x]  Consumer 가 Metrics 집계 처리
- [x]  `event_handled` 테이블을 통한 멱등 처리 구현
- [x]  재고 소진 시 상품 캐시 갱신
- [x]  중복 메세지 재전송 테스트 → 최종 결과가 한 번만 반영되는지 확인
## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - https://kafka.apache.org/41/design/protocol/
  - https://developer.confluent.io/courses/architecture/data-replication/
-->