### PR TITLE
[volume-9] Product Ranking with Redis

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEvent.java
@@ -23,16 +23,27 @@ public class OrderEvent {
             Long orderId,
             Long userId,
             Integer originalTotalPrice,
-            Integer discountPrice
+            Integer discountPrice,
+            List<OrderItemInfo> orderItems
     ) {
         public static OrderCreated from(Order order, String loginId) {
+            List<OrderItemInfo> orderItemInfos = order.getOrderItems().stream()
+                    .map(item -> new OrderItemInfo(
+                            item.getProductId(),
+                            item.getProductName(),
+                            item.getPrice(),
+                            item.getQuantity()
+                    ))
+                    .toList();
+            
             return new OrderCreated(
                     loginId,
                     order.getOrderKey(),
                     order.getId(),
                     order.getUserId(),
                     order.getOriginalTotalPrice(),
-                    order.getDiscountPrice()
+                    order.getDiscountPrice(),
+                    orderItemInfos
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
@@ -11,7 +11,8 @@ public record ProductInfo(
         Integer price,
         Integer likeCount,
         Integer stock,
-        ZonedDateTime createdAt
+        ZonedDateTime createdAt,
+        Long rank
 ) {
     public static ProductInfo from(Product product, String brandName) {
         return new ProductInfo(
@@ -22,7 +23,22 @@ public record ProductInfo(
                 product.getPrice().getPrice(),
                 product.getLikeCount().getCount(),
                 product.getStock().getQuantity(),
-                product.getCreatedAt()
+                product.getCreatedAt(),
+                null
+        );
+    }
+
+    public static ProductInfo from(Product product, String brandName, Long rank) {
+        return new ProductInfo(
+                product.getId(),
+                product.getName(),
+                product.getBrandId(),
+                brandName,
+                product.getPrice().getPrice(),
+                product.getLikeCount().getCount(),
+                product.getStock().getQuantity(),
+                product.getCreatedAt(),
+                rank
         );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
@@ -1,0 +1,14 @@
+package com.loopers.application.ranking;
+
+import java.time.LocalDate;
+
+public class RankingCommand {
+
+    public record GetDailyRankingCommand(
+            LocalDate date,
+            int page,
+            int size
+    ) {
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,0 +1,76 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.ranking.Ranking;
+import com.loopers.domain.ranking.RankingService;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class RankingFacade {
+
+    private final RankingService rankingService;
+    private final ProductService productService;
+    private final BrandService brandService;
+
+    public RankingInfo getDailyRanking(RankingCommand.GetDailyRankingCommand command) {
+        List<Ranking> rankings = rankingService.getRanking(
+                command.date(),
+                command.page(),
+                command.size()
+        );
+
+        if (rankings.isEmpty()) {
+            return new RankingInfo(List.of());
+        }
+
+        List<Long> productIds = rankings.stream()
+                .map(Ranking::productId)
+                .collect(Collectors.toList());
+
+        List<Product> products = productService.findProductsByIds(productIds);
+        Map<Long, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getId, product -> product));
+
+        List<Long> brandIds = products.stream()
+                .map(Product::getBrandId)
+                .distinct()
+                .collect(Collectors.toList());
+        Map<Long, String> brandNameMap = brandService.findBrandNamesByIds(brandIds);
+
+        List<RankingInfo.RankingItemInfo> rankingItemInfos = rankings.stream()
+                .map(ranking -> {
+                    Product product = productMap.get(ranking.productId());
+                    if (product == null) {
+                        log.warn("랭킹에 있는 상품이 DB에 존재하지 않음: productId={}", ranking.productId());
+                        return null;
+                    }
+
+                    String brandName = brandNameMap.getOrDefault(product.getBrandId(), "알 수 없음");
+
+                    return new RankingInfo.RankingItemInfo(
+                            ranking.productId(),
+                            product.getName(),
+                            brandName,
+                            product.getPrice().getPrice(),
+                            product.getLikeCount().getCount(),
+                            ranking.rank(),
+                            ranking.score()
+                    );
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        return new RankingInfo(rankingItemInfos);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingInfo.java
@@ -1,0 +1,18 @@
+package com.loopers.application.ranking;
+
+import java.util.List;
+
+public record RankingInfo(
+        List<RankingItemInfo> items
+) {
+    public record RankingItemInfo(
+            Long productId,
+            String productName,
+            String brandName,
+            Integer price,
+            Integer likeCount,
+            Long rank,
+            Double score
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
@@ -4,6 +4,7 @@ import com.loopers.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 
 @Entity
@@ -17,4 +18,19 @@ public class Brand extends BaseEntity {
     @Column(nullable = false)
     private String description;
 
+    public Brand() {
+    }
+
+    @Builder
+    public Brand(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public static Brand createBrand(String name, String description) {
+        return Brand.builder()
+                .name(name)
+                .description(description)
+                .build();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -15,4 +15,6 @@ public interface ProductRepository {
 
     List<Product> findProductsByLikesDesc(Long brandId, int page, int size);
 
+    List<Product> findProductsByIds(List<Long> productIds);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -53,6 +53,11 @@ public class ProductService {
         return productRepository.findProductsByLikesDesc(brandId, page, size);
     }
 
+    @Transactional(readOnly = true)
+    public List<Product> findProductsByIds(List<Long> productIds) {
+        return productRepository.findProductsByIds(productIds);
+    }
+
     @Transactional
     public Product increaseLikeCount(Long productId) {
         Product product = productRepository.findProductById(productId)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/Ranking.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/Ranking.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.ranking;
+
+public record Ranking(
+        Long productId,
+        Long rank,
+        Double score
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingItem.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.ranking;
+
+public record RankingItem(
+        Long productId,
+        Double score
+) {
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.infrastructure.cache.RankingCacheService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@RequiredArgsConstructor
+@Service
+public class RankingService {
+
+    private final RankingCacheService rankingCacheService;
+
+    public List<Ranking> getRanking(LocalDate date, int page, int size) {
+        long start = (long) (page - 1) * size;
+        long end = start + size - 1;
+
+        List<RankingItem> rankingItems = rankingCacheService.getRankingRange(date, start, end);
+
+        if (rankingItems.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return IntStream.range(0, rankingItems.size())
+                .mapToObj(i -> {
+                    RankingItem item = rankingItems.get(i);
+                    long rank = start + 1 + i;
+                    return new Ranking(item.productId(), rank, item.score());
+                })
+                .toList();
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RankingCacheService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RankingCacheService.java
@@ -59,11 +59,12 @@ public class RankingCacheService {
         return rankingItems;
     }
 
-    public Long getProductRank(LocalDate date, String productId) {
+    public Long getProductRank(LocalDate date, Long productId) {
         String key = getRankingKey(date);
         ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
 
-        Long rank = zSetOps.reverseRank(key, productId);
+        String productIdStr = String.valueOf(productId);
+        Long rank = zSetOps.reverseRank(key, productIdStr);
 
         if (rank == null) {
             log.debug("해당 상품이 랭킹에 존재하지 않음: key={}, productId={}", key, productId);

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RankingCacheService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RankingCacheService.java
@@ -1,0 +1,79 @@
+package com.loopers.infrastructure.cache;
+
+import com.loopers.domain.ranking.RankingItem;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Service
+public class RankingCacheService {
+
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RedisTemplate<String, String> redisTemplateMaster;
+
+    public RankingCacheService(@Qualifier("redisTemplateMaster") RedisTemplate<String, String> redisTemplateMaster) {
+        this.redisTemplateMaster = redisTemplateMaster;
+    }
+
+    public List<RankingItem> getRankingRange(LocalDate date, long start, long end) {
+        String key = getRankingKey(date);
+
+        ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+        Set<ZSetOperations.TypedTuple<String>> entries = zSetOps.reverseRangeWithScores(key, start, end);
+
+        if (entries == null || entries.isEmpty()) {
+            log.debug("랭킹 데이터가 없음: key={}, start={}, end={}", key, start, end);
+            return new ArrayList<>();
+        }
+
+        List<RankingItem> rankingItems = new ArrayList<>();
+        for (ZSetOperations.TypedTuple<String> entry : entries) {
+            String productIdStr = entry.getValue();
+            Double score = entry.getScore();
+
+            if (productIdStr == null || score == null) {
+                continue;
+            }
+
+            try {
+                Long productId = Long.parseLong(productIdStr);
+                rankingItems.add(new RankingItem(productId, score));
+            } catch (NumberFormatException e) {
+                log.warn("랭킹에서 잘못된 productId 형식: {}", productIdStr);
+            }
+        }
+
+        log.debug("랭킹 데이터 조회 완료: key={}, start={}, end={}, count={}", key, start, end, rankingItems.size());
+        return rankingItems;
+    }
+
+    public Long getProductRank(LocalDate date, String productId) {
+        String key = getRankingKey(date);
+        ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+        Long rank = zSetOps.reverseRank(key, productId);
+
+        if (rank == null) {
+            log.debug("해당 상품이 랭킹에 존재하지 않음: key={}, productId={}", key, productId);
+            return null;
+        }
+
+        return rank + 1;
+    }
+
+    private String getRankingKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -24,5 +24,8 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT p FROM Product p WHERE p.isDeleted = false AND (:brandId IS NULL OR p.brandId = :brandId) ORDER BY p.likeCount.count DESC")
     List<Product> findProductsByLikesDesc(@Param("brandId") Long brandId, Pageable pageable);
+
+    @Query("SELECT p FROM Product p WHERE p.isDeleted = false AND p.id IN :productIds")
+    List<Product> findProductsByIds(@Param("productIds") List<Long> productIds);
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -38,4 +38,12 @@ public class ProductRepositoryImpl implements ProductRepository {
     public List<Product> findProductsByLikesDesc(Long brandId, int page, int size) {
         return productJpaRepository.findProductsByLikesDesc(brandId, PageRequest.of(page, size));
     }
+
+    @Override
+    public List<Product> findProductsByIds(List<Long> productIds) {
+        if (productIds == null || productIds.isEmpty()) {
+            return List.of();
+        }
+        return productJpaRepository.findProductsByIds(productIds);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -47,7 +47,8 @@ public class ProductV1Dto {
             String brandName,
             Integer price,
             Integer likeCount,
-            Integer stock
+            Integer stock,
+            Long rank
     ) {
         public static ProductResponse from(ProductInfo info) {
             return new ProductResponse(
@@ -57,7 +58,8 @@ public class ProductV1Dto {
                     info.brandName(),
                     info.price(),
                     info.likeCount(),
-                    info.stock()
+                    info.stock(),
+                    info.rank()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+
+@Tag(name = "Ranking V1 API", description = "Ranking V1 API 입니다.")
+public interface RankingV1ApiSpec {
+
+    @Operation(
+            summary = "상품 랭킹 조회",
+            description = "상품의 일간 랭킹 정보를 조회합니다."
+    )
+    ApiResponse<RankingV1Dto.DailyRankingListResponse> getDailyRanking(
+            @Parameter(name = "date", description = "조회할 날짜 (yyyyMMdd 형식)", required = true)
+            LocalDate date,
+            @Parameter(name = "page", description = "페이지 번호 (기본값: 1)")
+            Integer page,
+            @Parameter(name = "size", description = "페이지당 상품 수 (기본값: 20)")
+            Integer size
+    );
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,8 +1,10 @@
 package com.loopers.interfaces.api.ranking;
 
+import com.loopers.application.ranking.RankingCommand;
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.application.ranking.RankingInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/rankings")
 public class RankingV1Controller implements RankingV1ApiSpec {
 
+    private final RankingFacade rankingFacade;
+
     @GetMapping
     @Override
     public ApiResponse<RankingV1Dto.DailyRankingListResponse> getDailyRanking(
@@ -22,8 +26,14 @@ public class RankingV1Controller implements RankingV1ApiSpec {
             @RequestParam(required = false, defaultValue = "1") Integer page,
             @RequestParam(required = false, defaultValue = "20") Integer size
     ) {
-        RankingV1Dto.DailyRankingListResponse response =
-                new RankingV1Dto.DailyRankingListResponse(List.of());
+        RankingCommand.GetDailyRankingCommand command = new RankingCommand.GetDailyRankingCommand(
+                date,
+                page,
+                size
+        );
+
+        RankingInfo rankingInfo = rankingFacade.getDailyRanking(command);
+        RankingV1Dto.DailyRankingListResponse response = RankingV1Dto.DailyRankingListResponse.from(rankingInfo);
 
         return ApiResponse.success(response);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.interfaces.api.ApiResponse;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/rankings")
+public class RankingV1Controller implements RankingV1ApiSpec {
+
+    @GetMapping
+    @Override
+    public ApiResponse<RankingV1Dto.DailyRankingListResponse> getDailyRanking(
+            @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+            @RequestParam(required = false, defaultValue = "1") Integer page,
+            @RequestParam(required = false, defaultValue = "20") Integer size
+    ) {
+        RankingV1Dto.DailyRankingListResponse response =
+                new RankingV1Dto.DailyRankingListResponse(List.of());
+
+        return ApiResponse.success(response);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -1,13 +1,26 @@
 package com.loopers.interfaces.api.ranking;
 
+import com.loopers.application.ranking.RankingInfo;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class RankingV1Dto {
 
     public record DailyRankingListResponse(
             List<DailyRankingItem> rankings
     ) {
-        public static DailyRankingListResponse from(List<DailyRankingItem> items) {
+        public static DailyRankingListResponse from(RankingInfo rankingInfo) {
+            List<DailyRankingItem> items = rankingInfo.items().stream()
+                    .map(item -> new DailyRankingItem(
+                            item.productId(),
+                            item.productName(),
+                            item.brandName(),
+                            item.price(),
+                            item.likeCount(),
+                            item.rank().intValue()
+                    ))
+                    .collect(Collectors.toList());
+
             return new DailyRankingListResponse(items);
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.ranking;
+
+import java.util.List;
+
+public class RankingV1Dto {
+
+    public record DailyRankingListResponse(
+            List<DailyRankingItem> rankings
+    ) {
+        public static DailyRankingListResponse from(List<DailyRankingItem> items) {
+            return new DailyRankingListResponse(items);
+        }
+    }
+
+    public record DailyRankingItem(
+            Long productId,
+            String productName,
+            String brandName,
+            Integer price,
+            Integer likeCount,
+            Integer rank
+    ) {
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
@@ -1,0 +1,214 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.LikeCount;
+import com.loopers.domain.product.Price;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.Stock;
+import com.loopers.infrastructure.brand.BrandJpaRepository;
+import com.loopers.support.IntegrationTest;
+import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RankingFacadeIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private RankingFacade rankingFacade;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private BrandJpaRepository brandJpaRepository;
+
+    @Autowired
+    @Qualifier("redisTemplateMaster")
+    private RedisTemplate<String, String> redisTemplateMaster;
+
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("일별 랭킹 조회")
+    @Nested
+    class GetDailyRanking {
+
+        @DisplayName("랭킹 데이터가 있고 상품 정보가 있으면 정상적으로 조회된다.")
+        @Test
+        void returnsRankingInfo_whenDataExists() {
+            // arrange
+            Brand brand1 = createBrand("브랜드1");
+            Brand brand2 = createBrand("브랜드2");
+            brand1 = brandJpaRepository.save(brand1);
+            brand2 = brandJpaRepository.save(brand2);
+
+            Product product1 = createProduct("상품1", brand1.getId(), 10000, 10, 100);
+            Product product2 = createProduct("상품2", brand2.getId(), 20000, 20, 200);
+            productRepository.saveProduct(product1);
+            productRepository.saveProduct(product2);
+
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            zSetOps.add(key, String.valueOf(product1.getId()), 100.0);
+            zSetOps.add(key, String.valueOf(product2.getId()), 50.0);
+
+            RankingCommand.GetDailyRankingCommand command = new RankingCommand.GetDailyRankingCommand(
+                    date, 1, 20
+            );
+
+            // act
+            RankingInfo result = rankingFacade.getDailyRanking(command);
+
+            // assert
+            assertThat(result.items()).hasSize(2);
+            RankingInfo.RankingItemInfo item1 = result.items().get(0);
+            assertThat(item1.productId()).isEqualTo(product1.getId());
+            assertThat(item1.productName()).isEqualTo("상품1");
+            assertThat(item1.brandName()).isEqualTo("브랜드1");
+            assertThat(item1.price()).isEqualTo(10000);
+            assertThat(item1.likeCount()).isEqualTo(10);
+            assertThat(item1.rank()).isEqualTo(1L);
+            assertThat(item1.score()).isEqualTo(100.0);
+
+            RankingInfo.RankingItemInfo item2 = result.items().get(1);
+            assertThat(item2.productId()).isEqualTo(product2.getId());
+            assertThat(item2.productName()).isEqualTo("상품2");
+            assertThat(item2.brandName()).isEqualTo("브랜드2");
+            assertThat(item2.price()).isEqualTo(20000);
+            assertThat(item2.likeCount()).isEqualTo(20);
+            assertThat(item2.rank()).isEqualTo(2L);
+            assertThat(item2.score()).isEqualTo(50.0);
+        }
+
+        @DisplayName("랭킹에 있지만 DB에 없는 상품은 제외된다.")
+        @Test
+        void excludesProducts_notInDatabase() {
+            // arrange
+            Brand brand = createBrand("브랜드1");
+            brand = brandJpaRepository.save(brand);
+
+            Product product = createProduct("상품1", brand.getId(), 10000, 10, 100);
+            productRepository.saveProduct(product);
+
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            zSetOps.add(key, String.valueOf(product.getId()), 100.0);
+            zSetOps.add(key, "999", 50.0); // DB에 없는 상품
+
+            RankingCommand.GetDailyRankingCommand command = new RankingCommand.GetDailyRankingCommand(
+                    date, 1, 20
+            );
+
+            // act
+            RankingInfo result = rankingFacade.getDailyRanking(command);
+
+            // assert
+            assertThat(result.items()).hasSize(1);
+            assertThat(result.items().get(0).productId()).isEqualTo(product.getId());
+        }
+
+        @DisplayName("랭킹 데이터가 없으면 빈 리스트를 반환한다.")
+        @Test
+        void returnsEmptyList_whenNoRankingData() {
+            // arrange
+            RankingCommand.GetDailyRankingCommand command = new RankingCommand.GetDailyRankingCommand(
+                    LocalDate.now(), 1, 20
+            );
+
+            // act
+            RankingInfo result = rankingFacade.getDailyRanking(command);
+
+            // assert
+            assertThat(result.items()).isEmpty();
+        }
+
+        @DisplayName("페이징이 정상적으로 동작한다.")
+        @Test
+        void returnsPaginatedResults() {
+            // arrange
+            Brand brand = createBrand("브랜드1");
+            brand = brandJpaRepository.save(brand);
+
+            Product product1 = createProduct("상품1", brand.getId(), 10000, 10, 100);
+            Product product2 = createProduct("상품2", brand.getId(), 20000, 20, 200);
+            Product product3 = createProduct("상품3", brand.getId(), 30000, 30, 300);
+            productRepository.saveProduct(product1);
+            productRepository.saveProduct(product2);
+            productRepository.saveProduct(product3);
+
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            zSetOps.add(key, String.valueOf(product1.getId()), 100.0);
+            zSetOps.add(key, String.valueOf(product2.getId()), 50.0);
+            zSetOps.add(key, String.valueOf(product3.getId()), 30.0);
+
+            // act - 첫 페이지
+            RankingInfo page1 = rankingFacade.getDailyRanking(
+                    new RankingCommand.GetDailyRankingCommand(date, 1, 2)
+            );
+
+            // assert
+            assertThat(page1.items()).hasSize(2);
+            assertThat(page1.items().get(0).productId()).isEqualTo(product1.getId());
+            assertThat(page1.items().get(1).productId()).isEqualTo(product2.getId());
+
+            // act - 두 번째 페이지
+            RankingInfo page2 = rankingFacade.getDailyRanking(
+                    new RankingCommand.GetDailyRankingCommand(date, 2, 2)
+            );
+
+            // assert
+            assertThat(page2.items()).hasSize(1);
+            assertThat(page2.items().get(0).productId()).isEqualTo(product3.getId());
+        }
+    }
+
+    private Brand createBrand(String name) {
+        return Brand.createBrand(name, name + " 설명");
+    }
+
+    private Product createProduct(String name, Long brandId, Integer price, Integer likeCount, Integer stock) {
+        return Product.createProduct(
+                name,
+                brandId,
+                Price.createPrice(price),
+                LikeCount.createLikeCount(likeCount),
+                Stock.createStock(stock)
+        );
+    }
+
+    private String getRankingKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
@@ -1,0 +1,159 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.support.IntegrationTest;
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RankingServiceIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private RankingService rankingService;
+
+    @Autowired
+    @Qualifier("redisTemplateMaster")
+    private RedisTemplate<String, String> redisTemplateMaster;
+
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @BeforeEach
+    void setUp() {
+        redisCleanUp.truncateAll();
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+    }
+
+    @DisplayName("랭킹 조회")
+    @Nested
+    class GetRanking {
+
+        @DisplayName("랭킹 데이터가 있으면 정상적으로 조회된다.")
+        @Test
+        void returnsRankings_whenDataExists() {
+            // arrange
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+            zSetOps.add(key, "1", 100.0);
+            zSetOps.add(key, "2", 50.0);
+            zSetOps.add(key, "3", 30.0);
+
+            // act
+            List<Ranking> result = rankingService.getRanking(date, 1, 20);
+
+            // assert
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).productId()).isEqualTo(1L);
+            assertThat(result.get(0).rank()).isEqualTo(1L);
+            assertThat(result.get(0).score()).isEqualTo(100.0);
+            assertThat(result.get(1).productId()).isEqualTo(2L);
+            assertThat(result.get(1).rank()).isEqualTo(2L);
+            assertThat(result.get(1).score()).isEqualTo(50.0);
+            assertThat(result.get(2).productId()).isEqualTo(3L);
+            assertThat(result.get(2).rank()).isEqualTo(3L);
+            assertThat(result.get(2).score()).isEqualTo(30.0);
+        }
+
+        @DisplayName("페이징이 정상적으로 동작한다.")
+        @Test
+        void returnsPaginatedResults() {
+            // arrange
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+            zSetOps.add(key, "1", 100.0);
+            zSetOps.add(key, "2", 90.0);
+            zSetOps.add(key, "3", 80.0);
+            zSetOps.add(key, "4", 70.0);
+            zSetOps.add(key, "5", 60.0);
+
+            // act - 첫 페이지
+            List<Ranking> page1 = rankingService.getRanking(date, 1, 2);
+
+            // assert
+            assertThat(page1).hasSize(2);
+            assertThat(page1.get(0).productId()).isEqualTo(1L);
+            assertThat(page1.get(0).rank()).isEqualTo(1L);
+            assertThat(page1.get(1).productId()).isEqualTo(2L);
+            assertThat(page1.get(1).rank()).isEqualTo(2L);
+
+            // act - 두 번째 페이지
+            List<Ranking> page2 = rankingService.getRanking(date, 2, 2);
+
+            // assert
+            assertThat(page2).hasSize(2);
+            assertThat(page2.get(0).productId()).isEqualTo(3L);
+            assertThat(page2.get(0).rank()).isEqualTo(3L);
+            assertThat(page2.get(1).productId()).isEqualTo(4L);
+            assertThat(page2.get(1).rank()).isEqualTo(4L);
+
+            // act - 세 번째 페이지
+            List<Ranking> page3 = rankingService.getRanking(date, 3, 2);
+
+            // assert
+            assertThat(page3).hasSize(1);
+            assertThat(page3.get(0).productId()).isEqualTo(5L);
+            assertThat(page3.get(0).rank()).isEqualTo(5L);
+        }
+
+        @DisplayName("랭킹 데이터가 없으면 빈 리스트를 반환한다.")
+        @Test
+        void returnsEmptyList_whenNoDataExists() {
+            // arrange
+            LocalDate date = LocalDate.now();
+
+            // act
+            List<Ranking> result = rankingService.getRanking(date, 1, 20);
+
+            // assert
+            assertThat(result).isEmpty();
+        }
+
+        @DisplayName("순위는 1부터 시작한다.")
+        @Test
+        void startsRankFromOne() {
+            // arrange
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+            zSetOps.add(key, "1", 100.0);
+
+            // act
+            List<Ranking> result = rankingService.getRanking(date, 1, 20);
+
+            // assert
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).rank()).isEqualTo(1L);
+        }
+    }
+
+    private String getRankingKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/cache/ProductCacheServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/cache/ProductCacheServiceIntegrationTest.java
@@ -336,7 +336,8 @@ class ProductCacheServiceIntegrationTest extends IntegrationTest {
                 price,
                 likeCount,
                 stock,
-                ZonedDateTime.now()
+                ZonedDateTime.now(),
+                null
         );
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/infrastructure/cache/RankingCacheServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/infrastructure/cache/RankingCacheServiceIntegrationTest.java
@@ -1,0 +1,166 @@
+package com.loopers.infrastructure.cache;
+
+import com.loopers.domain.ranking.RankingItem;
+import com.loopers.support.IntegrationTest;
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RankingCacheServiceIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private RankingCacheService rankingCacheService;
+
+    @Autowired
+    @Qualifier("redisTemplateMaster")
+    private RedisTemplate<String, String> redisTemplateMaster;
+
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+    }
+
+    @DisplayName("랭킹 범위 조회")
+    @Nested
+    class GetRankingRange {
+
+        @DisplayName("랭킹 데이터가 있으면 정상적으로 조회된다.")
+        @Test
+        void returnsRankingItems_whenDataExists() {
+            // arrange
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+            zSetOps.add(key, "1", 100.0);
+            zSetOps.add(key, "2", 50.0);
+            zSetOps.add(key, "3", 30.0);
+
+            // act
+            List<RankingItem> result = rankingCacheService.getRankingRange(date, 0, 2);
+
+            // assert
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).productId()).isEqualTo(1L);
+            assertThat(result.get(0).score()).isEqualTo(100.0);
+            assertThat(result.get(1).productId()).isEqualTo(2L);
+            assertThat(result.get(1).score()).isEqualTo(50.0);
+            assertThat(result.get(2).productId()).isEqualTo(3L);
+            assertThat(result.get(2).score()).isEqualTo(30.0);
+        }
+
+        @DisplayName("페이징이 정상적으로 동작한다.")
+        @Test
+        void returnsPaginatedResults() {
+            // arrange
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+            zSetOps.add(key, "1", 100.0);
+            zSetOps.add(key, "2", 90.0);
+            zSetOps.add(key, "3", 80.0);
+            zSetOps.add(key, "4", 70.0);
+            zSetOps.add(key, "5", 60.0);
+
+            // act - 첫 페이지 (0-1)
+            List<RankingItem> page1 = rankingCacheService.getRankingRange(date, 0, 1);
+
+            // assert
+            assertThat(page1).hasSize(2);
+            assertThat(page1.get(0).productId()).isEqualTo(1L);
+            assertThat(page1.get(1).productId()).isEqualTo(2L);
+
+            // act - 두 번째 페이지 (2-3)
+            List<RankingItem> page2 = rankingCacheService.getRankingRange(date, 2, 3);
+
+            // assert
+            assertThat(page2).hasSize(2);
+            assertThat(page2.get(0).productId()).isEqualTo(3L);
+            assertThat(page2.get(1).productId()).isEqualTo(4L);
+        }
+
+        @DisplayName("랭킹 데이터가 없으면 빈 리스트를 반환한다.")
+        @Test
+        void returnsEmptyList_whenNoDataExists() {
+            // arrange
+            LocalDate date = LocalDate.now();
+
+            // act
+            List<RankingItem> result = rankingCacheService.getRankingRange(date, 0, 10);
+
+            // assert
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @DisplayName("상품 랭킹 조회")
+    @Nested
+    class GetProductRank {
+
+        @DisplayName("랭킹에 있는 상품의 순위를 반환한다.")
+        @Test
+        void returnsRank_whenProductExistsInRanking() {
+            // arrange
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+            zSetOps.add(key, "1", 100.0);
+            zSetOps.add(key, "2", 50.0);
+            zSetOps.add(key, "3", 30.0);
+
+            // act
+            Long rank1 = rankingCacheService.getProductRank(date, 1L);
+            Long rank2 = rankingCacheService.getProductRank(date, 2L);
+            Long rank3 = rankingCacheService.getProductRank(date, 3L);
+
+            // assert
+            assertThat(rank1).isEqualTo(1L); // 1등
+            assertThat(rank2).isEqualTo(2L); // 2등
+            assertThat(rank3).isEqualTo(3L); // 3등
+        }
+
+        @DisplayName("랭킹에 없는 상품은 null을 반환한다.")
+        @Test
+        void returnsNull_whenProductNotInRanking() {
+            // arrange
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+            zSetOps.add(key, "1", 100.0);
+
+            // act
+            Long rank = rankingCacheService.getProductRank(date, 999L);
+
+            // assert
+            assertThat(rank).isNull();
+        }
+    }
+
+    private String getRankingKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
@@ -1,0 +1,232 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.infrastructure.brand.BrandJpaRepository;
+import com.loopers.domain.product.LikeCount;
+import com.loopers.domain.product.Price;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.Stock;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.IntegrationTest;
+import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RankingV1ApiE2ETest extends IntegrationTest {
+
+    private static final String ENDPOINT_RANKING = "/api/v1/rankings";
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final TestRestTemplate testRestTemplate;
+    private final BrandJpaRepository brandJpaRepository;
+    private final ProductRepository productRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+    private final RedisCleanUp redisCleanUp;
+
+    @Autowired
+    @Qualifier("redisTemplateMaster")
+    private RedisTemplate<String, String> redisTemplateMaster;
+
+    @Autowired
+    public RankingV1ApiE2ETest(
+            TestRestTemplate testRestTemplate,
+            BrandJpaRepository brandJpaRepository,
+            ProductRepository productRepository,
+            DatabaseCleanUp databaseCleanUp,
+            RedisCleanUp redisCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.brandJpaRepository = brandJpaRepository;
+        this.productRepository = productRepository;
+        this.databaseCleanUp = databaseCleanUp;
+        this.redisCleanUp = redisCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("GET /api/v1/rankings - 일별 랭킹 조회")
+    @Nested
+    class GetDailyRanking {
+
+        @DisplayName("랭킹 데이터가 있으면 정상적으로 반환된다.")
+        @Test
+        void returnsRanking_whenDataExists() {
+            // arrange
+            Brand brand1 = createBrand("브랜드1");
+            Brand brand2 = createBrand("브랜드2");
+            brand1 = brandJpaRepository.save(brand1);
+            brand2 = brandJpaRepository.save(brand2);
+
+            Product product1 = createProduct("상품1", brand1.getId(), 10000, 10, 100);
+            Product product2 = createProduct("상품2", brand2.getId(), 20000, 20, 200);
+            productRepository.saveProduct(product1);
+            productRepository.saveProduct(product2);
+
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            zSetOps.add(key, String.valueOf(product1.getId()), 100.0);
+            zSetOps.add(key, String.valueOf(product2.getId()), 50.0);
+
+            String url = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=1&size=20";
+
+            // act
+            ResponseEntity<ApiResponse<RankingV1Dto.DailyRankingListResponse>> response = testRestTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.SUCCESS);
+
+            RankingV1Dto.DailyRankingListResponse rankingResponse = response.getBody().data();
+            assertThat(rankingResponse.rankings()).hasSize(2);
+
+            RankingV1Dto.DailyRankingItem item1 = rankingResponse.rankings().get(0);
+            assertAll(
+                    () -> assertThat(item1.productId()).isEqualTo(product1.getId()),
+                    () -> assertThat(item1.productName()).isEqualTo("상품1"),
+                    () -> assertThat(item1.brandName()).isEqualTo("브랜드1"),
+                    () -> assertThat(item1.price()).isEqualTo(10000),
+                    () -> assertThat(item1.likeCount()).isEqualTo(10),
+                    () -> assertThat(item1.rank()).isEqualTo(1)
+            );
+
+            RankingV1Dto.DailyRankingItem item2 = rankingResponse.rankings().get(1);
+            assertAll(
+                    () -> assertThat(item2.productId()).isEqualTo(product2.getId()),
+                    () -> assertThat(item2.productName()).isEqualTo("상품2"),
+                    () -> assertThat(item2.brandName()).isEqualTo("브랜드2"),
+                    () -> assertThat(item2.price()).isEqualTo(20000),
+                    () -> assertThat(item2.likeCount()).isEqualTo(20),
+                    () -> assertThat(item2.rank()).isEqualTo(2)
+            );
+        }
+
+        @DisplayName("랭킹 데이터가 없으면 빈 리스트를 반환한다.")
+        @Test
+        void returnsEmptyList_whenNoDataExists() {
+            // arrange
+            LocalDate date = LocalDate.now();
+            String url = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=1&size=20";
+
+            // act
+            ResponseEntity<ApiResponse<RankingV1Dto.DailyRankingListResponse>> response = testRestTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.SUCCESS);
+
+            RankingV1Dto.DailyRankingListResponse rankingResponse = response.getBody().data();
+            assertThat(rankingResponse.rankings()).isEmpty();
+        }
+
+        @DisplayName("페이징이 정상적으로 동작한다.")
+        @Test
+        void returnsPaginatedResults() {
+            // arrange
+            Brand brand = createBrand("브랜드1");
+            brand = brandJpaRepository.save(brand);
+
+            Product product1 = createProduct("상품1", brand.getId(), 10000, 10, 100);
+            Product product2 = createProduct("상품2", brand.getId(), 20000, 20, 200);
+            Product product3 = createProduct("상품3", brand.getId(), 30000, 30, 300);
+            productRepository.saveProduct(product1);
+            productRepository.saveProduct(product2);
+            productRepository.saveProduct(product3);
+
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            zSetOps.add(key, String.valueOf(product1.getId()), 100.0);
+            zSetOps.add(key, String.valueOf(product2.getId()), 50.0);
+            zSetOps.add(key, String.valueOf(product3.getId()), 30.0);
+
+            // act - 첫 페이지
+            String url1 = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=1&size=2";
+            ResponseEntity<ApiResponse<RankingV1Dto.DailyRankingListResponse>> response1 = testRestTemplate.exchange(
+                    url1,
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response1.getStatusCode()).isEqualTo(HttpStatus.OK);
+            RankingV1Dto.DailyRankingListResponse page1 = response1.getBody().data();
+            assertThat(page1.rankings()).hasSize(2);
+            assertThat(page1.rankings().get(0).productId()).isEqualTo(product1.getId());
+            assertThat(page1.rankings().get(1).productId()).isEqualTo(product2.getId());
+
+            // act - 두 번째 페이지
+            String url2 = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=2&size=2";
+            ResponseEntity<ApiResponse<RankingV1Dto.DailyRankingListResponse>> response2 = testRestTemplate.exchange(
+                    url2,
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.OK);
+            RankingV1Dto.DailyRankingListResponse page2 = response2.getBody().data();
+            assertThat(page2.rankings()).hasSize(1);
+            assertThat(page2.rankings().get(0).productId()).isEqualTo(product3.getId());
+        }
+    }
+
+    private Brand createBrand(String name) {
+        return Brand.createBrand(name, name + " 설명");
+    }
+
+    private Product createProduct(String name, Long brandId, Integer price, Integer likeCount, Integer stock) {
+        return Product.createProduct(
+                name,
+                brandId,
+                Price.createPrice(price),
+                LikeCount.createLikeCount(likeCount),
+                Stock.createStock(stock)
+        );
+    }
+
+    private String getRankingKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/CommerceStreamerApplication.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/CommerceStreamerApplication.java
@@ -4,11 +4,13 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableScheduling
 public class CommerceStreamerApplication {
     @PostConstruct
     public void started() {

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,76 @@
+package com.loopers.domain.ranking;
+
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+public class RankingService {
+
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final int TTL_SECONDS = 2 * 24 * 60 * 60;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RedisTemplate<String, String> redisTemplateMaster;
+
+    public RankingService(@Qualifier("redisTemplateMaster") RedisTemplate<String, String> redisTemplateMaster) {
+        this.redisTemplateMaster = redisTemplateMaster;
+    }
+
+    public void incrementScore(Long productId, RankingWeight weight) {
+        LocalDate date = LocalDate.now();
+
+        String key = getRankingKey(date);
+        String member = String.valueOf(productId);
+
+        ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+        Double newScore = zSetOps.incrementScore(key, member, weight.getWeight());
+
+        redisTemplateMaster.expire(key, Duration.ofSeconds(TTL_SECONDS));
+
+        log.debug("랭킹 점수 증가: productId={}, weight={}, date={}, newScore={}",
+                productId, weight.getDescription(), date, newScore);
+    }
+
+    public void carryOverScore(LocalDate fromDate, LocalDate toDate) {
+        String fromKey = getRankingKey(fromDate);
+        String toKey = getRankingKey(toDate);
+
+        ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+
+        var entries = zSetOps.reverseRangeWithScores(fromKey, 0, -1);
+
+        if (entries == null || entries.isEmpty()) {
+            log.info("carry-over할 데이터가 없음: fromDate={}", fromDate);
+            return;
+        }
+
+        for (ZSetOperations.TypedTuple<String> entry : entries) {
+            String productId = entry.getValue();
+            Double score = entry.getScore();
+
+            if (productId == null || score == null || score <= 0) {
+                continue;
+            }
+
+            double carryOverScore = score * RankingWeight.CARRY_OVER.getWeight();
+            zSetOps.incrementScore(toKey, productId, carryOverScore);
+        }
+
+        redisTemplateMaster.expire(toKey, java.time.Duration.ofSeconds(TTL_SECONDS));
+
+        log.info("랭킹 점수 carry-over 완료: fromDate={}, toDate={}", fromDate, toDate);
+    }
+
+    private String getRankingKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeight.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingWeight.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.ranking;
+
+import lombok.Getter;
+
+@Getter
+public enum RankingWeight {
+    VIEW(0.1, "조회수"),
+    LIKE(0.2, "좋아요"),
+    ORDER_CREATED(0.7, "주문 생성"),
+    CARRY_OVER(0.1, "Carry-Over");
+
+    private final double weight;
+    private final String description;
+
+    RankingWeight(double weight, String description) {
+        this.weight = weight;
+        this.description = description;
+    }
+}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/scheduler/RankingScoreCarryOverScheduler.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/scheduler/RankingScoreCarryOverScheduler.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.scheduler;
+
+import com.loopers.domain.ranking.RankingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class RankingScoreCarryOverScheduler {
+
+    private final RankingService rankingService;
+
+    @Scheduled(cron = "0 50 23 * * *", zone = "Asia/Seoul")
+    public void carryOverRankingScore() {
+        try {
+            LocalDate today = LocalDate.now();
+            LocalDate targetDate = today.plusDays(1);
+
+            rankingService.carryOverScore(today, targetDate);
+        } catch (Exception e) {
+            log.error("랭킹 점수 carry-over 중 오류 발생", e);
+        }
+    }
+}
+

--- a/apps/commerce-streamer/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
@@ -1,0 +1,223 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@SpringBootTest
+class RankingServiceIntegrationTest {
+
+    @Autowired
+    private RankingService rankingService;
+
+    @Autowired
+    @Qualifier("redisTemplateMaster")
+    private RedisTemplate<String, String> redisTemplateMaster;
+
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+    }
+
+    @DisplayName("랭킹 점수 증가")
+    @Nested
+    class IncrementScore {
+
+        @DisplayName("좋아요 이벤트 발생 시 점수가 적절하게 증가한다.")
+        @Test
+        void incrementsScore_whenLikeEventOccurs() {
+            // arrange
+            Long productId = 1L;
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+
+            // act
+            rankingService.incrementScore(productId, RankingWeight.LIKE);
+
+            // assert
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            Double score = zSetOps.score(key, String.valueOf(productId));
+            assertThat(score).isNotNull();
+            assertThat(score).isCloseTo(RankingWeight.LIKE.getWeight(), within(0.001));
+
+            // TTL 확인
+            Long ttl = redisTemplateMaster.getExpire(key);
+            assertThat(ttl).isNotNull();
+            assertThat(ttl).isGreaterThan(0);
+            assertThat(ttl).isLessThanOrEqualTo(2 * 24 * 60 * 60); // 2일
+        }
+
+        @DisplayName("조회수 이벤트 발생 시 점수가 적절하게 증가한다.")
+        @Test
+        void incrementsScore_whenViewEventOccurs() {
+            // arrange
+            Long productId = 2L;
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+
+            // act
+            rankingService.incrementScore(productId, RankingWeight.VIEW);
+
+            // assert
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            Double score = zSetOps.score(key, String.valueOf(productId));
+            assertThat(score).isNotNull();
+            assertThat(score).isCloseTo(RankingWeight.VIEW.getWeight(), within(0.001));
+        }
+
+        @DisplayName("주문 생성 이벤트 발생 시 점수가 적절하게 증가한다.")
+        @Test
+        void incrementsScore_whenOrderCreatedEventOccurs() {
+            // arrange
+            Long productId = 3L;
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+
+            // act
+            rankingService.incrementScore(productId, RankingWeight.ORDER_CREATED);
+
+            // assert
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            Double score = zSetOps.score(key, String.valueOf(productId));
+            assertThat(score).isNotNull();
+            assertThat(score).isCloseTo(RankingWeight.ORDER_CREATED.getWeight(), within(0.001));
+        }
+
+        @DisplayName("여러 번 점수를 증가시키면 누적된다.")
+        @Test
+        void accumulatesScore_whenMultipleIncrements() {
+            // arrange
+            Long productId = 4L;
+            LocalDate date = LocalDate.now();
+            String key = getRankingKey(date);
+
+            // act
+            rankingService.incrementScore(productId, RankingWeight.LIKE);
+            rankingService.incrementScore(productId, RankingWeight.VIEW);
+            rankingService.incrementScore(productId, RankingWeight.ORDER_CREATED);
+
+            // assert
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            Double score = zSetOps.score(key, String.valueOf(productId));
+            assertThat(score).isNotNull();
+            double expectedScore = RankingWeight.LIKE.getWeight() +
+                    RankingWeight.VIEW.getWeight() +
+                    RankingWeight.ORDER_CREATED.getWeight();
+            assertThat(score).isCloseTo(expectedScore, within(0.001));
+        }
+
+        @DisplayName("날짜별로 다른 키를 사용한다.")
+        @Test
+        void usesDifferentKeys_forDifferentDates() {
+            // arrange
+            Long productId = 5L;
+            LocalDate today = LocalDate.now();
+            LocalDate tomorrow = today.plusDays(1);
+
+            // act
+            rankingService.incrementScore(productId, RankingWeight.LIKE);
+
+            // assert
+            String todayKey = getRankingKey(today);
+            String tomorrowKey = getRankingKey(tomorrow);
+
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            Double todayScore = zSetOps.score(todayKey, String.valueOf(productId));
+            Double tomorrowScore = zSetOps.score(tomorrowKey, String.valueOf(productId));
+
+            assertThat(todayScore).isNotNull();
+            assertThat(tomorrowScore).isNull(); // 내일 키에는 데이터가 없음
+        }
+    }
+
+    @DisplayName("랭킹 점수 Carry-Over")
+    @Nested
+    class CarryOverScore {
+
+        @DisplayName("전날 점수를 다음 날로 carry-over한다.")
+        @Test
+        void carriesOverScore_fromPreviousDayToNextDay() {
+            // arrange
+            Long productId1 = 10L;
+            Long productId2 = 20L;
+            LocalDate yesterday = LocalDate.now().minusDays(1);
+            LocalDate today = LocalDate.now();
+
+            String yesterdayKey = getRankingKey(yesterday);
+            String todayKey = getRankingKey(today);
+
+            // 전날 데이터 설정
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            zSetOps.add(yesterdayKey, String.valueOf(productId1), 100.0);
+            zSetOps.add(yesterdayKey, String.valueOf(productId2), 50.0);
+
+            // act
+            rankingService.carryOverScore(yesterday, today);
+
+            // assert
+            Double todayScore1 = zSetOps.score(todayKey, String.valueOf(productId1));
+            Double todayScore2 = zSetOps.score(todayKey, String.valueOf(productId2));
+
+            assertThat(todayScore1).isNotNull();
+            assertThat(todayScore2).isNotNull();
+
+            // carry-over weight (0.1)가 적용된 점수
+            assertThat(todayScore1).isCloseTo(100.0 * RankingWeight.CARRY_OVER.getWeight(), within(0.001));
+            assertThat(todayScore2).isCloseTo(50.0 * RankingWeight.CARRY_OVER.getWeight(), within(0.001));
+
+            // TTL 확인
+            Long ttl = redisTemplateMaster.getExpire(todayKey);
+            assertThat(ttl).isNotNull();
+            assertThat(ttl).isGreaterThan(0);
+        }
+
+        @DisplayName("carry-over 후에도 원본 데이터는 유지된다.")
+        @Test
+        void preservesOriginalData_afterCarryOver() {
+            // arrange
+            Long productId = 30L;
+            LocalDate yesterday = LocalDate.now().minusDays(1);
+            LocalDate today = LocalDate.now();
+
+            String yesterdayKey = getRankingKey(yesterday);
+            String todayKey = getRankingKey(today);
+
+            ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
+            zSetOps.add(yesterdayKey, String.valueOf(productId), 200.0);
+
+            // act
+            rankingService.carryOverScore(yesterday, today);
+
+            // assert
+            Double yesterdayScore = zSetOps.score(yesterdayKey, String.valueOf(productId));
+            Double todayScore = zSetOps.score(todayKey, String.valueOf(productId));
+
+            assertThat(yesterdayScore).isCloseTo(200.0, within(0.001));
+            assertThat(todayScore).isCloseTo(200.0 * RankingWeight.CARRY_OVER.getWeight(), within(0.001));
+        }
+    }
+
+    private String getRankingKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}
+

--- a/modules/kafka/src/main/java/com/loopers/application/kafka/KafkaEvent.java
+++ b/modules/kafka/src/main/java/com/loopers/application/kafka/KafkaEvent.java
@@ -29,9 +29,10 @@ public interface KafkaEvent {
                 Long orderId,
                 Integer totalPrice,
                 Integer discountPrice,
+                List<OrderItemInfo> orderItems,
                 ZonedDateTime timestamp
         ) implements OrderEvent {
-            public static OrderCreated from(String orderKey, Long userId, Long orderId, Integer totalPrice, Integer discountPrice) {
+            public static OrderCreated from(String orderKey, Long userId, Long orderId, Integer totalPrice, Integer discountPrice, List<OrderItemInfo> orderItems) {
                 return new OrderCreated(
                         KafkaEvent.generateEventId("order-created", orderKey),
                         orderKey,
@@ -39,6 +40,7 @@ public interface KafkaEvent {
                         orderId,
                         totalPrice,
                         discountPrice,
+                        orderItems,
                         ZonedDateTime.now()
                 );
             }


### PR DESCRIPTION
## 📌 Summary
- 컨슈머에서 상품 일별 랭킹 집계 
	- Redis ZSET TTL, 키 전략 구성
	- 콜드 스타트 문제 해결 
- 랭킹 Page 조회
- 상품 상세 조회 시 랭킹 반환 

---

## 💬 Review Points

### 1. `product_metrics`의 용도

현재 구현에서는 Kafka 이벤트(좋아요 등록, 조회수, 주문 생성)를 수신하면 
- Redis ZSET에 즉시 점수를 반영하고
- `product_metrics` 테이블에도 업데이트합니다. 

데이터 흐름: 
```
Kafka 이벤트 발생 (예: ProductLiked)
    ↓
MetricsConsumer.handleProductLikedEvents()
    ↓
    ├─→ rankingService.incrementScore(productId, LIKE)
    │   └─→ Redis ZSET에 점수 추가 
    │
    └─→ productMetricsService.incrementLikeCount(productId)
        └─→ ProductMetrics 테이블: productId의 likeCount 컬럼 +1
            (랭킹 계산과 무관)
```

`prodcut_metrics`는 현재 누적 데이터만 저장하는 구조인데, 일별 랭킹을 위한 일별 변화량을 추적하려면 `product_metrics` 테이블에 저장 날짜 컬럼을 추가해야 할까요?


---
 
### 2. 동일 점수 처리 방식 
레디스 zset에서 점수가 동일하면 멤버의 사전식 순서로 정렬되는 것 같습니다. 

```
Redis ZSET 상태:
- 상품 1: 10점
- 상품 2: 10점  (동일 점수)
- 상품 3: 5점

현재 동작:
1위: 상품 1 (10점, rank=1)
2위: 상품 2 (10점, rank=2)  ← 동일 점수인데도 다른 순위
3위: 상품 3 (5점, rank=3)
```

실무에서는 동일 점수인 경우 어떤 비즈니스 로직으로 처리하는 것이 일반적인가요?

---

### 3. 비동기 콜백에서 트랜잭션 관리 
지난 주 과제 리팩토링을 하면서 OutService의 이벤트 발행 로직을 비동기 방식에서 동기 방식으로 변경했습니다. 

변경 전:
```java
public void publishPendingOutboxes(int batchSize) {
    List<Outbox> pendingOutboxes = outboxRepository.findPendingOutboxes(batchSize);
    
    for (Outbox outbox : pendingOutboxes) {
        kafkaTemplate
                .send(
                        outbox.getTopic(),
                        outbox.getPartitionKey(),
                        outbox.getPayload()
                )
                .whenComplete((result, exception) -> {
                    // 비동기 콜백에서 DB 업데이트 시도
                    if (exception == null) {
                        outboxRepository.markAsPublished(outbox.getId());
                    } else {
                        outboxRepository.markAsFailed(outbox.getId(), exception.getMessage());
                    }
                });
    }
}
```

변경 후:
```java
public void publishPendingOutboxes(int batchSize) {
        List<Outbox> pendingOutboxes = outboxRepository.findPendingOutboxes(batchSize);
        
        for (Outbox outbox : pendingOutboxes) {
            try {
                // .get()으로 동기 처리로 변경
                kafkaTemplate.send(
                    outbox.getTopic(),
                    outbox.getPartitionKey(),
                    outbox.getPayload()
                ).get();  // CompletableFuture.get() - 블로킹 호출로 변경
                
                outboxRepository.markAsPublished(outbox.getId());
            } catch (Exception e) {
                outboxRepository.markAsFailed(outbox.getId(), e.getMessage());
            }
        }
    }

```

`whenComplete` 콜백은 비동기로 실행되므로 `outboxRepository.markAsPublished()`와 `markAsFailed()` 호출이 트랜잭션 밖에서 실행될 수 있어서, 동기 방식으로 변경해줬습니다. 

비동기 방식을 계속 사용하려면 트랜잭션 관리를 해줘야 하는데, 같은 클래스 내에서 트랜잭션 관리를 위해 별도의 Manager를 사용하는 방식이 실무에서 많이 사용하는 방식인가요? 아니면 지양하는 방식인가요?



---

## ✅ Checklist

### 📈 Ranking Consumer
- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API
- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 제품에 순위 정보 추가됨
  * 일일 제품 순위 조회 API 추가 (날짜, 페이지네이션 지원)
  * 주문 시 상품 상세 정보가 함께 기록됨
  * Redis 기반 순위 캐싱 시스템 구현으로 빠른 순위 조회 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->