### PR TITLE
[volume-10] Collect, Stack, Zip 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ docker-compose -f ./docker/monitoring-compose.yml up
 Root
 ├── apps ( spring-applications )
 │   ├── 📦 commerce-api
+│   ├── 📦 commerce-batch
 │   └── 📦 commerce-streamer
 ├── modules ( reusable-configurations )
 │   ├── 📦 jpa

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -29,7 +29,22 @@ public class RankingFacade {
   @Transactional(readOnly = true)
   public RankingResult getDailyRanking(LocalDate date, int page, int size, Long userId) {
     List<RankingEntry> entries = rankingService.getTopN(date, page, size);
+    return buildResult(entries, date, page, size, userId);
+  }
 
+  @Transactional(readOnly = true)
+  public RankingResult getWeeklyRanking(LocalDate date, int page, int size, Long userId) {
+    List<RankingEntry> entries = rankingService.getWeeklyTopN(date, page, size);
+    return buildResult(entries, date, page, size, userId);
+  }
+
+  @Transactional(readOnly = true)
+  public RankingResult getMonthlyRanking(LocalDate date, int page, int size, Long userId) {
+    List<RankingEntry> entries = rankingService.getMonthlyTopN(date, page, size);
+    return buildResult(entries, date, page, size, userId);
+  }
+
+  private RankingResult buildResult(List<RankingEntry> entries, LocalDate date, int page, int size, Long userId) {
     if (entries.isEmpty()) {
       return RankingResult.empty(date, page, size);
     }
@@ -72,5 +87,4 @@ public class RankingFacade {
 
     return new RankingResult(items, page, size, date);
   }
-
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankView.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankView.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.ranking;
+
+public interface ProductRankView {
+
+  Long getRefProductId();
+
+  Double getScore();
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -65,7 +65,7 @@ public class RankingService {
   }
 
   private String toYearWeek(LocalDate date) {
-    WeekFields weekFields = WeekFields.of(Locale.KOREA);
+    WeekFields weekFields = WeekFields.of(Locale.getDefault());
     int weekBasedYear = date.get(weekFields.weekBasedYear());
     int weekOfYear = date.get(weekFields.weekOfWeekBasedYear());
     return String.format("%d-W%02d", weekBasedYear, weekOfYear);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,12 +1,21 @@
 package com.loopers.domain.ranking;
 
-import java.time.LocalDate;
-import java.util.List;
+import com.loopers.domain.ranking.mv.MonthlyProductRank;
+import com.loopers.domain.ranking.mv.MonthlyProductRankRepository;
+import com.loopers.domain.ranking.mv.WeeklyProductRank;
+import com.loopers.domain.ranking.mv.WeeklyProductRankRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 @Slf4j
 @Service
@@ -15,10 +24,34 @@ public class RankingService {
 
   private final RankingRepository rankingRepository;
   private final RankingKeyPolicy rankingKeyPolicy;
+  private final WeeklyProductRankRepository weeklyProductRankRepository;
+  private final MonthlyProductRankRepository monthlyProductRankRepository;
 
   public List<RankingEntry> getTopN(LocalDate date, int page, int size) {
     String key = rankingKeyPolicy.buildKey(date);
     return rankingRepository.getTopN(key, page, size);
+  }
+
+  public List<RankingEntry> getWeeklyTopN(LocalDate date, int page, int size) {
+    String yearWeek = toYearWeek(date);
+    List<WeeklyProductRank> ranks = weeklyProductRankRepository.findByYearWeekOrderByScoreDesc(yearWeek, page, size);
+    return toRankingEntries(ranks, page, size);
+  }
+
+  public List<RankingEntry> getMonthlyTopN(LocalDate date, int page, int size) {
+    String yearMonth = date.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+    List<MonthlyProductRank> ranks = monthlyProductRankRepository.findByYearMonthOrderByScoreDesc(yearMonth, page, size);
+    return toRankingEntries(ranks, page, size);
+  }
+
+  private List<RankingEntry> toRankingEntries(List<? extends ProductRankView> ranks, int page, int size) {
+    int baseRank = page * size;
+    List<RankingEntry> result = new ArrayList<>();
+    for (int i = 0; i < ranks.size(); i++) {
+      ProductRankView rank = ranks.get(i);
+      result.add(new RankingEntry(rank.getRefProductId(), rank.getScore(), baseRank + i + 1));
+    }
+    return result;
   }
 
   public Integer getRankOrNull(LocalDate date, Long productId) {
@@ -29,5 +62,12 @@ public class RankingService {
       log.warn("랭킹 조회 실패: productId={}, date={}", productId, date, e);
       return null;
     }
+  }
+
+  private String toYearWeek(LocalDate date) {
+    WeekFields weekFields = WeekFields.of(Locale.KOREA);
+    int weekBasedYear = date.get(weekFields.weekBasedYear());
+    int weekOfYear = date.get(weekFields.weekOfWeekBasedYear());
+    return String.format("%d-W%02d", weekBasedYear, weekOfYear);
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/MonthlyProductRank.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/MonthlyProductRank.java
@@ -1,0 +1,51 @@
+package com.loopers.domain.ranking.mv;
+
+import com.loopers.domain.ranking.ProductRankView;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mv_product_rank_monthly")
+@IdClass(MonthlyProductRankId.class)
+public class MonthlyProductRank implements ProductRankView {
+
+  @Id
+  @Column(name = "ref_product_id", nullable = false)
+  private Long refProductId;
+
+  @Id
+  @Column(name = "ranking_year_month", nullable = false)
+  private String yearMonth;
+
+  @Column(name = "score", nullable = false)
+  private Double score;
+
+  @Column(name = "period_start", nullable = false)
+  private LocalDate periodStart;
+
+  @Column(name = "period_end", nullable = false)
+  private LocalDate periodEnd;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  protected MonthlyProductRank() {}
+
+  public Long getRefProductId() {
+    return refProductId;
+  }
+
+  public String getYearMonth() {
+    return yearMonth;
+  }
+
+  public Double getScore() {
+    return score;
+  }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/MonthlyProductRankId.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/MonthlyProductRankId.java
@@ -1,0 +1,30 @@
+package com.loopers.domain.ranking.mv;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class MonthlyProductRankId implements Serializable {
+
+  private Long refProductId;
+  private String yearMonth;
+
+  public MonthlyProductRankId() {}
+
+  public MonthlyProductRankId(Long refProductId, String yearMonth) {
+    this.refProductId = refProductId;
+    this.yearMonth = yearMonth;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MonthlyProductRankId that = (MonthlyProductRankId) o;
+    return Objects.equals(refProductId, that.refProductId) && Objects.equals(yearMonth, that.yearMonth);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(refProductId, yearMonth);
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/MonthlyProductRankRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/MonthlyProductRankRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.ranking.mv;
+
+import java.util.List;
+
+public interface MonthlyProductRankRepository {
+
+  List<MonthlyProductRank> findByYearMonthOrderByScoreDesc(String yearMonth, int page, int size);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/WeeklyProductRank.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/WeeklyProductRank.java
@@ -1,0 +1,58 @@
+package com.loopers.domain.ranking.mv;
+
+import com.loopers.domain.ranking.ProductRankView;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mv_product_rank_weekly")
+@IdClass(WeeklyProductRankId.class)
+public class WeeklyProductRank implements ProductRankView {
+
+  @Id
+  @Column(name = "ref_product_id", nullable = false)
+  private Long refProductId;
+
+  @Id
+  @Column(name = "ranking_year_week", nullable = false)
+  private String yearWeek;
+
+  @Column(name = "score", nullable = false)
+  private Double score;
+
+  @Column(name = "period_start", nullable = false)
+  private LocalDate periodStart;
+
+  @Column(name = "period_end", nullable = false)
+  private LocalDate periodEnd;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  protected WeeklyProductRank() {}
+
+  public Long getRefProductId() {
+    return refProductId;
+  }
+
+  public String getYearWeek() {
+    return yearWeek;
+  }
+
+  public Double getScore() {
+    return score;
+  }
+
+  public LocalDate getPeriodStart() {
+    return periodStart;
+  }
+
+  public LocalDate getPeriodEnd() {
+    return periodEnd;
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/WeeklyProductRankId.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/WeeklyProductRankId.java
@@ -1,0 +1,30 @@
+package com.loopers.domain.ranking.mv;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class WeeklyProductRankId implements Serializable {
+
+  private Long refProductId;
+  private String yearWeek;
+
+  public WeeklyProductRankId() {}
+
+  public WeeklyProductRankId(Long refProductId, String yearWeek) {
+    this.refProductId = refProductId;
+    this.yearWeek = yearWeek;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WeeklyProductRankId that = (WeeklyProductRankId) o;
+    return Objects.equals(refProductId, that.refProductId) && Objects.equals(yearWeek, that.yearWeek);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(refProductId, yearWeek);
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/WeeklyProductRankRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/mv/WeeklyProductRankRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.ranking.mv;
+
+import java.util.List;
+
+public interface WeeklyProductRankRepository {
+
+  List<WeeklyProductRank> findByYearWeekOrderByScoreDesc(String yearWeek, int page, int size);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/MonthlyProductRankJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/MonthlyProductRankJpaRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.ranking.mv;
+
+import com.loopers.domain.ranking.mv.MonthlyProductRank;
+import com.loopers.domain.ranking.mv.MonthlyProductRankId;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthlyProductRankJpaRepository extends JpaRepository<MonthlyProductRank, MonthlyProductRankId> {
+
+  List<MonthlyProductRank> findByYearMonthOrderByScoreDesc(String yearMonth, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/MonthlyProductRankRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/MonthlyProductRankRepositoryImpl.java
@@ -15,6 +15,9 @@ public class MonthlyProductRankRepositoryImpl implements MonthlyProductRankRepos
 
   @Override
   public List<MonthlyProductRank> findByYearMonthOrderByScoreDesc(String yearMonth, int page, int size) {
+    if (page < 0 || size < 1) {
+      throw new IllegalArgumentException("page는 0 이상, size는 1 이상이어야 합니다");
+    }
     return jpaRepository.findByYearMonthOrderByScoreDesc(yearMonth, PageRequest.of(page, size));
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/MonthlyProductRankRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/MonthlyProductRankRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.ranking.mv;
+
+import com.loopers.domain.ranking.mv.MonthlyProductRank;
+import com.loopers.domain.ranking.mv.MonthlyProductRankRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MonthlyProductRankRepositoryImpl implements MonthlyProductRankRepository {
+
+  private final MonthlyProductRankJpaRepository jpaRepository;
+
+  @Override
+  public List<MonthlyProductRank> findByYearMonthOrderByScoreDesc(String yearMonth, int page, int size) {
+    return jpaRepository.findByYearMonthOrderByScoreDesc(yearMonth, PageRequest.of(page, size));
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/WeeklyProductRankJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/WeeklyProductRankJpaRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.ranking.mv;
+
+import com.loopers.domain.ranking.mv.WeeklyProductRank;
+import com.loopers.domain.ranking.mv.WeeklyProductRankId;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeeklyProductRankJpaRepository extends JpaRepository<WeeklyProductRank, WeeklyProductRankId> {
+
+  List<WeeklyProductRank> findByYearWeekOrderByScoreDesc(String yearWeek, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/WeeklyProductRankRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/WeeklyProductRankRepositoryImpl.java
@@ -15,6 +15,9 @@ public class WeeklyProductRankRepositoryImpl implements WeeklyProductRankReposit
 
   @Override
   public List<WeeklyProductRank> findByYearWeekOrderByScoreDesc(String yearWeek, int page, int size) {
+    if (page < 0 || size < 1) {
+      throw new IllegalArgumentException("page는 0 이상, size는 1 이상이어야 합니다");
+    }
     return jpaRepository.findByYearWeekOrderByScoreDesc(yearWeek, PageRequest.of(page, size));
   }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/WeeklyProductRankRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/mv/WeeklyProductRankRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.ranking.mv;
+
+import com.loopers.domain.ranking.mv.WeeklyProductRank;
+import com.loopers.domain.ranking.mv.WeeklyProductRankRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class WeeklyProductRankRepositoryImpl implements WeeklyProductRankRepository {
+
+  private final WeeklyProductRankJpaRepository jpaRepository;
+
+  @Override
+  public List<WeeklyProductRank> findByYearWeekOrderByScoreDesc(String yearWeek, int page, int size) {
+    return jpaRepository.findByYearWeekOrderByScoreDesc(yearWeek, PageRequest.of(page, size));
+  }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingApiSpec.java
@@ -10,11 +10,27 @@ import java.time.LocalDate;
 @Tag(name = "Ranking", description = "랭킹 API")
 public interface RankingApiSpec {
 
-  @Operation(summary = "일간 랭킹 조회", description = "지정된 날짜의 상품 랭킹을 조회합니다.")
+  @Operation(summary = "일간 랭킹 조회", description = "지정된 날짜의 상품 일간 랭킹을 조회합니다.")
   ApiResponse<RankingResponse> getDailyRanking(
       @Parameter(description = "사용자 ID") Long userId,
       @Parameter(description = "조회 날짜 (yyyyMMdd)", required = true, example = "20251224") LocalDate date,
       @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") int page,
+      @Parameter(description = "페이지 크기", example = "10") int size
+  );
+
+  @Operation(summary = "주간 랭킹 조회", description = "지정된 날짜가 속한 주의 상품 랭킹을 조회합니다. TOP 100까지만 제공됩니다.")
+  ApiResponse<RankingResponse> getWeeklyRanking(
+      @Parameter(description = "사용자 ID") Long userId,
+      @Parameter(description = "조회 날짜 (yyyyMMdd)", required = true, example = "20251224") LocalDate date,
+      @Parameter(description = "페이지 번호 (0부터 시작, TOP 100 내에서 페이지네이션)", example = "0") int page,
+      @Parameter(description = "페이지 크기", example = "10") int size
+  );
+
+  @Operation(summary = "월간 랭킹 조회", description = "지정된 날짜가 속한 월의 상품 랭킹을 조회합니다. TOP 100까지만 제공됩니다.")
+  ApiResponse<RankingResponse> getMonthlyRanking(
+      @Parameter(description = "사용자 ID") Long userId,
+      @Parameter(description = "조회 날짜 (yyyyMMdd)", required = true, example = "20251224") LocalDate date,
+      @Parameter(description = "페이지 번호 (0부터 시작, TOP 100 내에서 페이지네이션)", example = "0") int page,
       @Parameter(description = "페이지 크기", example = "10") int size
   );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
@@ -37,4 +37,30 @@ public class RankingController implements RankingApiSpec {
     RankingResponse response = RankingResponse.from(result);
     return ApiResponse.success(response);
   }
+
+  @Override
+  @GetMapping("/weekly")
+  public ApiResponse<RankingResponse> getWeeklyRanking(
+      @RequestHeader(value = ApiHeaders.USER_ID, required = false) Long userId,
+      @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
+  ) {
+    RankingResult result = rankingFacade.getWeeklyRanking(date, page, size, userId);
+    RankingResponse response = RankingResponse.from(result);
+    return ApiResponse.success(response);
+  }
+
+  @Override
+  @GetMapping("/monthly")
+  public ApiResponse<RankingResponse> getMonthlyRanking(
+      @RequestHeader(value = ApiHeaders.USER_ID, required = false) Long userId,
+      @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
+  ) {
+    RankingResult result = rankingFacade.getMonthlyRanking(date, page, size, userId);
+    RankingResponse response = RankingResponse.from(result);
+    return ApiResponse.success(response);
+  }
 }

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,0 +1,21 @@
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // batch
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+    testImplementation("org.springframework.batch:spring-batch-test")
+
+    // querydsl
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+}

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     // batch
     implementation("org.springframework.boot:spring-boot-starter-batch")
+    implementation("org.springframework.boot:spring-boot-starter-web") // Job 수동 실행 API용
     testImplementation("org.springframework.batch:spring-batch-test")
 
     // querydsl

--- a/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
@@ -1,0 +1,24 @@
+package com.loopers;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+import java.util.TimeZone;
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+public class CommerceBatchApplication {
+
+    @PostConstruct
+    public void started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
+    public static void main(String[] args) {
+        int exitCode = SpringApplication.exit(SpringApplication.run(CommerceBatchApplication.class, args));
+        System.exit(exitCode);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
@@ -4,9 +4,11 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
+@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class CommerceBatchApplication {

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/application/BatchJobFacade.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/application/BatchJobFacade.java
@@ -1,0 +1,51 @@
+package com.loopers.batch.application;
+
+import com.loopers.batch.domain.ranking.RankingPeriod;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BatchJobFacade {
+
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+  private final JobLauncher jobLauncher;
+  private final Job rankingAggregationJob;
+
+  public JobExecutionResult runRankingAggregation(RankingPeriod period, LocalDate date) {
+    String baseDate = date.format(DATE_FORMATTER);
+    log.info("랭킹 집계 Job 실행: period={}, baseDate={}", period, baseDate);
+
+    try {
+      JobExecution execution = jobLauncher.run(
+          rankingAggregationJob,
+          new JobParametersBuilder()
+              .addString("period", period.name())
+              .addString("baseDate", baseDate)
+              .addString("runId", LocalDateTime.now().toString())
+              .toJobParameters()
+      );
+
+      return new JobExecutionResult(
+          execution.getJobId(),
+          execution.getStatus().toString(),
+          "Job 실행 완료"
+      );
+    } catch (Exception e) {
+      log.error("랭킹 집계 Job 실행 실패", e);
+      return new JobExecutionResult(null, "FAILED", e.getMessage());
+    }
+  }
+
+  public record JobExecutionResult(Long jobId, String status, String message) {}
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/config/NoOpJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/config/NoOpJobConfig.java
@@ -1,0 +1,38 @@
+package com.loopers.batch.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * job.name이 지정되지 않았을 때 사용되는 빈 Job.
+ * 아무 작업도 수행하지 않고 즉시 완료됨.
+ */
+@Configuration
+@RequiredArgsConstructor
+public class NoOpJobConfig {
+
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager transactionManager;
+
+  @Bean("NONE")
+  public Job noOpJob() {
+    return new JobBuilder("NONE", jobRepository)
+        .start(noOpStep())
+        .build();
+  }
+
+  @Bean
+  public Step noOpStep() {
+    return new StepBuilder("noOpStep", jobRepository)
+        .tasklet((contribution, chunkContext) -> RepeatStatus.FINISHED, transactionManager)
+        .build();
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/config/RankingBatchProperties.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/config/RankingBatchProperties.java
@@ -1,0 +1,31 @@
+package com.loopers.batch.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "ranking")
+public class RankingBatchProperties {
+
+  private Weight weight = new Weight();
+  private Batch batch = new Batch();
+
+  @Getter
+  @Setter
+  public static class Weight {
+    private double view = 0.1;
+    private double like = 0.3;
+    private double order = 0.6;
+  }
+
+  @Getter
+  @Setter
+  public static class Batch {
+    private int chunkSize = 100;
+    private int limit = 100;
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/metrics/ProductMetrics.java
@@ -26,16 +26,27 @@ public class ProductMetrics {
 
   protected ProductMetrics() {}
 
-  private ProductMetrics(ProductMetricsId id, Long viewCount, Long likeCount, Long salesCount) {
+  private ProductMetrics(
+      ProductMetricsId id, Long viewCount, Long likeCount, Long salesCount, Long updatedAt) {
     this.id = id;
     this.viewCount = viewCount;
     this.likeCount = likeCount;
     this.salesCount = salesCount;
-    this.updatedAt = System.currentTimeMillis();
+    this.updatedAt = updatedAt;
   }
 
-  public static ProductMetrics of(Long refProductId, Integer metricDate, Long viewCount, Long likeCount, Long salesCount) {
-    return new ProductMetrics(ProductMetricsId.of(refProductId, metricDate), viewCount, likeCount, salesCount);
+  public static ProductMetrics of(
+      Long refProductId,
+      Integer metricDate,
+      Long viewCount,
+      Long likeCount,
+      Long salesCount,
+      Long updatedAt) {
+    if (refProductId == null || metricDate == null) {
+      throw new IllegalArgumentException("refProductId, metricDate는 필수입니다");
+    }
+    return new ProductMetrics(
+        ProductMetricsId.of(refProductId, metricDate), viewCount, likeCount, salesCount, updatedAt);
   }
 
   public Long getRefProductId() {

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/metrics/ProductMetrics.java
@@ -1,0 +1,60 @@
+package com.loopers.batch.domain.metrics;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "product_metrics")
+public class ProductMetrics {
+
+  @EmbeddedId
+  private ProductMetricsId id;
+
+  @Column(name = "like_count", nullable = false)
+  private Long likeCount;
+
+  @Column(name = "sales_count", nullable = false)
+  private Long salesCount;
+
+  @Column(name = "view_count", nullable = false)
+  private Long viewCount;
+
+  @Column(name = "updated_at", nullable = false)
+  private Long updatedAt;
+
+  protected ProductMetrics() {}
+
+  private ProductMetrics(ProductMetricsId id, Long viewCount, Long likeCount, Long salesCount) {
+    this.id = id;
+    this.viewCount = viewCount;
+    this.likeCount = likeCount;
+    this.salesCount = salesCount;
+    this.updatedAt = System.currentTimeMillis();
+  }
+
+  public static ProductMetrics of(Long refProductId, Integer metricDate, Long viewCount, Long likeCount, Long salesCount) {
+    return new ProductMetrics(ProductMetricsId.of(refProductId, metricDate), viewCount, likeCount, salesCount);
+  }
+
+  public Long getRefProductId() {
+    return id.getRefProductId();
+  }
+
+  public Integer getMetricDate() {
+    return id.getMetricDate();
+  }
+
+  public Long getLikeCount() {
+    return likeCount;
+  }
+
+  public Long getSalesCount() {
+    return salesCount;
+  }
+
+  public Long getViewCount() {
+    return viewCount;
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/metrics/ProductMetricsId.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/metrics/ProductMetricsId.java
@@ -1,0 +1,48 @@
+package com.loopers.batch.domain.metrics;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class ProductMetricsId implements Serializable {
+
+  @Column(name = "ref_product_id", nullable = false)
+  private Long refProductId;
+
+  @Column(name = "metric_date", nullable = false)
+  private Integer metricDate;
+
+  protected ProductMetricsId() {}
+
+  private ProductMetricsId(Long refProductId, Integer metricDate) {
+    this.refProductId = refProductId;
+    this.metricDate = metricDate;
+  }
+
+  public static ProductMetricsId of(Long refProductId, Integer metricDate) {
+    return new ProductMetricsId(refProductId, metricDate);
+  }
+
+  public Long getRefProductId() {
+    return refProductId;
+  }
+
+  public Integer getMetricDate() {
+    return metricDate;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ProductMetricsId that = (ProductMetricsId) o;
+    return Objects.equals(refProductId, that.refProductId) && Objects.equals(metricDate, that.metricDate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(refProductId, metricDate);
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/MonthlyProductRank.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/MonthlyProductRank.java
@@ -1,0 +1,70 @@
+package com.loopers.batch.domain.ranking;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mv_product_rank_monthly")
+@IdClass(MonthlyProductRankId.class)
+public class MonthlyProductRank implements ProductRankEntity {
+
+  @Id
+  @Column(name = "ref_product_id", nullable = false)
+  private Long refProductId;
+
+  @Id
+  @Column(name = "ranking_year_month", nullable = false)
+  private String yearMonth;
+
+  @Column(name = "score", nullable = false)
+  private Double score;
+
+  @Column(name = "period_start", nullable = false)
+  private LocalDate periodStart;
+
+  @Column(name = "period_end", nullable = false)
+  private LocalDate periodEnd;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  protected MonthlyProductRank() {}
+
+  private MonthlyProductRank(
+      Long refProductId,
+      String yearMonth,
+      Double score,
+      LocalDate periodStart,
+      LocalDate periodEnd,
+      LocalDateTime updatedAt) {
+    this.refProductId = refProductId;
+    this.yearMonth = yearMonth;
+    this.score = score;
+    this.periodStart = periodStart;
+    this.periodEnd = periodEnd;
+    this.updatedAt = updatedAt;
+  }
+
+  public static MonthlyProductRank of(
+      Long refProductId,
+      String yearMonth,
+      Double score,
+      LocalDate periodStart,
+      LocalDate periodEnd,
+      LocalDateTime updatedAt) {
+    return new MonthlyProductRank(refProductId, yearMonth, score, periodStart, periodEnd, updatedAt);
+  }
+
+  public String getYearMonth() {
+    return yearMonth;
+  }
+
+  public Double getScore() {
+    return score;
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/MonthlyProductRankId.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/MonthlyProductRankId.java
@@ -1,0 +1,31 @@
+package com.loopers.batch.domain.ranking;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+// MonthlyProductRank 복합키 (refProductId + yearMonth)
+public class MonthlyProductRankId implements Serializable {
+
+  private Long refProductId;
+  private String yearMonth;
+
+  public MonthlyProductRankId() {}
+
+  public MonthlyProductRankId(Long refProductId, String yearMonth) {
+    this.refProductId = refProductId;
+    this.yearMonth = yearMonth;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MonthlyProductRankId that = (MonthlyProductRankId) o;
+    return Objects.equals(refProductId, that.refProductId) && Objects.equals(yearMonth, that.yearMonth);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(refProductId, yearMonth);
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/ProductRankEntity.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/ProductRankEntity.java
@@ -1,0 +1,4 @@
+package com.loopers.batch.domain.ranking;
+
+// Weekly/Monthly 랭킹 엔티티의 공통 마커 인터페이스
+public interface ProductRankEntity {}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/RankingPeriod.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/RankingPeriod.java
@@ -1,0 +1,32 @@
+package com.loopers.batch.domain.ranking;
+
+import java.util.Arrays;
+
+public enum RankingPeriod {
+  WEEKLY("weekly", "주간 랭킹"),
+  MONTHLY("monthly", "월간 랭킹");
+
+  private final String code;
+  private final String description;
+
+  RankingPeriod(String code, String description) {
+    this.code = code;
+    this.description = description;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public static RankingPeriod fromCode(String code) {
+    return Arrays.stream(values())
+        .filter(period -> period.code.equalsIgnoreCase(code))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "유효하지 않은 period: " + code + ". WEEKLY 또는 MONTHLY만 허용됩니다."));
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/WeeklyProductRank.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/WeeklyProductRank.java
@@ -1,0 +1,70 @@
+package com.loopers.batch.domain.ranking;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mv_product_rank_weekly")
+@IdClass(WeeklyProductRankId.class)
+public class WeeklyProductRank implements ProductRankEntity {
+
+  @Id
+  @Column(name = "ref_product_id", nullable = false)
+  private Long refProductId;
+
+  @Id
+  @Column(name = "ranking_year_week", nullable = false)
+  private String yearWeek;
+
+  @Column(name = "score", nullable = false)
+  private Double score;
+
+  @Column(name = "period_start", nullable = false)
+  private LocalDate periodStart;
+
+  @Column(name = "period_end", nullable = false)
+  private LocalDate periodEnd;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  protected WeeklyProductRank() {}
+
+  private WeeklyProductRank(
+      Long refProductId,
+      String yearWeek,
+      Double score,
+      LocalDate periodStart,
+      LocalDate periodEnd,
+      LocalDateTime updatedAt) {
+    this.refProductId = refProductId;
+    this.yearWeek = yearWeek;
+    this.score = score;
+    this.periodStart = periodStart;
+    this.periodEnd = periodEnd;
+    this.updatedAt = updatedAt;
+  }
+
+  public static WeeklyProductRank of(
+      Long refProductId,
+      String yearWeek,
+      Double score,
+      LocalDate periodStart,
+      LocalDate periodEnd,
+      LocalDateTime updatedAt) {
+    return new WeeklyProductRank(refProductId, yearWeek, score, periodStart, periodEnd, updatedAt);
+  }
+
+  public String getYearWeek() {
+    return yearWeek;
+  }
+
+  public Double getScore() {
+    return score;
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/WeeklyProductRankId.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/WeeklyProductRankId.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 // WeeklyProductRank 복합키 (refProductId + yearWeek)
 public class WeeklyProductRankId implements Serializable {
 
+  private static final long serialVersionUID = 1L;
+
   private Long refProductId;
   private String yearWeek;
 

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/WeeklyProductRankId.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/domain/ranking/WeeklyProductRankId.java
@@ -1,0 +1,31 @@
+package com.loopers.batch.domain.ranking;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+// WeeklyProductRank 복합키 (refProductId + yearWeek)
+public class WeeklyProductRankId implements Serializable {
+
+  private Long refProductId;
+  private String yearWeek;
+
+  public WeeklyProductRankId() {}
+
+  public WeeklyProductRankId(Long refProductId, String yearWeek) {
+    this.refProductId = refProductId;
+    this.yearWeek = yearWeek;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WeeklyProductRankId that = (WeeklyProductRankId) o;
+    return Objects.equals(refProductId, that.refProductId) && Objects.equals(yearWeek, that.yearWeek);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(refProductId, yearWeek);
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/interfaces/BatchJobController.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/interfaces/BatchJobController.java
@@ -1,0 +1,30 @@
+package com.loopers.batch.interfaces;
+
+import com.loopers.batch.application.BatchJobFacade;
+import com.loopers.batch.application.BatchJobFacade.JobExecutionResult;
+import com.loopers.batch.domain.ranking.RankingPeriod;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+//  인증/권한 체크 필요
+@RestController
+@RequestMapping("/api/v1/jobs")
+@RequiredArgsConstructor
+public class BatchJobController {
+
+  private final BatchJobFacade batchJobFacade;
+
+  @PostMapping("/ranking")
+  public ResponseEntity<JobExecutionResult> runRankingAggregation(
+      @RequestParam RankingPeriod period,
+      @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date
+  ) {
+    return ResponseEntity.ok(batchJobFacade.runRankingAggregation(period, date));
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/interfaces/RankingScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/interfaces/RankingScheduler.java
@@ -1,0 +1,37 @@
+package com.loopers.batch.interfaces;
+
+import com.loopers.batch.application.BatchJobFacade;
+import com.loopers.batch.domain.ranking.RankingPeriod;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingScheduler {
+
+  private final BatchJobFacade batchJobFacade;
+
+  /**
+   * 주간 랭킹 집계: 매주 월요일 02:00 실행 (전주 월~일 데이터 집계)
+   */
+  @Scheduled(cron = "0 0 2 * * MON")
+  public void runWeeklyRankingAggregation() {
+    LocalDate lastWeek = LocalDate.now().minusWeeks(1);
+    log.info("주간 랭킹 집계 스케줄 실행: baseDate={}", lastWeek);
+    batchJobFacade.runRankingAggregation(RankingPeriod.WEEKLY, lastWeek);
+  }
+
+  /**
+   * 월간 랭킹 집계: 매월 1일 03:00 실행 (전월 1일~말일 데이터 집계)
+   */
+  @Scheduled(cron = "0 0 3 1 * *")
+  public void runMonthlyRankingAggregation() {
+    LocalDate lastMonth = LocalDate.now().minusMonths(1);
+    log.info("월간 랭킹 집계 스케줄 실행: baseDate={}", lastMonth);
+    batchJobFacade.runRankingAggregation(RankingPeriod.MONTHLY, lastMonth);
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/demo/DemoJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/demo/DemoJobConfig.java
@@ -1,0 +1,48 @@
+package com.loopers.batch.job.demo;
+
+import com.loopers.batch.job.demo.step.DemoTasklet;
+import com.loopers.batch.listener.JobListener;
+import com.loopers.batch.listener.StepMonitorListener;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@ConditionalOnProperty(name = "spring.batch.job.name", havingValue = DemoJobConfig.JOB_NAME)
+@RequiredArgsConstructor
+@Configuration
+public class DemoJobConfig {
+    public static final String JOB_NAME = "demoJob";
+    private static final String STEP_DEMO_SIMPLE_TASK_NAME = "demoSimpleTask";
+
+    private final JobRepository jobRepository;
+    private final JobListener jobListener;
+    private final StepMonitorListener stepMonitorListener;
+    private final DemoTasklet demoTasklet;
+
+    @Bean(JOB_NAME)
+    public Job demoJob() {
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(categorySyncStep())
+                .listener(jobListener)
+                .build();
+    }
+
+    @JobScope
+    @Bean(STEP_DEMO_SIMPLE_TASK_NAME)
+    public Step categorySyncStep() {
+        return new StepBuilder(STEP_DEMO_SIMPLE_TASK_NAME, jobRepository)
+                .tasklet(demoTasklet, new ResourcelessTransactionManager())
+                .listener(stepMonitorListener)
+                .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/demo/step/DemoTasklet.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/demo/step/DemoTasklet.java
@@ -1,0 +1,32 @@
+package com.loopers.batch.job.demo.step;
+
+import com.loopers.batch.job.demo.DemoJobConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@StepScope
+@ConditionalOnProperty(name = "spring.batch.job.name", havingValue = DemoJobConfig.JOB_NAME)
+@RequiredArgsConstructor
+@Component
+public class DemoTasklet implements Tasklet {
+    @Value("#{jobParameters['requestDate']}")
+    private String requestDate;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        if (requestDate == null) {
+            throw new RuntimeException("requestDate is null");
+        }
+        System.out.println("Demo Tasklet 실행 (실행 일자 : " + requestDate + ")");
+        Thread.sleep(1000);
+        System.out.println("Demo Tasklet 작업 완료");
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/AggregatedProductScore.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/AggregatedProductScore.java
@@ -7,6 +7,12 @@ public record AggregatedProductScore(
     Long totalSalesCount
 ) {
 
+  public AggregatedProductScore {
+    totalViewCount = totalViewCount != null ? totalViewCount : 0L;
+    totalLikeCount = totalLikeCount != null ? totalLikeCount : 0L;
+    totalSalesCount = totalSalesCount != null ? totalSalesCount : 0L;
+  }
+
   public double calculateScore(double viewWeight, double likeWeight, double orderWeight) {
     return (totalViewCount * viewWeight) + (totalLikeCount * likeWeight) + (totalSalesCount * orderWeight);
   }

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/AggregatedProductScore.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/AggregatedProductScore.java
@@ -1,0 +1,13 @@
+package com.loopers.batch.job.ranking;
+
+public record AggregatedProductScore(
+    Long refProductId,
+    Long totalViewCount,
+    Long totalLikeCount,
+    Long totalSalesCount
+) {
+
+  public double calculateScore(double viewWeight, double likeWeight, double orderWeight) {
+    return (totalViewCount * viewWeight) + (totalLikeCount * likeWeight) + (totalSalesCount * orderWeight);
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/DateRange.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/DateRange.java
@@ -1,9 +1,31 @@
 package com.loopers.batch.job.ranking;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
 // 집계 기간 (시작일, 종료일 - YYYYMMDD 형식)
 public record DateRange(int startDate, int endDate) {
 
+  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+  public DateRange {
+    validateDateFormat(startDate, "시작일");
+    validateDateFormat(endDate, "종료일");
+    if (startDate > endDate) {
+      throw new IllegalArgumentException("시작일은 종료일보다 클 수 없습니다");
+    }
+  }
+
   public static DateRange of(int startDate, int endDate) {
     return new DateRange(startDate, endDate);
+  }
+
+  private static void validateDateFormat(int date, String fieldName) {
+    try {
+      LocalDate.parse(String.valueOf(date), DATE_FORMAT);
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException(fieldName + "이 유효하지 않은 날짜 형식입니다: " + date);
+    }
   }
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/DateRange.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/DateRange.java
@@ -1,0 +1,9 @@
+package com.loopers.batch.job.ranking;
+
+// 집계 기간 (시작일, 종료일 - YYYYMMDD 형식)
+public record DateRange(int startDate, int endDate) {
+
+  public static DateRange of(int startDate, int endDate) {
+    return new DateRange(startDate, endDate);
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/RankingAggregationJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/RankingAggregationJobConfig.java
@@ -92,19 +92,12 @@ public class RankingAggregationJobConfig {
         FROM ProductMetrics m
         WHERE m.id.metricDate BETWEEN :startDate AND :endDate
         GROUP BY m.id.refProductId
-        ORDER BY
-          (CAST(SUM(m.viewCount) AS double) * :viewWeight
-            + CAST(SUM(m.likeCount) AS double) * :likeWeight
-            + CAST(SUM(m.salesCount) AS double) * :orderWeight) DESC,
-          m.id.refProductId
+        ORDER BY m.id.refProductId
         """;
 
     Map<String, Object> params = new HashMap<>();
     params.put("startDate", dateRange.startDate());
     params.put("endDate", dateRange.endDate());
-    params.put("viewWeight", properties.getWeight().getView());
-    params.put("likeWeight", properties.getWeight().getLike());
-    params.put("orderWeight", properties.getWeight().getOrder());
 
     return new JpaPagingItemReaderBuilder<AggregatedProductScore>()
         .name("aggregatedScoreReader")

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/RankingAggregationJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/RankingAggregationJobConfig.java
@@ -1,0 +1,163 @@
+package com.loopers.batch.job.ranking;
+
+import com.loopers.batch.config.RankingBatchProperties;
+import com.loopers.batch.domain.ranking.MonthlyProductRank;
+import com.loopers.batch.domain.ranking.ProductRankEntity;
+import com.loopers.batch.domain.ranking.RankingPeriod;
+import com.loopers.batch.domain.ranking.WeeklyProductRank;
+import com.loopers.batch.listener.JobListener;
+import com.loopers.infrastructure.ranking.MonthlyProductRankJpaRepository;
+import com.loopers.infrastructure.ranking.WeeklyProductRankJpaRepository;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class RankingAggregationJobConfig {
+
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+  private static final String JOB_NAME = "rankingAggregationJob";
+
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager transactionManager;
+  private final EntityManagerFactory entityManagerFactory;
+  private final RankingBatchProperties properties;
+  private final JobListener jobListener;
+  private final WeeklyProductRankJpaRepository weeklyRepository;
+  private final MonthlyProductRankJpaRepository monthlyRepository;
+
+  @Bean(JOB_NAME)
+  public Job rankingAggregationJob() {
+    return new JobBuilder(JOB_NAME, jobRepository)
+        .listener(jobListener)
+        .start(rankingAggregationStep(null, null))
+        .build();
+  }
+
+  @Bean
+  @JobScope
+  public Step rankingAggregationStep(
+      @Value("#{jobParameters['period']}") String period,
+      @Value("#{jobParameters['baseDate']}") String baseDate) {
+    return new StepBuilder("rankingAggregationStep", jobRepository)
+        .<AggregatedProductScore, ProductRankEntity>chunk(properties.getBatch().getChunkSize(), transactionManager)
+        .reader(aggregatedScoreReader(period, baseDate))
+        .processor(rankingProcessor())
+        .writer(rankingWriter(period))
+        .build();
+  }
+
+  @Bean
+  @StepScope
+  public JpaPagingItemReader<AggregatedProductScore> aggregatedScoreReader(
+      @Value("#{jobParameters['period']}") String period,
+      @Value("#{jobParameters['baseDate']}") String baseDate) {
+
+    LocalDate base = LocalDate.parse(baseDate, DATE_FORMATTER);
+    RankingPeriod rankingPeriod = RankingPeriod.fromCode(period);
+    DateRange dateRange = calculateDateRange(rankingPeriod, base);
+
+    log.info("집계 기간: {} ~ {} (period={})", dateRange.startDate(), dateRange.endDate(), period);
+
+    String jpql = """
+        SELECT new com.loopers.batch.job.ranking.AggregatedProductScore(
+            m.id.refProductId,
+            SUM(m.viewCount),
+            SUM(m.likeCount),
+            SUM(m.salesCount)
+        )
+        FROM ProductMetrics m
+        WHERE m.id.metricDate BETWEEN :startDate AND :endDate
+        GROUP BY m.id.refProductId
+        ORDER BY
+          (CAST(SUM(m.viewCount) AS double) * :viewWeight
+            + CAST(SUM(m.likeCount) AS double) * :likeWeight
+            + CAST(SUM(m.salesCount) AS double) * :orderWeight) DESC,
+          m.id.refProductId
+        """;
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("startDate", dateRange.startDate());
+    params.put("endDate", dateRange.endDate());
+    params.put("viewWeight", properties.getWeight().getView());
+    params.put("likeWeight", properties.getWeight().getLike());
+    params.put("orderWeight", properties.getWeight().getOrder());
+
+    return new JpaPagingItemReaderBuilder<AggregatedProductScore>()
+        .name("aggregatedScoreReader")
+        .entityManagerFactory(entityManagerFactory)
+        .queryString(jpql)
+        .parameterValues(params)
+        .pageSize(properties.getBatch().getChunkSize())
+        .maxItemCount(properties.getBatch().getLimit())
+        .build();
+  }
+
+  @Bean
+  @StepScope
+  public RankingItemProcessor rankingProcessor() {
+    return new RankingItemProcessor(properties);
+  }
+
+  @Bean
+  @StepScope
+  public ItemWriter<ProductRankEntity> rankingWriter(
+      @Value("#{jobParameters['period']}") String period) {
+    RankingPeriod rankingPeriod = RankingPeriod.fromCode(period);
+
+    if (rankingPeriod == RankingPeriod.WEEKLY) {
+      return items -> {
+        List<WeeklyProductRank> ranks = items.getItems().stream()
+            .map(WeeklyProductRank.class::cast)
+            .toList();
+        weeklyRepository.saveAll(ranks);
+        log.debug("주간 점수 {} 건 저장 완료", ranks.size());
+      };
+    }
+    return items -> {
+      List<MonthlyProductRank> ranks = items.getItems().stream()
+          .map(MonthlyProductRank.class::cast)
+          .toList();
+      monthlyRepository.saveAll(ranks);
+      log.debug("월간 점수 {} 건 저장 완료", ranks.size());
+    };
+  }
+
+  private DateRange calculateDateRange(RankingPeriod period, LocalDate base) {
+    if (period == RankingPeriod.WEEKLY) {
+      LocalDate weekStart = base.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+      LocalDate weekEnd = base.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+      return DateRange.of(
+          Integer.parseInt(weekStart.format(DATE_FORMATTER)),
+          Integer.parseInt(weekEnd.format(DATE_FORMATTER)));
+    }
+    LocalDate monthStart = base.withDayOfMonth(1);
+    LocalDate monthEnd = base.with(TemporalAdjusters.lastDayOfMonth());
+    return DateRange.of(
+        Integer.parseInt(monthStart.format(DATE_FORMATTER)),
+        Integer.parseInt(monthEnd.format(DATE_FORMATTER)));
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/RankingItemProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/RankingItemProcessor.java
@@ -38,13 +38,20 @@ public class RankingItemProcessor implements ItemProcessor<AggregatedProductScor
   private LocalDate monthStart;
   private LocalDate monthEnd;
 
+  private LocalDateTime batchStartTime;
+
   @BeforeStep
   public void beforeStep(StepExecution stepExecution) {
     String periodParam = stepExecution.getJobParameters().getString("period");
     String baseDateParam = stepExecution.getJobParameters().getString("baseDate");
 
+    if (periodParam == null || baseDateParam == null) {
+      throw new IllegalArgumentException("period와 baseDate 파라미터는 필수입니다");
+    }
+
     this.period = RankingPeriod.fromCode(periodParam);
     this.baseDate = LocalDate.parse(baseDateParam, DATE_FORMATTER);
+    this.batchStartTime = LocalDateTime.now();
 
     if (period == RankingPeriod.WEEKLY) {
       initWeeklyFields();
@@ -74,11 +81,9 @@ public class RankingItemProcessor implements ItemProcessor<AggregatedProductScor
         properties.getWeight().getLike(),
         properties.getWeight().getOrder());
 
-    LocalDateTime now = LocalDateTime.now();
-
     if (period == RankingPeriod.WEEKLY) {
-      return WeeklyProductRank.of(item.refProductId(), yearWeek, score, weekStart, weekEnd, now);
+      return WeeklyProductRank.of(item.refProductId(), yearWeek, score, weekStart, weekEnd, batchStartTime);
     }
-    return MonthlyProductRank.of(item.refProductId(), yearMonth, score, monthStart, monthEnd, now);
+    return MonthlyProductRank.of(item.refProductId(), yearMonth, score, monthStart, monthEnd, batchStartTime);
   }
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/RankingItemProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/ranking/RankingItemProcessor.java
@@ -1,0 +1,84 @@
+package com.loopers.batch.job.ranking;
+
+import com.loopers.batch.config.RankingBatchProperties;
+import com.loopers.batch.domain.ranking.MonthlyProductRank;
+import com.loopers.batch.domain.ranking.ProductRankEntity;
+import com.loopers.batch.domain.ranking.RankingPeriod;
+import com.loopers.batch.domain.ranking.WeeklyProductRank;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.item.ItemProcessor;
+
+// 점수 계산 + 엔티티 변환
+@RequiredArgsConstructor
+public class RankingItemProcessor implements ItemProcessor<AggregatedProductScore, ProductRankEntity> {
+
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+  private final RankingBatchProperties properties;
+
+  private RankingPeriod period;
+  private LocalDate baseDate;
+
+  // 주간용 필드
+  private String yearWeek;
+  private LocalDate weekStart;
+  private LocalDate weekEnd;
+
+  // 월간용 필드
+  private String yearMonth;
+  private LocalDate monthStart;
+  private LocalDate monthEnd;
+
+  @BeforeStep
+  public void beforeStep(StepExecution stepExecution) {
+    String periodParam = stepExecution.getJobParameters().getString("period");
+    String baseDateParam = stepExecution.getJobParameters().getString("baseDate");
+
+    this.period = RankingPeriod.fromCode(periodParam);
+    this.baseDate = LocalDate.parse(baseDateParam, DATE_FORMATTER);
+
+    if (period == RankingPeriod.WEEKLY) {
+      initWeeklyFields();
+    } else {
+      initMonthlyFields();
+    }
+  }
+
+  private void initWeeklyFields() {
+    WeekFields weekFields = WeekFields.of(Locale.KOREA);
+    int weekBasedYear = baseDate.get(weekFields.weekBasedYear());
+    this.yearWeek = String.format("%d-W%02d", weekBasedYear, baseDate.get(weekFields.weekOfWeekBasedYear()));
+    this.weekStart = baseDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+    this.weekEnd = baseDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+  }
+
+  private void initMonthlyFields() {
+    this.yearMonth = baseDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+    this.monthStart = baseDate.withDayOfMonth(1);
+    this.monthEnd = baseDate.with(TemporalAdjusters.lastDayOfMonth());
+  }
+
+  @Override
+  public ProductRankEntity process(AggregatedProductScore item) {
+    double score = item.calculateScore(
+        properties.getWeight().getView(),
+        properties.getWeight().getLike(),
+        properties.getWeight().getOrder());
+
+    LocalDateTime now = LocalDateTime.now();
+
+    if (period == RankingPeriod.WEEKLY) {
+      return WeeklyProductRank.of(item.refProductId(), yearWeek, score, weekStart, weekEnd, now);
+    }
+    return MonthlyProductRank.of(item.refProductId(), yearMonth, score, monthStart, monthEnd, now);
+  }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/listener/ChunkListener.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/listener/ChunkListener.java
@@ -1,0 +1,21 @@
+package com.loopers.batch.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.annotation.AfterChunk;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ChunkListener {
+
+    @AfterChunk
+    void afterChunk(ChunkContext chunkContext) {
+        log.info(
+            "청크 종료: readCount: ${chunkContext.stepContext.stepExecution.readCount}, " +
+                    "writeCount: ${chunkContext.stepContext.stepExecution.writeCount}"
+        );
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/listener/JobListener.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/listener/JobListener.java
@@ -1,0 +1,53 @@
+package com.loopers.batch.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.annotation.AfterJob;
+import org.springframework.batch.core.annotation.BeforeJob;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JobListener {
+
+    @BeforeJob
+    void beforeJob(JobExecution jobExecution) {
+        log.info("Job '${jobExecution.jobInstance.jobName}' 시작");
+        jobExecution.getExecutionContext().putLong("startTime", System.currentTimeMillis());
+    }
+
+    @AfterJob
+    void afterJob(JobExecution jobExecution) {
+        var startTime = jobExecution.getExecutionContext().getLong("startTime");
+        var endTime = System.currentTimeMillis();
+
+        var startDateTime = Instant.ofEpochMilli(startTime)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime();
+        var endDateTime = Instant.ofEpochMilli(endTime)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime();
+
+        var totalTime = endTime - startTime;
+        var duration = Duration.ofMillis(totalTime);
+        var hours = duration.toHours();
+        var minutes = duration.toMinutes() % 60;
+        var seconds = duration.getSeconds() % 60;
+
+        var message = String.format(
+            """
+                *Start Time:* %s
+                *End Time:* %s
+                *Total Time:* %d시간 %d분 %d초
+            """, startDateTime, endDateTime, hours, minutes, seconds
+        ).trim();
+
+        log.info(message);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/listener/StepMonitorListener.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/listener/StepMonitorListener.java
@@ -1,0 +1,44 @@
+package com.loopers.batch.listener;
+
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.stereotype.Component;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class StepMonitorListener implements StepExecutionListener {
+
+    @Override
+    public void beforeStep(@Nonnull StepExecution stepExecution) {
+        log.info("Step '{}' 시작", stepExecution.getStepName());
+    }
+
+    @Override
+    public ExitStatus afterStep(@Nonnull StepExecution stepExecution) {
+        if (!stepExecution.getFailureExceptions().isEmpty()) {
+            var jobName = stepExecution.getJobExecution().getJobInstance().getJobName();
+            var exceptions = stepExecution.getFailureExceptions().stream()
+                    .map(Throwable::getMessage)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.joining("\n"));
+            log.info(
+                """
+                   [에러 발생]
+                   jobName: {}
+                   exceptions:
+                   {}
+               """.trim(), jobName, exceptions
+            );
+            // error 발생 시 slack 등 다른 채널로 모니터 전송
+            return ExitStatus.FAILED;
+        }
+        return ExitStatus.COMPLETED;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyProductRankJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyProductRankJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.batch.domain.ranking.MonthlyProductRank;
+import com.loopers.batch.domain.ranking.MonthlyProductRankId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthlyProductRankJpaRepository extends JpaRepository<MonthlyProductRank, MonthlyProductRankId> {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyProductRankJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyProductRankJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.batch.domain.ranking.WeeklyProductRank;
+import com.loopers.batch.domain.ranking.WeeklyProductRankId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeeklyProductRankJpaRepository extends JpaRepository<WeeklyProductRank, WeeklyProductRankId> {
+}

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,0 +1,54 @@
+spring:
+  main:
+    web-application-type: none
+  application:
+    name: commerce-batch
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+  batch:
+    job:
+      name: ${job.name:NONE}
+    jdbc:
+      initialize-schema: never
+
+management:
+  health:
+    defaults:
+      enabled: false
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+  batch:
+    jdbc:
+      initialize-schema: always
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,6 +1,9 @@
+server:
+  port: 8082
+
 spring:
   main:
-    web-application-type: none
+    web-application-type: servlet  # 수동 실행 API 제공을 위해 웹 서버 활성화
   application:
     name: commerce-batch
   profiles:
@@ -21,6 +24,15 @@ management:
   health:
     defaults:
       enabled: false
+
+ranking:
+  weight:
+    view: 0.1    # 조회 가중치
+    like: 0.3    # 좋아요 가중치
+    order: 0.6   # 주문 가중치
+  batch:
+    chunk-size: 100  # 청크 사이즈
+    limit: 100       # TOP N 랭킹 개수
 
 ---
 spring:

--- a/apps/commerce-batch/src/test/java/com/loopers/CommerceBatchApplicationTest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/CommerceBatchApplicationTest.java
@@ -1,0 +1,10 @@
+package com.loopers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CommerceBatchApplicationTest {
+    @Test
+    void contextLoads() {}
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/job/demo/DemoJobE2ETest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/job/demo/DemoJobE2ETest.java
@@ -1,0 +1,76 @@
+package com.loopers.job.demo;
+
+import com.loopers.batch.job.demo.DemoJobConfig;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@SpringBatchTest
+@TestPropertySource(properties = "spring.batch.job.name=" + DemoJobConfig.JOB_NAME)
+class DemoJobE2ETest {
+
+    // IDE 정적 분석 상 [SpringBatchTest] 의 주입보다 [SpringBootTest] 의 주입이 우선되어, 해당 컴포넌트는 없으므로 오류처럼 보일 수 있음.
+    // [SpringBatchTest] 자체가 Scope 기반으로 주입하기 때문에 정상 동작함.
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    @Qualifier(DemoJobConfig.JOB_NAME)
+    private Job job;
+
+    @BeforeEach
+    void beforeEach() {
+
+    }
+
+    @DisplayName("jobParameter 중 requestDate 인자가 주어지지 않았을 때, demoJob 배치는 실패한다.")
+    @Test
+    void shouldNotSaveCategories_whenApiError() throws Exception {
+        // arrange
+        jobLauncherTestUtils.setJob(job);
+
+        // act
+        var jobExecution = jobLauncherTestUtils.launchJob();
+
+        // assert
+        assertAll(
+            () -> assertThat(jobExecution).isNotNull(),
+            () -> assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo(ExitStatus.FAILED.getExitCode())
+        );
+    }
+
+    @DisplayName("demoJob 배치가 정상적으로 실행된다.")
+    @Test
+    void success() throws Exception {
+        // arrange
+        jobLauncherTestUtils.setJob(job);
+
+        // act
+        var jobParameters = new JobParametersBuilder()
+            .addLocalDate("requestDate", LocalDate.now())
+            .toJobParameters();
+        var jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+        // assert
+        assertAll(
+                () -> assertThat(jobExecution).isNotNull(),
+                () -> assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo(ExitStatus.COMPLETED.getExitCode())
+        );
+    }
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/job/ranking/ProductMetricsTestRepository.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/job/ranking/ProductMetricsTestRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.job.ranking;
+
+import com.loopers.batch.domain.metrics.ProductMetrics;
+import com.loopers.batch.domain.metrics.ProductMetricsId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMetricsTestRepository extends JpaRepository<ProductMetrics, ProductMetricsId> {
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/job/ranking/RankingAggregationJobE2ETest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/job/ranking/RankingAggregationJobE2ETest.java
@@ -34,6 +34,7 @@ import org.springframework.test.context.jdbc.Sql;
 class RankingAggregationJobE2ETest {
 
   private static final AtomicLong RUN_ID_COUNTER = new AtomicLong(System.currentTimeMillis());
+  private static final Long FIXED_UPDATED_AT = 1704067200000L; // 2024-01-01 00:00:00 UTC
 
   @Autowired
   private JobLauncherTestUtils jobLauncherTestUtils;
@@ -142,9 +143,12 @@ class RankingAggregationJobE2ETest {
               .isEqualTo(ExitStatus.COMPLETED.getExitCode()),
           () -> {
             List<WeeklyProductRank> ranks = weeklyRepository.findAll();
-            assertThat(ranks).hasSize(2);
-            // 상품2가 더 높은 점수 (score = 200*0.1 + 20*0.3 + 10*0.6 = 32)
-            // 상품1 합계 (score = 150*0.1 + 15*0.3 + 7*0.6 = 23.7)
+            // 상품1: (100+50)*0.1 + (10+5)*0.3 + (5+2)*0.6 = 23.7
+            // 상품2: 200*0.1 + 20*0.3 + 10*0.6 = 32.0
+            assertThat(ranks)
+                .hasSize(2)
+                .extracting(WeeklyProductRank::getScore)
+                .containsExactlyInAnyOrder(23.7, 32.0);
           }
       );
     }
@@ -246,7 +250,9 @@ class RankingAggregationJobE2ETest {
     productMetricsRepository.saveAll(List.of(metrics));
   }
 
-  private ProductMetrics metrics(Long productId, Integer metricDate, Long viewCount, Long likeCount, Long salesCount) {
-    return ProductMetrics.of(productId, metricDate, viewCount, likeCount, salesCount);
+  private ProductMetrics metrics(
+      Long productId, Integer metricDate, Long viewCount, Long likeCount, Long salesCount) {
+    return ProductMetrics.of(
+        productId, metricDate, viewCount, likeCount, salesCount, FIXED_UPDATED_AT);
   }
 }

--- a/apps/commerce-batch/src/test/java/com/loopers/job/ranking/RankingAggregationJobE2ETest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/job/ranking/RankingAggregationJobE2ETest.java
@@ -1,0 +1,252 @@
+package com.loopers.job.ranking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.batch.domain.metrics.ProductMetrics;
+import com.loopers.batch.domain.ranking.WeeklyProductRank;
+import com.loopers.batch.domain.ranking.MonthlyProductRank;
+import com.loopers.infrastructure.ranking.WeeklyProductRankJpaRepository;
+import com.loopers.infrastructure.ranking.MonthlyProductRankJpaRepository;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest
+@SpringBatchTest
+@TestPropertySource(properties = "spring.batch.job.name=rankingAggregationJob")
+@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Import(RankingJobTestConfig.class)
+class RankingAggregationJobE2ETest {
+
+  private static final AtomicLong RUN_ID_COUNTER = new AtomicLong(System.currentTimeMillis());
+
+  @Autowired
+  private JobLauncherTestUtils jobLauncherTestUtils;
+
+  @Autowired
+  @Qualifier("rankingAggregationJob")
+  private Job job;
+
+  @Autowired
+  private ProductMetricsTestRepository productMetricsRepository;
+
+  @Autowired
+  private WeeklyProductRankJpaRepository weeklyRepository;
+
+  @Autowired
+  private MonthlyProductRankJpaRepository monthlyRepository;
+
+  @BeforeEach
+  void setUp() {
+    jobLauncherTestUtils.setJob(job);
+  }
+
+  @Nested
+  @DisplayName("파라미터 검증")
+  class ParameterValidation {
+
+    @Test
+    @DisplayName("period 파라미터가 없으면 Job이 실패한다")
+    void shouldFail_whenPeriodMissing() throws Exception {
+      // given
+      var jobParameters = new JobParametersBuilder()
+          .addLong("run.id", RUN_ID_COUNTER.incrementAndGet())
+          .addString("baseDate", "20251224")
+          .toJobParameters();
+
+      // when
+      var jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+      // then
+      assertThat(jobExecution.getExitStatus().getExitCode())
+          .isEqualTo(ExitStatus.FAILED.getExitCode());
+    }
+
+    @Test
+    @DisplayName("baseDate 파라미터가 없으면 Job이 실패한다")
+    void shouldFail_whenBaseDateMissing() throws Exception {
+      // given
+      var jobParameters = new JobParametersBuilder()
+          .addLong("run.id", RUN_ID_COUNTER.incrementAndGet())
+          .addString("period", "weekly")
+          .toJobParameters();
+
+      // when
+      var jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+      // then
+      assertThat(jobExecution.getExitStatus().getExitCode())
+          .isEqualTo(ExitStatus.FAILED.getExitCode());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 period 값이면 Job이 실패한다")
+    void shouldFail_whenInvalidPeriod() throws Exception {
+      // given
+      var jobParameters = new JobParametersBuilder()
+          .addLong("run.id", RUN_ID_COUNTER.incrementAndGet())
+          .addString("period", "daily")
+          .addString("baseDate", "20251224")
+          .toJobParameters();
+
+      // when
+      var jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+      // then
+      assertThat(jobExecution.getExitStatus().getExitCode())
+          .isEqualTo(ExitStatus.FAILED.getExitCode());
+    }
+  }
+
+  @Nested
+  @DisplayName("주간 랭킹 집계")
+  class WeeklyAggregation {
+
+    @Test
+    @DisplayName("주간 메트릭을 집계하여 MV 테이블에 저장한다")
+    void shouldAggregateWeeklyMetrics() throws Exception {
+      // given: 2025-12-22 (월) ~ 2025-12-28 (일) 주간 데이터
+      saveAllMetrics(
+          metrics(1L, 20251222, 100L, 10L, 5L),  // 월
+          metrics(1L, 20251223, 50L, 5L, 2L),    // 화
+          metrics(2L, 20251222, 200L, 20L, 10L)  // 상품2가 더 높은 점수
+      );
+
+      var jobParameters = new JobParametersBuilder()
+          .addLong("run.id", RUN_ID_COUNTER.incrementAndGet())
+          .addString("period", "weekly")
+          .addString("baseDate", "20251224")  // 수요일 기준
+          .toJobParameters();
+
+      // when
+      var jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+      // then
+      assertAll(
+          () -> assertThat(jobExecution.getExitStatus().getExitCode())
+              .isEqualTo(ExitStatus.COMPLETED.getExitCode()),
+          () -> {
+            List<WeeklyProductRank> ranks = weeklyRepository.findAll();
+            assertThat(ranks).hasSize(2);
+            // 상품2가 더 높은 점수 (score = 200*0.1 + 20*0.3 + 10*0.6 = 32)
+            // 상품1 합계 (score = 150*0.1 + 15*0.3 + 7*0.6 = 23.7)
+          }
+      );
+    }
+
+    @Test
+    @DisplayName("연도 경계: 2024-12-30은 2025-W01에 속한다")
+    void shouldHandleYearBoundary_weekBelongsToNextYear() throws Exception {
+      // given: 2024-12-30 (월) ~ 2025-01-05 (일) = 2025-W01
+      saveAllMetrics(
+          metrics(1L, 20241230, 100L, 10L, 5L),
+          metrics(1L, 20250101, 50L, 5L, 2L)
+      );
+
+      var jobParameters = new JobParametersBuilder()
+          .addLong("run.id", RUN_ID_COUNTER.incrementAndGet())
+          .addString("period", "weekly")
+          .addString("baseDate", "20241231")  // 2024년 마지막 날이지만 2025-W01
+          .toJobParameters();
+
+      // when
+      var jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+      // then
+      assertAll(
+          () -> assertThat(jobExecution.getExitStatus().getExitCode())
+              .isEqualTo(ExitStatus.COMPLETED.getExitCode()),
+          () -> {
+            List<WeeklyProductRank> ranks = weeklyRepository.findAll();
+            assertThat(ranks).isNotEmpty();
+            assertThat(ranks.get(0).getYearWeek()).isEqualTo("2025-W01");
+          }
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("월간 랭킹 집계")
+  class MonthlyAggregation {
+
+    @Test
+    @DisplayName("월간 메트릭을 집계하여 MV 테이블에 저장한다")
+    void shouldAggregateMonthlyMetrics() throws Exception {
+      // given: 2025년 12월 전체 데이터
+      saveAllMetrics(
+          metrics(1L, 20251201, 100L, 10L, 5L),
+          metrics(1L, 20251215, 100L, 10L, 5L),
+          metrics(1L, 20251231, 100L, 10L, 5L)
+      );
+
+      var jobParameters = new JobParametersBuilder()
+          .addLong("run.id", RUN_ID_COUNTER.incrementAndGet())
+          .addString("period", "monthly")
+          .addString("baseDate", "20251215")
+          .toJobParameters();
+
+      // when
+      var jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+      // then
+      assertAll(
+          () -> assertThat(jobExecution.getExitStatus().getExitCode())
+              .isEqualTo(ExitStatus.COMPLETED.getExitCode()),
+          () -> {
+            List<MonthlyProductRank> ranks = monthlyRepository.findAll();
+            assertThat(ranks).hasSize(1);
+            assertThat(ranks.get(0).getYearMonth()).isEqualTo("2025-12");
+          }
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("점수 계산 검증")
+  class ScoreCalculation {
+
+    @Test
+    @DisplayName("메트릭 가중치에 따라 점수가 계산된다")
+    void shouldCalculateScore_withConfiguredWeights() throws Exception {
+      // given: score = view*viewWeight + like*likeWeight + sales*orderWeight
+      saveAllMetrics(metrics(1L, 20251222, 100L, 10L, 5L));
+
+      var jobParameters = new JobParametersBuilder()
+          .addLong("run.id", RUN_ID_COUNTER.incrementAndGet())
+          .addString("period", "weekly")
+          .addString("baseDate", "20251224")
+          .toJobParameters();
+
+      // when
+      var jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+      // then
+      List<WeeklyProductRank> ranks = weeklyRepository.findAll();
+      assertThat(ranks).hasSize(1);
+      assertThat(ranks.get(0).getScore()).isEqualTo(16.0);
+    }
+  }
+
+  private void saveAllMetrics(ProductMetrics... metrics) {
+    productMetricsRepository.saveAll(List.of(metrics));
+  }
+
+  private ProductMetrics metrics(Long productId, Integer metricDate, Long viewCount, Long likeCount, Long salesCount) {
+    return ProductMetrics.of(productId, metricDate, viewCount, likeCount, salesCount);
+  }
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/job/ranking/RankingJobTestConfig.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/job/ranking/RankingJobTestConfig.java
@@ -1,0 +1,9 @@
+package com.loopers.job.ranking;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@TestConfiguration
+@EnableJpaRepositories(basePackageClasses = ProductMetricsTestRepository.class)
+public class RankingJobTestConfig {
+}

--- a/apps/commerce-batch/src/test/resources/sql/cleanup.sql
+++ b/apps/commerce-batch/src/test/resources/sql/cleanup.sql
@@ -1,0 +1,3 @@
+DELETE FROM mv_product_rank_weekly;
+DELETE FROM mv_product_rank_monthly;
+DELETE FROM product_metrics;

--- a/apps/commerce-batch/src/test/resources/sql/cleanup.sql
+++ b/apps/commerce-batch/src/test/resources/sql/cleanup.sql
@@ -1,3 +1,3 @@
-DELETE FROM mv_product_rank_weekly;
-DELETE FROM mv_product_rank_monthly;
-DELETE FROM product_metrics;
+TRUNCATE TABLE mv_product_rank_weekly;
+TRUNCATE TABLE mv_product_rank_monthly;
+TRUNCATE TABLE product_metrics;

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/strategy/ProductLikedStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/strategy/ProductLikedStrategy.java
@@ -2,7 +2,9 @@ package com.loopers.application.strategy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.loopers.domain.event.EventType;
+import com.loopers.domain.metrics.MetricDateConverter;
 import com.loopers.domain.metrics.ProductMetricsRepository;
+import com.loopers.infrastructure.ranking.RankingRedisProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class ProductLikedStrategy implements CatalogEventStrategy {
 
   private final ProductMetricsRepository productMetricsRepository;
+  private final RankingRedisProperties rankingProperties;
 
   @Override
   public boolean supports(String eventType) {
@@ -21,7 +24,8 @@ public class ProductLikedStrategy implements CatalogEventStrategy {
 
   @Override
   public void handle(Long productId, Long occurredAt, JsonNode payload) {
-    productMetricsRepository.upsertLikeCount(productId, 1, occurredAt);
-    log.debug("상품 {} 좋아요 수 증가", productId);
+    Integer metricDate = MetricDateConverter.toMetricDate(occurredAt, rankingProperties.getTimezone());
+    productMetricsRepository.upsertLikeCount(productId, metricDate, 1, occurredAt);
+    log.debug("상품 {} 좋아요 수 증가 (날짜: {})", productId, metricDate);
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/strategy/ProductSoldStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/strategy/ProductSoldStrategy.java
@@ -2,7 +2,9 @@ package com.loopers.application.strategy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.loopers.domain.event.EventType;
+import com.loopers.domain.metrics.MetricDateConverter;
 import com.loopers.domain.metrics.ProductMetricsRepository;
+import com.loopers.infrastructure.ranking.RankingRedisProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class ProductSoldStrategy implements CatalogEventStrategy {
 
   private final ProductMetricsRepository productMetricsRepository;
+  private final RankingRedisProperties rankingProperties;
 
   @Override
   public boolean supports(String eventType) {
@@ -22,8 +25,9 @@ public class ProductSoldStrategy implements CatalogEventStrategy {
   @Override
   public void handle(Long productId, Long occurredAt, JsonNode payload) {
     int quantity = extractQuantity(payload, productId);
-    productMetricsRepository.upsertSalesCount(productId, quantity, occurredAt);
-    log.debug("상품 {} 판매 수량 {} 증가", productId, quantity);
+    Integer metricDate = MetricDateConverter.toMetricDate(occurredAt, rankingProperties.getTimezone());
+    productMetricsRepository.upsertSalesCount(productId, metricDate, quantity, occurredAt);
+    log.debug("상품 {} 판매 수량 {} 증가 (날짜: {})", productId, quantity, metricDate);
   }
 
   private int extractQuantity(JsonNode payload, Long productId) {

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/strategy/ProductUnlikedStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/strategy/ProductUnlikedStrategy.java
@@ -2,7 +2,9 @@ package com.loopers.application.strategy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.loopers.domain.event.EventType;
+import com.loopers.domain.metrics.MetricDateConverter;
 import com.loopers.domain.metrics.ProductMetricsRepository;
+import com.loopers.infrastructure.ranking.RankingRedisProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class ProductUnlikedStrategy implements CatalogEventStrategy {
 
   private final ProductMetricsRepository productMetricsRepository;
+  private final RankingRedisProperties rankingProperties;
 
   @Override
   public boolean supports(String eventType) {
@@ -21,7 +24,8 @@ public class ProductUnlikedStrategy implements CatalogEventStrategy {
 
   @Override
   public void handle(Long productId, Long occurredAt, JsonNode payload) {
-    productMetricsRepository.upsertLikeCount(productId, -1, occurredAt);
-    log.debug("상품 {} 좋아요 수 감소", productId);
+    Integer metricDate = MetricDateConverter.toMetricDate(occurredAt, rankingProperties.getTimezone());
+    productMetricsRepository.upsertLikeCount(productId, metricDate, -1, occurredAt);
+    log.debug("상품 {} 좋아요 수 감소 (날짜: {})", productId, metricDate);
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/strategy/ProductViewedStrategy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/strategy/ProductViewedStrategy.java
@@ -2,7 +2,9 @@ package com.loopers.application.strategy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.loopers.domain.event.EventType;
+import com.loopers.domain.metrics.MetricDateConverter;
 import com.loopers.domain.metrics.ProductMetricsRepository;
+import com.loopers.infrastructure.ranking.RankingRedisProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class ProductViewedStrategy implements CatalogEventStrategy {
 
   private final ProductMetricsRepository productMetricsRepository;
+  private final RankingRedisProperties rankingProperties;
 
   @Override
   public boolean supports(String eventType) {
@@ -21,7 +24,8 @@ public class ProductViewedStrategy implements CatalogEventStrategy {
 
   @Override
   public void handle(Long productId, Long occurredAt, JsonNode payload) {
-    productMetricsRepository.upsertViewCount(productId, 1, occurredAt);
-    log.debug("상품 {} 조회 수 증가", productId);
+    Integer metricDate = MetricDateConverter.toMetricDate(occurredAt, rankingProperties.getTimezone());
+    productMetricsRepository.upsertViewCount(productId, metricDate, 1, occurredAt);
+    log.debug("상품 {} 조회 수 증가 (날짜: {})", productId, metricDate);
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricDateConverter.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/MetricDateConverter.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.metrics;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public final class MetricDateConverter {
+
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+  private MetricDateConverter() {}
+
+  public static Integer toMetricDate(Long epochMillis, ZoneId zoneId) {
+    if (epochMillis == null) {
+      throw new IllegalArgumentException("epochMillis는 null일 수 없습니다");
+    }
+    String dateStr = Instant.ofEpochMilli(epochMillis)
+        .atZone(zoneId)
+        .toLocalDate()
+        .format(DATE_FORMATTER);
+    return Integer.parseInt(dateStr);
+  }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -36,6 +36,9 @@ public class ProductMetrics {
   }
 
   public static ProductMetrics createWithLike(Long productId, Integer metricDate, int delta, Long occurredAt) {
+    if (productId == null || metricDate == null || occurredAt == null) {
+      throw new IllegalArgumentException("productId, metricDate, occurredAt은 필수입니다");
+    }
     long initialLikeCount = Math.max(delta, 0);
     return new ProductMetrics(ProductMetricsId.of(productId, metricDate), initialLikeCount, 0L, 0L, occurredAt);
   }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -1,17 +1,16 @@
 package com.loopers.domain.metrics;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "product_metrics")
 public class ProductMetrics {
 
-  @Id
-  @Column(name = "ref_product_id", nullable = false)
-  private Long refProductId;
+  @EmbeddedId
+  private ProductMetricsId id;
 
   @Column(name = "like_count", nullable = false)
   private Long likeCount;
@@ -28,21 +27,29 @@ public class ProductMetrics {
   protected ProductMetrics() {}
 
   private ProductMetrics(
-      Long refProductId, Long likeCount, Long salesCount, Long viewCount, Long updatedAt) {
-    this.refProductId = refProductId;
+      ProductMetricsId id, Long likeCount, Long salesCount, Long viewCount, Long updatedAt) {
+    this.id = id;
     this.likeCount = likeCount;
     this.salesCount = salesCount;
     this.viewCount = viewCount;
     this.updatedAt = updatedAt;
   }
 
-  public static ProductMetrics createWithLike(Long productId, int delta, Long occurredAt) {
+  public static ProductMetrics createWithLike(Long productId, Integer metricDate, int delta, Long occurredAt) {
     long initialLikeCount = Math.max(delta, 0);
-    return new ProductMetrics(productId, initialLikeCount, 0L, 0L, occurredAt);
+    return new ProductMetrics(ProductMetricsId.of(productId, metricDate), initialLikeCount, 0L, 0L, occurredAt);
+  }
+
+  public ProductMetricsId getId() {
+    return id;
   }
 
   public Long getRefProductId() {
-    return refProductId;
+    return id.getRefProductId();
+  }
+
+  public Integer getMetricDate() {
+    return id.getMetricDate();
   }
 
   public Long getLikeCount() {
@@ -59,21 +66,5 @@ public class ProductMetrics {
 
   public Long getUpdatedAt() {
     return updatedAt;
-  }
-
-  public void incrementLikeCount(Long occurredAt) {
-    this.likeCount++;
-    updateTimestamp(occurredAt);
-  }
-
-  public void decrementLikeCount(Long occurredAt) {
-    this.likeCount = Math.max(this.likeCount - 1, 0);
-    updateTimestamp(occurredAt);
-  }
-
-  private void updateTimestamp(Long occurredAt) {
-    if (occurredAt != null && (this.updatedAt == null || occurredAt > this.updatedAt)) {
-      this.updatedAt = occurredAt;
-    }
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsId.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsId.java
@@ -1,0 +1,48 @@
+package com.loopers.domain.metrics;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class ProductMetricsId implements Serializable {
+
+  @Column(name = "ref_product_id", nullable = false)
+  private Long refProductId;
+
+  @Column(name = "metric_date", nullable = false)
+  private Integer metricDate;
+
+  protected ProductMetricsId() {}
+
+  private ProductMetricsId(Long refProductId, Integer metricDate) {
+    this.refProductId = refProductId;
+    this.metricDate = metricDate;
+  }
+
+  public static ProductMetricsId of(Long refProductId, Integer metricDate) {
+    return new ProductMetricsId(refProductId, metricDate);
+  }
+
+  public Long getRefProductId() {
+    return refProductId;
+  }
+
+  public Integer getMetricDate() {
+    return metricDate;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ProductMetricsId that = (ProductMetricsId) o;
+    return Objects.equals(refProductId, that.refProductId) && Objects.equals(metricDate, that.metricDate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(refProductId, metricDate);
+  }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
@@ -2,9 +2,9 @@ package com.loopers.domain.metrics;
 
 public interface ProductMetricsRepository {
 
-  void upsertLikeCount(Long productId, int delta, Long occurredAt);
+  void upsertLikeCount(Long productId, Integer metricDate, int delta, Long occurredAt);
 
-  void upsertSalesCount(Long productId, int quantity, Long occurredAt);
+  void upsertSalesCount(Long productId, Integer metricDate, int quantity, Long occurredAt);
 
-  void upsertViewCount(Long productId, int count, Long occurredAt);
+  void upsertViewCount(Long productId, Integer metricDate, int count, Long occurredAt);
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -1,19 +1,20 @@
 package com.loopers.infrastructure.metrics;
 
 import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
+public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, ProductMetricsId> {
 
-  @Modifying
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(
       value =
           """
-          INSERT INTO product_metrics (ref_product_id, like_count, sales_count, view_count, updated_at)
-          VALUES (:productId, GREATEST(:delta, 0), 0, 0, :occurredAt)
+          INSERT INTO product_metrics (ref_product_id, metric_date, like_count, sales_count, view_count, updated_at)
+          VALUES (:productId, :metricDate, GREATEST(:delta, 0), 0, 0, :occurredAt)
           ON DUPLICATE KEY UPDATE
             like_count = GREATEST(like_count + :delta, 0),
             updated_at = GREATEST(updated_at, :occurredAt)
@@ -21,15 +22,16 @@ public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetric
       nativeQuery = true)
   void upsertLikeCount(
       @Param("productId") Long productId,
+      @Param("metricDate") Integer metricDate,
       @Param("delta") int delta,
       @Param("occurredAt") Long occurredAt);
 
-  @Modifying
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(
       value =
           """
-          INSERT INTO product_metrics (ref_product_id, like_count, sales_count, view_count, updated_at)
-          VALUES (:productId, 0, :quantity, 0, :occurredAt)
+          INSERT INTO product_metrics (ref_product_id, metric_date, like_count, sales_count, view_count, updated_at)
+          VALUES (:productId, :metricDate, 0, :quantity, 0, :occurredAt)
           ON DUPLICATE KEY UPDATE
             sales_count = sales_count + :quantity,
             updated_at = GREATEST(updated_at, :occurredAt)
@@ -37,15 +39,16 @@ public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetric
       nativeQuery = true)
   void upsertSalesCount(
       @Param("productId") Long productId,
+      @Param("metricDate") Integer metricDate,
       @Param("quantity") int quantity,
       @Param("occurredAt") Long occurredAt);
 
-  @Modifying
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(
       value =
           """
-          INSERT INTO product_metrics (ref_product_id, like_count, sales_count, view_count, updated_at)
-          VALUES (:productId, 0, 0, :count, :occurredAt)
+          INSERT INTO product_metrics (ref_product_id, metric_date, like_count, sales_count, view_count, updated_at)
+          VALUES (:productId, :metricDate, 0, 0, :count, :occurredAt)
           ON DUPLICATE KEY UPDATE
             view_count = view_count + :count,
             updated_at = GREATEST(updated_at, :occurredAt)
@@ -53,6 +56,7 @@ public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetric
       nativeQuery = true)
   void upsertViewCount(
       @Param("productId") Long productId,
+      @Param("metricDate") Integer metricDate,
       @Param("count") int count,
       @Param("occurredAt") Long occurredAt);
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -11,17 +11,17 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
   private final ProductMetricsJpaRepository jpaRepository;
 
   @Override
-  public void upsertLikeCount(Long productId, int delta, Long occurredAt) {
-    jpaRepository.upsertLikeCount(productId, delta, occurredAt);
+  public void upsertLikeCount(Long productId, Integer metricDate, int delta, Long occurredAt) {
+    jpaRepository.upsertLikeCount(productId, metricDate, delta, occurredAt);
   }
 
   @Override
-  public void upsertSalesCount(Long productId, int quantity, Long occurredAt) {
-    jpaRepository.upsertSalesCount(productId, quantity, occurredAt);
+  public void upsertSalesCount(Long productId, Integer metricDate, int quantity, Long occurredAt) {
+    jpaRepository.upsertSalesCount(productId, metricDate, quantity, occurredAt);
   }
 
   @Override
-  public void upsertViewCount(Long productId, int count, Long occurredAt) {
-    jpaRepository.upsertViewCount(productId, count, occurredAt);
+  public void upsertViewCount(Long productId, Integer metricDate, int count, Long occurredAt) {
+    jpaRepository.upsertViewCount(productId, metricDate, count, occurredAt);
   }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -12,16 +12,25 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
 
   @Override
   public void upsertLikeCount(Long productId, Integer metricDate, int delta, Long occurredAt) {
+    validateParams(productId, metricDate, occurredAt);
     jpaRepository.upsertLikeCount(productId, metricDate, delta, occurredAt);
   }
 
   @Override
   public void upsertSalesCount(Long productId, Integer metricDate, int quantity, Long occurredAt) {
+    validateParams(productId, metricDate, occurredAt);
     jpaRepository.upsertSalesCount(productId, metricDate, quantity, occurredAt);
   }
 
   @Override
   public void upsertViewCount(Long productId, Integer metricDate, int count, Long occurredAt) {
+    validateParams(productId, metricDate, occurredAt);
     jpaRepository.upsertViewCount(productId, metricDate, count, occurredAt);
+  }
+
+  private void validateParams(Long productId, Integer metricDate, Long occurredAt) {
+    if (productId == null || metricDate == null || occurredAt == null) {
+      throw new IllegalArgumentException("productId, metricDate, occurredAt은 필수입니다");
+    }
   }
 }

--- a/apps/commerce-streamer/src/test/java/com/loopers/application/strategy/ProductMetricsIntegrationTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/application/strategy/ProductMetricsIntegrationTest.java
@@ -22,6 +22,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 @DisplayName("ProductMetrics 집계 통합 테스트")
 class ProductMetricsIntegrationTest extends IntegrationTestSupport {
 
+  private static final long FIXED_TIME = 1704067200000L; // 2024-01-01 00:00:00 UTC
+
   @Autowired
   private CatalogEventHandler catalogEventHandler;
 
@@ -44,7 +46,7 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
       Long productId = 100L;
       int quantity = 3;
       String eventId = UUID.randomUUID().toString();
-      long occurredAt = System.currentTimeMillis();
+      long occurredAt = FIXED_TIME;
       JsonNode payload = objectMapper.readTree("{\"quantity\":" + quantity + ",\"orderId\":1}");
 
       catalogEventHandler.handle(
@@ -59,23 +61,22 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
     @DisplayName("동일 상품에 여러 번 판매 이벤트 발생 시 sales_count가 누적된다")
     void shouldAccumulateSalesCount_whenMultipleProductSoldEvents() throws Exception {
       Long productId = 101L;
-      long now = System.currentTimeMillis();
 
       catalogEventHandler.handle(
           UUID.randomUUID().toString(),
           EventType.PRODUCT_SOLD.getCode(),
           String.valueOf(productId),
-          now,
+          FIXED_TIME,
           objectMapper.readTree("{\"quantity\":2,\"orderId\":1}"));
 
       catalogEventHandler.handle(
           UUID.randomUUID().toString(),
           EventType.PRODUCT_SOLD.getCode(),
           String.valueOf(productId),
-          now + 1,
+          FIXED_TIME + 1,
           objectMapper.readTree("{\"quantity\":5,\"orderId\":2}"));
 
-      Integer metricDate = MetricDateConverter.toMetricDate(now, rankingProperties.getTimezone());
+      Integer metricDate = MetricDateConverter.toMetricDate(FIXED_TIME, rankingProperties.getTimezone());
       ProductMetrics metrics = productMetricsJpaRepository.findById(ProductMetricsId.of(productId, metricDate)).orElseThrow();
       assertThat(metrics.getSalesCount()).isEqualTo(7);
     }

--- a/apps/commerce-streamer/src/test/java/com/loopers/application/strategy/ProductMetricsIntegrationTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/application/strategy/ProductMetricsIntegrationTest.java
@@ -6,9 +6,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.application.CatalogEventHandler;
+import com.loopers.domain.metrics.MetricDateConverter;
 import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsId;
 import com.loopers.infrastructure.metrics.ProductMetricsJpaRepository;
 import com.loopers.domain.event.EventType;
+import com.loopers.infrastructure.ranking.RankingRedisProperties;
 import com.loopers.support.test.IntegrationTestSupport;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +31,9 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
   @Autowired
   private ObjectMapper objectMapper;
 
+  @Autowired
+  private RankingRedisProperties rankingProperties;
+
   @Nested
   @DisplayName("sales_count 집계")
   class SalesCountAggregation {
@@ -38,12 +44,14 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
       Long productId = 100L;
       int quantity = 3;
       String eventId = UUID.randomUUID().toString();
+      long occurredAt = System.currentTimeMillis();
       JsonNode payload = objectMapper.readTree("{\"quantity\":" + quantity + ",\"orderId\":1}");
 
       catalogEventHandler.handle(
-          eventId, EventType.PRODUCT_SOLD.getCode(), String.valueOf(productId), System.currentTimeMillis(), payload);
+          eventId, EventType.PRODUCT_SOLD.getCode(), String.valueOf(productId), occurredAt, payload);
 
-      ProductMetrics metrics = productMetricsJpaRepository.findById(productId).orElseThrow();
+      Integer metricDate = MetricDateConverter.toMetricDate(occurredAt, rankingProperties.getTimezone());
+      ProductMetrics metrics = productMetricsJpaRepository.findById(ProductMetricsId.of(productId, metricDate)).orElseThrow();
       assertThat(metrics.getSalesCount()).isEqualTo(quantity);
     }
 
@@ -67,7 +75,8 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
           now + 1,
           objectMapper.readTree("{\"quantity\":5,\"orderId\":2}"));
 
-      ProductMetrics metrics = productMetricsJpaRepository.findById(productId).orElseThrow();
+      Integer metricDate = MetricDateConverter.toMetricDate(now, rankingProperties.getTimezone());
+      ProductMetrics metrics = productMetricsJpaRepository.findById(ProductMetricsId.of(productId, metricDate)).orElseThrow();
       assertThat(metrics.getSalesCount()).isEqualTo(7);
     }
 
@@ -100,16 +109,18 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
     void shouldIncreaseLikeCount_whenProductLikedEventReceived() throws Exception {
       Long productId = 200L;
       String eventId = UUID.randomUUID().toString();
+      long occurredAt = System.currentTimeMillis();
       JsonNode emptyPayload = objectMapper.readTree("{}");
 
       catalogEventHandler.handle(
           eventId,
           EventType.PRODUCT_LIKED.getCode(),
           String.valueOf(productId),
-          System.currentTimeMillis(),
+          occurredAt,
           emptyPayload);
 
-      ProductMetrics metrics = productMetricsJpaRepository.findById(productId).orElseThrow();
+      Integer metricDate = MetricDateConverter.toMetricDate(occurredAt, rankingProperties.getTimezone());
+      ProductMetrics metrics = productMetricsJpaRepository.findById(ProductMetricsId.of(productId, metricDate)).orElseThrow();
       assertThat(metrics.getLikeCount()).isEqualTo(1);
     }
 
@@ -142,7 +153,8 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
           now + 2,
           emptyPayload);
 
-      ProductMetrics metrics = productMetricsJpaRepository.findById(productId).orElseThrow();
+      Integer metricDate = MetricDateConverter.toMetricDate(now, rankingProperties.getTimezone());
+      ProductMetrics metrics = productMetricsJpaRepository.findById(ProductMetricsId.of(productId, metricDate)).orElseThrow();
       assertThat(metrics.getLikeCount()).isEqualTo(1);
     }
 
@@ -150,6 +162,7 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
     @DisplayName("like_count는 0 미만으로 내려가지 않는다")
     void shouldNotGoBelowZero_whenUnlikedMoreThanLiked() throws Exception {
       Long productId = 202L;
+      long occurredAt = System.currentTimeMillis();
       JsonNode emptyPayload = objectMapper.readTree("{}");
 
       // 좋아요 없이 취소 시도
@@ -157,10 +170,11 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
           UUID.randomUUID().toString(),
           EventType.PRODUCT_UNLIKED.getCode(),
           String.valueOf(productId),
-          System.currentTimeMillis(),
+          occurredAt,
           emptyPayload);
 
-      ProductMetrics metrics = productMetricsJpaRepository.findById(productId).orElseThrow();
+      Integer metricDate = MetricDateConverter.toMetricDate(occurredAt, rankingProperties.getTimezone());
+      ProductMetrics metrics = productMetricsJpaRepository.findById(ProductMetricsId.of(productId, metricDate)).orElseThrow();
       assertThat(metrics.getLikeCount()).isZero();
     }
   }
@@ -174,16 +188,18 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
     void shouldIncreaseViewCount_whenProductViewedEventReceived() throws Exception {
       Long productId = 300L;
       String eventId = UUID.randomUUID().toString();
+      long occurredAt = System.currentTimeMillis();
       JsonNode emptyPayload = objectMapper.readTree("{}");
 
       catalogEventHandler.handle(
           eventId,
           EventType.PRODUCT_VIEWED.getCode(),
           String.valueOf(productId),
-          System.currentTimeMillis(),
+          occurredAt,
           emptyPayload);
 
-      ProductMetrics metrics = productMetricsJpaRepository.findById(productId).orElseThrow();
+      Integer metricDate = MetricDateConverter.toMetricDate(occurredAt, rankingProperties.getTimezone());
+      ProductMetrics metrics = productMetricsJpaRepository.findById(ProductMetricsId.of(productId, metricDate)).orElseThrow();
       assertThat(metrics.getViewCount()).isEqualTo(1);
     }
 
@@ -215,7 +231,8 @@ class ProductMetricsIntegrationTest extends IntegrationTestSupport {
           now + 2,
           emptyPayload);
 
-      ProductMetrics metrics = productMetricsJpaRepository.findById(productId).orElseThrow();
+      Integer metricDate = MetricDateConverter.toMetricDate(now, rankingProperties.getTimezone());
+      ProductMetrics metrics = productMetricsJpaRepository.findById(ProductMetricsId.of(productId, metricDate)).orElseThrow();
       assertThat(metrics.getViewCount()).isEqualTo(3);
     }
   }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     ":apps:commerce-api",
     ":apps:commerce-streamer",
     ":apps:pg-simulator",
+    ":apps:commerce-batch",
     ":modules:jpa",
     ":modules:redis",
     ":modules:kafka",


### PR DESCRIPTION
# Round 10 - Spring Batch 기반 주간/월간 랭킹 시스템 구축

## Summary

10주차 Spring-Batch와 MV로 주간/월간 기능을 구현하였습니다.
- Spring Batch Job으로 `product_metrics` 일간 데이터를 집계하여 주간/월간 상품별 점수 저장
- Materialized View 테이블(`mv_product_rank_weekly`, `mv_product_rank_monthly`)에 집계 결과 저장
- 랭킹 API 확장: 일간(Redis ZSet), 주간/월간(MV 테이블) 데이터 소스 분리
- Chunk Oriented Processing (Reader/Processor/Writer) 패턴으로 대량 데이터 배치 처리

| 항목 | 내용 |
|------|------|
| **핵심 변경** | Spring Batch 기반 주간/월간 랭킹 집계 시스템 |
| **아키텍처** | commerce-batch 모듈 신규 추가, MV 테이블 설계 |
| **주요 기술** | Spring Batch, JpaPagingItemReader, Chunk Processing |

---

## Checklist

### Spring Batch
- [x] **Spring Batch Job을 작성하고, 파라미터 기반으로 동작시킬 수 있다.**
    - `RankingAggregationJobConfig`에서 `period`, `baseDate` 파라미터로 Job 실행

- [x] **Chunk Oriented Processing 기반의 배치 처리를 구현했다.**
    - Reader: `JpaPagingItemReader` (GROUP BY + SUM 집계 쿼리)
    - Processor: `RankingItemProcessor` (가중치 적용 점수 계산)
    - Writer: `saveAll()` 배치 저장

- [x] **집계 결과를 저장할 Materialized View의 구조를 설계하고 올바르게 적재했다.**
    - `mv_product_rank_weekly` (ref_product_id, score, period_start, period_end, ranking_year_week)
    - `mv_product_rank_monthly` (ref_product_id, score, period_start, period_end, ranking_year_month)

### Ranking API

- [x] **API가 일간, 주간, 월간 랭킹을 제공하며 적절한 데이터를 기반으로 랭킹을 제공한다.**
    - 일간: Redis ZSet 조회 (`GET /api/v1/rankings/daily`)
    - 주간: MV 테이블 조회 (`GET /api/v1/rankings/weekly`)
    - 월간: MV 테이블 조회 (`GET /api/v1/rankings/monthly`)

---

## Key Changes

### 1. commerce-batch 모듈 신규 추가

Spring Batch 애플리케이션으로 랭킹 집계 Job 구현:

```
apps/commerce-batch/
├── job/ranking/
│   ├── RankingAggregationJobConfig.java  # Job/Step 설정
│   ├── RankingItemProcessor.java          # 가중치 점수 계산
│   ├── AggregatedProductScore.java        # 집계 DTO
│   └── DateRange.java                     # 기간 범위 record
├── domain/ranking/
│   ├── WeeklyProductRank.java             # 주간 MV 엔티티
│   └── MonthlyProductRank.java            # 월간 MV 엔티티
├── interfaces/
│   ├── BatchJobController.java            # 수동 실행 API
│   └── RankingScheduler.java              # @Scheduled 스케줄러
└── config/
    └── RankingBatchProperties.java        # 가중치/청크 설정
```

### 2. Chunk Oriented Processing 역할 분리

| 구분 | 역할 |
|------|------|
| Reader | GROUP BY + SUM (합계) + ORDER BY id |
| Processor | 가중치 적용 점수 계산 (view*0.1 + like*0.3 + order*0.6) |
| Writer | `saveAll()` 배치 저장 |

### 3. Ranking API 데이터 소스 분리

| 기간 | 데이터 소스 | 엔드포인트 |
|------|-------------|------------|
| 일간 | Redis ZSet | `GET /api/v1/rankings/daily` |
| 주간 | MV 테이블 | `GET /api/v1/rankings/weekly` |
| 월간 | MV 테이블 | `GET /api/v1/rankings/monthly` |

### 4. ProductMetrics 날짜별 집계 구조 개선

- `ProductMetricsId` 복합키 변경: `(ref_product_id, metric_date)`
- `metric_date` 컬럼 추가 (YYYYMMDD 형식)

### 5. Job 트리거 방식

| 방식 | 설명 |
|------|------|
| **스케줄러** | `@Scheduled`로 자동 실행 |
| **수동 API** | `POST /api/v1/jobs/ranking`으로 수동 실행 |

**스케줄 설정:**
| 기간 | 크론 표현식 | 실행 시점 |
|------|------------|----------|
| 주간 | `0 0 2 * * MON` | 매주 월요일 02:00 (전주 집계) |
| 월간 | `0 0 3 1 * *` | 매월 1일 03:00 (전월 집계) |

**수동 API:**
```
POST /api/v1/jobs/ranking?period=WEEKLY&date=20260101
POST /api/v1/jobs/ranking?period=MONTHLY&date=20260101
```

---

## Review Points

### 1. Reader/Processor/Writer 역할 분리 구조

아래와 같이 Reader, Processor, Writer이 역할을 분리햇는데, 이 구조가 적절한지 리뷰 받아보고 싶습니다.

| 구분 | 역할 | 설명 |
|------|------|------|
| Reader | GROUP BY + SUM (합계만) | 데이터 조회/집계 |
| Processor | 가중치 점수 계산 | 비즈니스 로직 (view×0.1 + like×0.3 + order×0.6) |
| Writer | 점수 저장만 | rank_position 없이 score만 저장 |

**설계 배경**:
- **Processor 제약**: 1:1 매핑만 가능 (1개 input → 1개 output). 여러 아이템을 모아서 정렬하거나 전체 순위를 부여할 수 없음
- **Chunk 병렬 처리 문제**: chunkSize=100일 때 각 chunk가 독립적으로 Writer에 전달되어, chunk마다 rank 1~100이 중복 저장되는 문제 발생 → rank_position 저장 제거
- **해결**: rank_position은 "파생 데이터"로 판단. MV에는 score만 저장하고, API 조회 시 `ORDER BY score DESC`로 랭킹 계산

**트레이드오프**:
- 장점: Chunk 병렬 처리 가능, Writer 로직 단순화, TOP 100 → 500 확장 시 코드 변경 불필요
- 단점: 조회 시 정렬 비용 (TOP 100 규모에서 무시 가능)

---

### 2. 주간/월간 랭킹 API의 기간 정책 표현

현재의 URL 설계 만으로는 API를 사용하는 입장에서 "월요일~일요일"이라는 비즈니스 정책을 나타내기 부족하다고 생각이 들었습니다.
- Swagger 등 API 문서나 사내 비즈니스 정책 약속을 통해 인지는 가능할 것 같은데
- URL 설계 관점에서 이런 기간 정책을 더 명확히 표현할 수 있는 방법이 있을지 궁금합니다

**현재**: `GET /api/v1/rankings/weekly?date=260101`
- `date=260101` 전달 시, 해당 날짜가 속한 **주의 월요일~일요일** 랭킹을 조회
- 예: 2026년 1월 1일(목) → 2025년 12월 29일(월) ~ 2026년 1월 4일(일) 주간 랭킹 반환

---
