### PR TITLE
[volume-10] Collect, Stack, Zip 

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCommand.java
@@ -4,8 +4,15 @@ import java.time.LocalDate;
 
 public class RankingCommand {
 
-    public record GetDailyRankingCommand(
+    public enum RankingType {
+        DAILY,
+        WEEKLY,
+        MONTHLY
+    }
+
+    public record GetRankingCommand(
             LocalDate date,
+            RankingType type,
             int page,
             int size
     ) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -5,6 +5,8 @@ import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.ranking.Ranking;
 import com.loopers.domain.ranking.RankingService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,12 +25,18 @@ public class RankingFacade {
     private final ProductService productService;
     private final BrandService brandService;
 
-    public RankingInfo getDailyRanking(RankingCommand.GetDailyRankingCommand command) {
-        List<Ranking> rankings = rankingService.getRanking(
-                command.date(),
-                command.page(),
-                command.size()
-        );
+    public RankingInfo getRanking(RankingCommand.GetRankingCommand command) {
+        List<Ranking> rankings;
+
+        if (command.type() == RankingCommand.RankingType.DAILY) {
+            rankings = rankingService.getDailyRanking(command.date(), command.page(), command.size());
+        } else if (command.type() == RankingCommand.RankingType.WEEKLY) {
+            rankings = rankingService.getWeeklyRanking(command.date(), command.page(), command.size());
+        } else if (command.type() == RankingCommand.RankingType.MONTHLY) {
+            rankings = rankingService.getMonthlyRanking(command.date(), command.page(), command.size());
+        } else {
+            throw new CoreException(ErrorType.BAD_REQUEST, "지원하지 않는 랭킹 타입입니다: " + command.type());
+        }
 
         if (rankings.isEmpty()) {
             return new RankingInfo(List.of());

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MvProductRankMonthly.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MvProductRankMonthly.java
@@ -1,0 +1,77 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "mv_product_rank_monthly",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"product_id", "period_start_date", "period_end_date"})
+        }
+)
+@Getter
+public class MvProductRankMonthly extends BaseEntity {
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(nullable = true)
+    private Integer ranking;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Column(name = "period_start_date", nullable = false)
+    private LocalDate periodStartDate;
+
+    @Column(name = "period_end_date", nullable = false)
+    private LocalDate periodEndDate;
+
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    @Column(name = "sales_count", nullable = false)
+    private Long salesCount;
+
+    @Builder
+    private MvProductRankMonthly(Long productId, Integer ranking, Double score, LocalDate periodStartDate,
+                                 LocalDate periodEndDate, Long likeCount, Long viewCount, Long salesCount) {
+        this.productId = productId;
+        this.ranking = ranking;
+        this.score = score;
+        this.periodStartDate = periodStartDate;
+        this.periodEndDate = periodEndDate;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.salesCount = salesCount;
+    }
+
+    public MvProductRankMonthly() {
+    }
+
+    public static MvProductRankMonthly create(Long productId, Integer ranking, Double score, LocalDate periodStartDate,
+                                              LocalDate periodEndDate, Long likeCount, Long viewCount, Long salesCount) {
+        return MvProductRankMonthly.builder()
+                .productId(productId)
+                .ranking(ranking)
+                .score(score)
+                .periodStartDate(periodStartDate)
+                .periodEndDate(periodEndDate)
+                .likeCount(likeCount)
+                .viewCount(viewCount)
+                .salesCount(salesCount)
+                .build();
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MvProductRankMonthlyRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MvProductRankMonthlyRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MvProductRankMonthlyRepository {
+    List<MvProductRankMonthly> findByPeriodOrderByRankingAsc(LocalDate periodStartDate, LocalDate periodEndDate, int page, int size);
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MvProductRankWeekly.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MvProductRankWeekly.java
@@ -1,0 +1,77 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "mv_product_rank_weekly",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"product_id", "period_start_date", "period_end_date"})
+        }
+)
+@Getter
+public class MvProductRankWeekly extends BaseEntity {
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(nullable = true)
+    private Integer ranking;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Column(name = "period_start_date", nullable = false)
+    private LocalDate periodStartDate;
+
+    @Column(name = "period_end_date", nullable = false)
+    private LocalDate periodEndDate;
+
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    @Column(name = "sales_count", nullable = false)
+    private Long salesCount;
+
+    @Builder
+    private MvProductRankWeekly(Long productId, Integer ranking, Double score, LocalDate periodStartDate, LocalDate periodEndDate,
+                                Long likeCount, Long viewCount, Long salesCount) {
+        this.productId = productId;
+        this.ranking = ranking;
+        this.score = score;
+        this.periodStartDate = periodStartDate;
+        this.periodEndDate = periodEndDate;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.salesCount = salesCount;
+    }
+
+    public MvProductRankWeekly() {
+    }
+
+    public static MvProductRankWeekly create(Long productId, Integer ranking, Double score, LocalDate periodStartDate,
+                                             LocalDate periodEndDate, Long likeCount, Long viewCount, Long salesCount) {
+        return MvProductRankWeekly.builder()
+                .productId(productId)
+                .ranking(ranking)
+                .score(score)
+                .periodStartDate(periodStartDate)
+                .periodEndDate(periodEndDate)
+                .likeCount(likeCount)
+                .viewCount(viewCount)
+                .salesCount(salesCount)
+                .build();
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MvProductRankWeeklyRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MvProductRankWeeklyRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MvProductRankWeeklyRepository {
+    List<MvProductRankWeekly> findByPeriodOrderByRankingAsc(LocalDate periodStartDate, LocalDate periodEndDate, int page, int size);
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPeriod.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPeriod.java
@@ -1,0 +1,25 @@
+package com.loopers.domain.ranking;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.temporal.TemporalAdjusters;
+
+public record RankingPeriod(
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static RankingPeriod ofWeek(LocalDate date) {
+        LocalDate weekStart = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEnd = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        return new RankingPeriod(weekStart, weekEnd);
+    }
+
+    public static RankingPeriod ofMonth(LocalDate date) {
+        YearMonth yearMonth = YearMonth.from(date);
+        LocalDate monthStart = yearMonth.atDay(1);
+        LocalDate monthEnd = yearMonth.atEndOfMonth();
+        return new RankingPeriod(monthStart, monthEnd);
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -15,7 +15,7 @@ public class RankingService {
 
     private final RankingCacheService rankingCacheService;
 
-    public List<Ranking> getRanking(LocalDate date, int page, int size) {
+    public List<Ranking> getDailyRanking(LocalDate date, int page, int size) {
         long start = (long) (page - 1) * size;
         long end = start + size - 1;
 
@@ -32,6 +32,14 @@ public class RankingService {
                     return new Ranking(item.productId(), rank, item.score());
                 })
                 .toList();
+    }
+
+    public List<Ranking> getWeeklyRanking(LocalDate date, int page, int size) {
+        return new ArrayList<>();
+    }
+
+    public List<Ranking> getMonthlyRanking(LocalDate date, int page, int size) {
+        return new ArrayList<>();
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -14,6 +14,8 @@ import java.util.stream.IntStream;
 public class RankingService {
 
     private final RankingCacheService rankingCacheService;
+    private final MvProductRankWeeklyRepository mvProductRankWeeklyRepository;
+    private final MvProductRankMonthlyRepository mvProductRankMonthlyRepository;
 
     public List<Ranking> getDailyRanking(LocalDate date, int page, int size) {
         long start = (long) (page - 1) * size;
@@ -35,11 +37,51 @@ public class RankingService {
     }
 
     public List<Ranking> getWeeklyRanking(LocalDate date, int page, int size) {
-        return new ArrayList<>();
+        RankingPeriod period = RankingPeriod.ofWeek(date);
+        List<MvProductRankWeekly> weeklyRanks = mvProductRankWeeklyRepository
+                .findByPeriodOrderByRankingAsc(
+                        period.startDate(),
+                        period.endDate(),
+                        page,
+                        size
+                );
+
+        if (weeklyRanks.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return weeklyRanks.stream()
+                .filter(rank -> rank.getRanking() != null)
+                .map(rank -> new Ranking(
+                        rank.getProductId(),
+                        rank.getRanking().longValue(),
+                        rank.getScore()
+                ))
+                .toList();
     }
 
     public List<Ranking> getMonthlyRanking(LocalDate date, int page, int size) {
-        return new ArrayList<>();
+        RankingPeriod period = RankingPeriod.ofMonth(date);
+        List<MvProductRankMonthly> monthlyRanks = mvProductRankMonthlyRepository
+                .findByPeriodOrderByRankingAsc(
+                        period.startDate(),
+                        period.endDate(),
+                        page,
+                        size
+                );
+
+        if (monthlyRanks.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return monthlyRanks.stream()
+                .filter(rank -> rank.getRanking() != null)
+                .map(rank -> new Ranking(
+                        rank.getProductId(),
+                        rank.getRanking().longValue(),
+                        rank.getScore()
+                ))
+                .toList();
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MvProductRankMonthlyJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MvProductRankMonthlyJpaRepository.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MvProductRankMonthly;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MvProductRankMonthlyJpaRepository extends JpaRepository<MvProductRankMonthly, Long> {
+
+    List<MvProductRankMonthly> findByPeriodStartDateAndPeriodEndDateOrderByRankingAsc(
+            LocalDate periodStartDate,
+            LocalDate periodEndDate,
+            Pageable pageable
+    );
+
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MvProductRankMonthlyRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MvProductRankMonthlyRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MvProductRankMonthly;
+import com.loopers.domain.ranking.MvProductRankMonthlyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MvProductRankMonthlyRepositoryImpl implements MvProductRankMonthlyRepository {
+
+    private final MvProductRankMonthlyJpaRepository mvProductRankMonthlyJpaRepository;
+
+    @Override
+    public List<MvProductRankMonthly> findByPeriodOrderByRankingAsc(LocalDate periodStartDate, LocalDate periodEndDate, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return mvProductRankMonthlyJpaRepository.findByPeriodStartDateAndPeriodEndDateOrderByRankingAsc(periodStartDate, periodEndDate, pageable);
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MvProductRankWeeklyJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MvProductRankWeeklyJpaRepository.java
@@ -1,0 +1,18 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MvProductRankWeekly;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MvProductRankWeeklyJpaRepository extends JpaRepository<MvProductRankWeekly, Long> {
+    
+    List<MvProductRankWeekly> findByPeriodStartDateAndPeriodEndDateOrderByRankingAsc(
+            LocalDate periodStartDate,
+            LocalDate periodEndDate,
+            Pageable pageable
+    );
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MvProductRankWeeklyRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MvProductRankWeeklyRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MvProductRankWeekly;
+import com.loopers.domain.ranking.MvProductRankWeeklyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MvProductRankWeeklyRepositoryImpl implements MvProductRankWeeklyRepository {
+
+    private final MvProductRankWeeklyJpaRepository mvProductRankWeeklyJpaRepository;
+
+    @Override
+    public List<MvProductRankWeekly> findByPeriodOrderByRankingAsc(LocalDate periodStartDate, LocalDate periodEndDate, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return mvProductRankWeeklyJpaRepository.findByPeriodStartDateAndPeriodEndDateOrderByRankingAsc(periodStartDate, periodEndDate, pageable);
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -11,11 +11,13 @@ public interface RankingV1ApiSpec {
 
     @Operation(
             summary = "상품 랭킹 조회",
-            description = "상품의 일간 랭킹 정보를 조회합니다."
+            description = "상품의 일간/주간/월간 랭킹 정보를 조회합니다."
     )
-    ApiResponse<RankingV1Dto.DailyRankingListResponse> getDailyRanking(
+    ApiResponse<RankingV1Dto.RankingListResponse> getRanking(
             @Parameter(name = "date", description = "조회할 날짜 (yyyyMMdd 형식)", required = true)
             LocalDate date,
+            @Parameter(name = "type", description = "랭킹 타입 (DAILY, WEEKLY, MONTHLY)", required = true)
+            String type,
             @Parameter(name = "page", description = "페이지 번호 (기본값: 1)")
             Integer page,
             @Parameter(name = "size", description = "페이지당 상품 수 (기본값: 20)")

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -4,6 +4,9 @@ import com.loopers.application.ranking.RankingCommand;
 import com.loopers.application.ranking.RankingFacade;
 import com.loopers.application.ranking.RankingInfo;
 import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -21,19 +24,23 @@ public class RankingV1Controller implements RankingV1ApiSpec {
 
     @GetMapping
     @Override
-    public ApiResponse<RankingV1Dto.DailyRankingListResponse> getDailyRanking(
+    public ApiResponse<RankingV1Dto.RankingListResponse> getRanking(
             @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+            @RequestParam @NotNull String type,
             @RequestParam(required = false, defaultValue = "1") Integer page,
             @RequestParam(required = false, defaultValue = "20") Integer size
     ) {
-        RankingCommand.GetDailyRankingCommand command = new RankingCommand.GetDailyRankingCommand(
-                date,
-                page,
-                size
-        );
+        RankingCommand.RankingType rankingType;
+        try {
+            rankingType = RankingCommand.RankingType.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "지원하지 않는 랭킹 타입입니다.");
+        }
 
-        RankingInfo rankingInfo = rankingFacade.getDailyRanking(command);
-        RankingV1Dto.DailyRankingListResponse response = RankingV1Dto.DailyRankingListResponse.from(rankingInfo);
+        RankingCommand.GetRankingCommand command = new RankingCommand.GetRankingCommand(date, rankingType, page, size);
+
+        RankingInfo rankingInfo = rankingFacade.getRanking(command);
+        RankingV1Dto.RankingListResponse response = RankingV1Dto.RankingListResponse.from(rankingInfo);
 
         return ApiResponse.success(response);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -6,7 +6,6 @@ import com.loopers.application.ranking.RankingInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -26,7 +25,7 @@ public class RankingV1Controller implements RankingV1ApiSpec {
     @Override
     public ApiResponse<RankingV1Dto.RankingListResponse> getRanking(
             @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
-            @RequestParam @NotNull String type,
+            @RequestParam String type,
             @RequestParam(required = false, defaultValue = "1") Integer page,
             @RequestParam(required = false, defaultValue = "20") Integer size
     ) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -6,12 +6,12 @@ import java.util.stream.Collectors;
 
 public class RankingV1Dto {
 
-    public record DailyRankingListResponse(
-            List<DailyRankingItem> rankings
+    public record RankingListResponse(
+            List<RankingItem> rankings
     ) {
-        public static DailyRankingListResponse from(RankingInfo rankingInfo) {
-            List<DailyRankingItem> items = rankingInfo.items().stream()
-                    .map(item -> new DailyRankingItem(
+        public static RankingListResponse from(RankingInfo rankingInfo) {
+            List<RankingItem> items = rankingInfo.items().stream()
+                    .map(item -> new RankingItem(
                             item.productId(),
                             item.productName(),
                             item.brandName(),
@@ -21,11 +21,11 @@ public class RankingV1Dto {
                     ))
                     .collect(Collectors.toList());
 
-            return new DailyRankingListResponse(items);
+            return new RankingListResponse(items);
         }
     }
 
-    public record DailyRankingItem(
+    public record RankingItem(
             Long productId,
             String productName,
             String brandName,

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
     import:
       - jpa.yml
       - redis.yml
+      - kafka.yml
       - logging.yml
       - monitoring.yml
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.loopers.application.ranking;
 
+import com.loopers.application.ranking.RankingCommand.GetRankingCommand;
+import com.loopers.application.ranking.RankingCommand.RankingType;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.LikeCount;
 import com.loopers.domain.product.Price;
@@ -80,12 +82,12 @@ class RankingFacadeIntegrationTest extends IntegrationTest {
             zSetOps.add(key, String.valueOf(product1.getId()), 100.0);
             zSetOps.add(key, String.valueOf(product2.getId()), 50.0);
 
-            RankingCommand.GetDailyRankingCommand command = new RankingCommand.GetDailyRankingCommand(
-                    date, 1, 20
+            GetRankingCommand command = new GetRankingCommand(
+                    date, RankingType.DAILY, 1, 20
             );
 
             // act
-            RankingInfo result = rankingFacade.getDailyRanking(command);
+            RankingInfo result = rankingFacade.getRanking(command);
 
             // assert
             assertThat(result.items()).hasSize(2);
@@ -124,12 +126,12 @@ class RankingFacadeIntegrationTest extends IntegrationTest {
             zSetOps.add(key, String.valueOf(product.getId()), 100.0);
             zSetOps.add(key, "999", 50.0); // DB에 없는 상품
 
-            RankingCommand.GetDailyRankingCommand command = new RankingCommand.GetDailyRankingCommand(
-                    date, 1, 20
+            GetRankingCommand command = new GetRankingCommand(
+                    date, RankingType.DAILY, 1, 20
             );
 
             // act
-            RankingInfo result = rankingFacade.getDailyRanking(command);
+            RankingInfo result = rankingFacade.getRanking(command);
 
             // assert
             assertThat(result.items()).hasSize(1);
@@ -140,12 +142,12 @@ class RankingFacadeIntegrationTest extends IntegrationTest {
         @Test
         void returnsEmptyList_whenNoRankingData() {
             // arrange
-            RankingCommand.GetDailyRankingCommand command = new RankingCommand.GetDailyRankingCommand(
-                    LocalDate.now(), 1, 20
+            GetRankingCommand command = new GetRankingCommand(
+                    LocalDate.now(), RankingType.DAILY, 1, 20
             );
 
             // act
-            RankingInfo result = rankingFacade.getDailyRanking(command);
+            RankingInfo result = rankingFacade.getRanking(command);
 
             // assert
             assertThat(result.items()).isEmpty();
@@ -173,8 +175,8 @@ class RankingFacadeIntegrationTest extends IntegrationTest {
             zSetOps.add(key, String.valueOf(product3.getId()), 30.0);
 
             // act - 첫 페이지
-            RankingInfo page1 = rankingFacade.getDailyRanking(
-                    new RankingCommand.GetDailyRankingCommand(date, 1, 2)
+            RankingInfo page1 = rankingFacade.getRanking(
+                    new GetRankingCommand(date, RankingType.DAILY, 1, 2)
             );
 
             // assert
@@ -183,8 +185,8 @@ class RankingFacadeIntegrationTest extends IntegrationTest {
             assertThat(page1.items().get(1).productId()).isEqualTo(product2.getId());
 
             // act - 두 번째 페이지
-            RankingInfo page2 = rankingFacade.getDailyRanking(
-                    new RankingCommand.GetDailyRankingCommand(date, 2, 2)
+            RankingInfo page2 = rankingFacade.getRanking(
+                    new GetRankingCommand(date, RankingType.DAILY, 2, 2)
             );
 
             // assert

--- a/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
@@ -1,6 +1,9 @@
 package com.loopers.domain.ranking;
 
+import com.loopers.infrastructure.ranking.MvProductRankMonthlyJpaRepository;
+import com.loopers.infrastructure.ranking.MvProductRankWeeklyJpaRepository;
 import com.loopers.support.IntegrationTest;
+import com.loopers.utils.DatabaseCleanUp;
 import com.loopers.utils.RedisCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,17 +35,28 @@ class RankingServiceIntegrationTest extends IntegrationTest {
     @Autowired
     private RedisCleanUp redisCleanUp;
 
+    @Autowired
+    private MvProductRankWeeklyJpaRepository mvProductRankWeeklyJpaRepository;
+
+    @Autowired
+    private MvProductRankMonthlyJpaRepository mvProductRankMonthlyJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
     private static final String RANKING_KEY_PREFIX = "ranking:all:";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     @BeforeEach
     void setUp() {
         redisCleanUp.truncateAll();
+        databaseCleanUp.truncateAllTables();
     }
 
     @AfterEach
     void tearDown() {
         redisCleanUp.truncateAll();
+        databaseCleanUp.truncateAllTables();
     }
 
     @DisplayName("랭킹 조회")
@@ -148,6 +162,240 @@ class RankingServiceIntegrationTest extends IntegrationTest {
 
             // assert
             assertThat(result).hasSize(1);
+            assertThat(result.get(0).rank()).isEqualTo(1L);
+        }
+    }
+
+    @DisplayName("주간 랭킹 조회")
+    @Nested
+    class GetWeeklyRanking {
+
+        @DisplayName("주간 랭킹 데이터가 있으면 정상적으로 조회된다.")
+        @Test
+        void returnsRankings_whenDataExists() {
+            // arrange
+            LocalDate date = LocalDate.of(2024, 1, 10); // 수요일
+            RankingPeriod period = RankingPeriod.ofWeek(date);
+
+            MvProductRankWeekly rank1 = MvProductRankWeekly.create(
+                    1L, 1, 100.0, period.startDate(), period.endDate(), 10L, 100L, 5L
+            );
+            MvProductRankWeekly rank2 = MvProductRankWeekly.create(
+                    2L, 2, 50.0, period.startDate(), period.endDate(), 5L, 50L, 3L
+            );
+            MvProductRankWeekly rank3 = MvProductRankWeekly.create(
+                    3L, 3, 30.0, period.startDate(), period.endDate(), 3L, 30L, 2L
+            );
+
+            mvProductRankWeeklyJpaRepository.save(rank1);
+            mvProductRankWeeklyJpaRepository.save(rank2);
+            mvProductRankWeeklyJpaRepository.save(rank3);
+
+            // act
+            List<Ranking> result = rankingService.getWeeklyRanking(date, 1, 20);
+
+            // assert
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).productId()).isEqualTo(1L);
+            assertThat(result.get(0).rank()).isEqualTo(1L);
+            assertThat(result.get(0).score()).isEqualTo(100.0);
+            assertThat(result.get(1).productId()).isEqualTo(2L);
+            assertThat(result.get(1).rank()).isEqualTo(2L);
+            assertThat(result.get(1).score()).isEqualTo(50.0);
+            assertThat(result.get(2).productId()).isEqualTo(3L);
+            assertThat(result.get(2).rank()).isEqualTo(3L);
+            assertThat(result.get(2).score()).isEqualTo(30.0);
+        }
+
+        @DisplayName("페이징이 정상적으로 동작한다.")
+        @Test
+        void returnsPaginatedResults() {
+            // arrange
+            LocalDate date = LocalDate.of(2024, 1, 10);
+            RankingPeriod period = RankingPeriod.ofWeek(date);
+
+            for (int i = 1; i <= 5; i++) {
+                MvProductRankWeekly rank = MvProductRankWeekly.create(
+                        (long) i, i, (double) (100 - i * 10), period.startDate(), period.endDate(),
+                        10L, 100L, 5L
+                );
+                mvProductRankWeeklyJpaRepository.save(rank);
+            }
+
+            // act - 첫 페이지
+            List<Ranking> page1 = rankingService.getWeeklyRanking(date, 1, 2);
+
+            // assert
+            assertThat(page1).hasSize(2);
+            assertThat(page1.get(0).productId()).isEqualTo(1L);
+            assertThat(page1.get(0).rank()).isEqualTo(1L);
+            assertThat(page1.get(1).productId()).isEqualTo(2L);
+            assertThat(page1.get(1).rank()).isEqualTo(2L);
+
+            // act - 두 번째 페이지
+            List<Ranking> page2 = rankingService.getWeeklyRanking(date, 2, 2);
+
+            // assert
+            assertThat(page2).hasSize(2);
+            assertThat(page2.get(0).productId()).isEqualTo(3L);
+            assertThat(page2.get(0).rank()).isEqualTo(3L);
+            assertThat(page2.get(1).productId()).isEqualTo(4L);
+            assertThat(page2.get(1).rank()).isEqualTo(4L);
+        }
+
+        @DisplayName("랭킹 데이터가 없으면 빈 리스트를 반환한다.")
+        @Test
+        void returnsEmptyList_whenNoDataExists() {
+            // arrange
+            LocalDate date = LocalDate.of(2024, 1, 10);
+
+            // act
+            List<Ranking> result = rankingService.getWeeklyRanking(date, 1, 20);
+
+            // assert
+            assertThat(result).isEmpty();
+        }
+
+        @DisplayName("ranking이 null인 경우 필터링된다.")
+        @Test
+        void filtersNullRanking() {
+            // arrange
+            LocalDate date = LocalDate.of(2024, 1, 10);
+            RankingPeriod period = RankingPeriod.ofWeek(date);
+
+            MvProductRankWeekly rank1 = MvProductRankWeekly.create(
+                    1L, 1, 100.0, period.startDate(), period.endDate(), 10L, 100L, 5L
+            );
+            MvProductRankWeekly rank2 = MvProductRankWeekly.create(
+                    2L, null, 50.0, period.startDate(), period.endDate(), 5L, 50L, 3L
+            );
+
+            mvProductRankWeeklyJpaRepository.save(rank1);
+            mvProductRankWeeklyJpaRepository.save(rank2);
+
+            // act
+            List<Ranking> result = rankingService.getWeeklyRanking(date, 1, 20);
+
+            // assert
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).productId()).isEqualTo(1L);
+            assertThat(result.get(0).rank()).isEqualTo(1L);
+        }
+    }
+
+    @DisplayName("월간 랭킹 조회")
+    @Nested
+    class GetMonthlyRanking {
+
+        @DisplayName("월간 랭킹 데이터가 있으면 정상적으로 조회된다.")
+        @Test
+        void returnsRankings_whenDataExists() {
+            // arrange
+            LocalDate date = LocalDate.of(2024, 1, 15);
+            RankingPeriod period = RankingPeriod.ofMonth(date);
+
+            MvProductRankMonthly rank1 = MvProductRankMonthly.create(
+                    1L, 1, 100.0, period.startDate(), period.endDate(), 10L, 100L, 5L
+            );
+            MvProductRankMonthly rank2 = MvProductRankMonthly.create(
+                    2L, 2, 50.0, period.startDate(), period.endDate(), 5L, 50L, 3L
+            );
+            MvProductRankMonthly rank3 = MvProductRankMonthly.create(
+                    3L, 3, 30.0, period.startDate(), period.endDate(), 3L, 30L, 2L
+            );
+
+            mvProductRankMonthlyJpaRepository.save(rank1);
+            mvProductRankMonthlyJpaRepository.save(rank2);
+            mvProductRankMonthlyJpaRepository.save(rank3);
+
+            // act
+            List<Ranking> result = rankingService.getMonthlyRanking(date, 1, 20);
+
+            // assert
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).productId()).isEqualTo(1L);
+            assertThat(result.get(0).rank()).isEqualTo(1L);
+            assertThat(result.get(0).score()).isEqualTo(100.0);
+            assertThat(result.get(1).productId()).isEqualTo(2L);
+            assertThat(result.get(1).rank()).isEqualTo(2L);
+            assertThat(result.get(1).score()).isEqualTo(50.0);
+            assertThat(result.get(2).productId()).isEqualTo(3L);
+            assertThat(result.get(2).rank()).isEqualTo(3L);
+            assertThat(result.get(2).score()).isEqualTo(30.0);
+        }
+
+        @DisplayName("페이징이 정상적으로 동작한다.")
+        @Test
+        void returnsPaginatedResults() {
+            // arrange
+            LocalDate date = LocalDate.of(2024, 1, 15);
+            RankingPeriod period = RankingPeriod.ofMonth(date);
+
+            for (int i = 1; i <= 5; i++) {
+                MvProductRankMonthly rank = MvProductRankMonthly.create(
+                        (long) i, i, (double) (100 - i * 10), period.startDate(), period.endDate(),
+                        10L, 100L, 5L
+                );
+                mvProductRankMonthlyJpaRepository.save(rank);
+            }
+
+            // act - 첫 페이지
+            List<Ranking> page1 = rankingService.getMonthlyRanking(date, 1, 2);
+
+            // assert
+            assertThat(page1).hasSize(2);
+            assertThat(page1.get(0).productId()).isEqualTo(1L);
+            assertThat(page1.get(0).rank()).isEqualTo(1L);
+            assertThat(page1.get(1).productId()).isEqualTo(2L);
+            assertThat(page1.get(1).rank()).isEqualTo(2L);
+
+            // act - 두 번째 페이지
+            List<Ranking> page2 = rankingService.getMonthlyRanking(date, 2, 2);
+
+            // assert
+            assertThat(page2).hasSize(2);
+            assertThat(page2.get(0).productId()).isEqualTo(3L);
+            assertThat(page2.get(0).rank()).isEqualTo(3L);
+            assertThat(page2.get(1).productId()).isEqualTo(4L);
+            assertThat(page2.get(1).rank()).isEqualTo(4L);
+        }
+
+        @DisplayName("랭킹 데이터가 없으면 빈 리스트를 반환한다.")
+        @Test
+        void returnsEmptyList_whenNoDataExists() {
+            // arrange
+            LocalDate date = LocalDate.of(2024, 1, 15);
+
+            // act
+            List<Ranking> result = rankingService.getMonthlyRanking(date, 1, 20);
+
+            // assert
+            assertThat(result).isEmpty();
+        }
+
+        @DisplayName("ranking이 null인 경우 필터링된다.")
+        @Test
+        void filtersNullRanking() {
+            // arrange
+            LocalDate date = LocalDate.of(2024, 1, 15);
+            RankingPeriod period = RankingPeriod.ofMonth(date);
+
+            MvProductRankMonthly rank1 = MvProductRankMonthly.create(
+                    1L, 1, 100.0, period.startDate(), period.endDate(), 10L, 100L, 5L
+            );
+            MvProductRankMonthly rank2 = MvProductRankMonthly.create(
+                    2L, null, 50.0, period.startDate(), period.endDate(), 5L, 50L, 3L
+            );
+
+            mvProductRankMonthlyJpaRepository.save(rank1);
+            mvProductRankMonthlyJpaRepository.save(rank2);
+
+            // act
+            List<Ranking> result = rankingService.getMonthlyRanking(date, 1, 20);
+
+            // assert
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).productId()).isEqualTo(1L);
             assertThat(result.get(0).rank()).isEqualTo(1L);
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
@@ -54,7 +54,7 @@ class RankingServiceIntegrationTest extends IntegrationTest {
         void returnsRankings_whenDataExists() {
             // arrange
             LocalDate date = LocalDate.now();
-            String key = getRankingKey(date);
+            String key = getDailyRankingKey(date);
             ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
 
             zSetOps.add(key, "1", 100.0);
@@ -62,7 +62,7 @@ class RankingServiceIntegrationTest extends IntegrationTest {
             zSetOps.add(key, "3", 30.0);
 
             // act
-            List<Ranking> result = rankingService.getRanking(date, 1, 20);
+            List<Ranking> result = rankingService.getDailyRanking(date, 1, 20);
 
             // assert
             assertThat(result).hasSize(3);
@@ -82,7 +82,7 @@ class RankingServiceIntegrationTest extends IntegrationTest {
         void returnsPaginatedResults() {
             // arrange
             LocalDate date = LocalDate.now();
-            String key = getRankingKey(date);
+            String key = getDailyRankingKey(date);
             ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
 
             zSetOps.add(key, "1", 100.0);
@@ -92,7 +92,7 @@ class RankingServiceIntegrationTest extends IntegrationTest {
             zSetOps.add(key, "5", 60.0);
 
             // act - 첫 페이지
-            List<Ranking> page1 = rankingService.getRanking(date, 1, 2);
+            List<Ranking> page1 = rankingService.getDailyRanking(date, 1, 2);
 
             // assert
             assertThat(page1).hasSize(2);
@@ -102,7 +102,7 @@ class RankingServiceIntegrationTest extends IntegrationTest {
             assertThat(page1.get(1).rank()).isEqualTo(2L);
 
             // act - 두 번째 페이지
-            List<Ranking> page2 = rankingService.getRanking(date, 2, 2);
+            List<Ranking> page2 = rankingService.getDailyRanking(date, 2, 2);
 
             // assert
             assertThat(page2).hasSize(2);
@@ -112,7 +112,7 @@ class RankingServiceIntegrationTest extends IntegrationTest {
             assertThat(page2.get(1).rank()).isEqualTo(4L);
 
             // act - 세 번째 페이지
-            List<Ranking> page3 = rankingService.getRanking(date, 3, 2);
+            List<Ranking> page3 = rankingService.getDailyRanking(date, 3, 2);
 
             // assert
             assertThat(page3).hasSize(1);
@@ -127,7 +127,7 @@ class RankingServiceIntegrationTest extends IntegrationTest {
             LocalDate date = LocalDate.now();
 
             // act
-            List<Ranking> result = rankingService.getRanking(date, 1, 20);
+            List<Ranking> result = rankingService.getDailyRanking(date, 1, 20);
 
             // assert
             assertThat(result).isEmpty();
@@ -138,13 +138,13 @@ class RankingServiceIntegrationTest extends IntegrationTest {
         void startsRankFromOne() {
             // arrange
             LocalDate date = LocalDate.now();
-            String key = getRankingKey(date);
+            String key = getDailyRankingKey(date);
             ZSetOperations<String, String> zSetOps = redisTemplateMaster.opsForZSet();
 
             zSetOps.add(key, "1", 100.0);
 
             // act
-            List<Ranking> result = rankingService.getRanking(date, 1, 20);
+            List<Ranking> result = rankingService.getDailyRanking(date, 1, 20);
 
             // assert
             assertThat(result).hasSize(1);
@@ -152,7 +152,7 @@ class RankingServiceIntegrationTest extends IntegrationTest {
         }
     }
 
-    private String getRankingKey(LocalDate date) {
+    private String getDailyRankingKey(LocalDate date) {
         return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
@@ -96,7 +96,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
             zSetOps.add(key, String.valueOf(product1.getId()), 100.0);
             zSetOps.add(key, String.valueOf(product2.getId()), 50.0);
 
-            String url = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=1&size=20";
+            String url = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&type=DAILY&page=1&size=20";
 
             // act
             ResponseEntity<ApiResponse<RankingListResponse>> response = testRestTemplate.exchange(
@@ -140,7 +140,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
         void returnsEmptyList_whenNoDataExists() {
             // arrange
             LocalDate date = LocalDate.now();
-            String url = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=1&size=20";
+            String url = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&type=DAILY&page=1&size=20";
 
             // act
             ResponseEntity<ApiResponse<RankingListResponse>> response = testRestTemplate.exchange(
@@ -181,7 +181,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
             zSetOps.add(key, String.valueOf(product3.getId()), 30.0);
 
             // act - 첫 페이지
-            String url1 = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=1&size=2";
+            String url1 = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&type=DAILY&page=1&size=2";
             ResponseEntity<ApiResponse<RankingListResponse>> response1 = testRestTemplate.exchange(
                     url1,
                     HttpMethod.GET,
@@ -197,7 +197,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
             assertThat(page1.rankings().get(1).productId()).isEqualTo(product2.getId());
 
             // act - 두 번째 페이지
-            String url2 = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=2&size=2";
+            String url2 = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&type=DAILY&page=2&size=2";
             ResponseEntity<ApiResponse<RankingListResponse>> response2 = testRestTemplate.exchange(
                     url2,
                     HttpMethod.GET,

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
@@ -8,6 +8,8 @@ import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.Stock;
 import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.ranking.RankingV1Dto.RankingItem;
+import com.loopers.interfaces.api.ranking.RankingV1Dto.RankingListResponse;
 import com.loopers.support.IntegrationTest;
 import com.loopers.utils.DatabaseCleanUp;
 import com.loopers.utils.RedisCleanUp;
@@ -97,7 +99,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
             String url = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=1&size=20";
 
             // act
-            ResponseEntity<ApiResponse<RankingV1Dto.DailyRankingListResponse>> response = testRestTemplate.exchange(
+            ResponseEntity<ApiResponse<RankingListResponse>> response = testRestTemplate.exchange(
                     url,
                     HttpMethod.GET,
                     null,
@@ -109,10 +111,10 @@ class RankingV1ApiE2ETest extends IntegrationTest {
             assertThat(response.getBody()).isNotNull();
             assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.SUCCESS);
 
-            RankingV1Dto.DailyRankingListResponse rankingResponse = response.getBody().data();
+            RankingListResponse rankingResponse = response.getBody().data();
             assertThat(rankingResponse.rankings()).hasSize(2);
 
-            RankingV1Dto.DailyRankingItem item1 = rankingResponse.rankings().get(0);
+            RankingItem item1 = rankingResponse.rankings().get(0);
             assertAll(
                     () -> assertThat(item1.productId()).isEqualTo(product1.getId()),
                     () -> assertThat(item1.productName()).isEqualTo("상품1"),
@@ -122,7 +124,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
                     () -> assertThat(item1.rank()).isEqualTo(1)
             );
 
-            RankingV1Dto.DailyRankingItem item2 = rankingResponse.rankings().get(1);
+            RankingItem item2 = rankingResponse.rankings().get(1);
             assertAll(
                     () -> assertThat(item2.productId()).isEqualTo(product2.getId()),
                     () -> assertThat(item2.productName()).isEqualTo("상품2"),
@@ -141,7 +143,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
             String url = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=1&size=20";
 
             // act
-            ResponseEntity<ApiResponse<RankingV1Dto.DailyRankingListResponse>> response = testRestTemplate.exchange(
+            ResponseEntity<ApiResponse<RankingListResponse>> response = testRestTemplate.exchange(
                     url,
                     HttpMethod.GET,
                     null,
@@ -153,7 +155,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
             assertThat(response.getBody()).isNotNull();
             assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.SUCCESS);
 
-            RankingV1Dto.DailyRankingListResponse rankingResponse = response.getBody().data();
+            RankingListResponse rankingResponse = response.getBody().data();
             assertThat(rankingResponse.rankings()).isEmpty();
         }
 
@@ -180,7 +182,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
 
             // act - 첫 페이지
             String url1 = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=1&size=2";
-            ResponseEntity<ApiResponse<RankingV1Dto.DailyRankingListResponse>> response1 = testRestTemplate.exchange(
+            ResponseEntity<ApiResponse<RankingListResponse>> response1 = testRestTemplate.exchange(
                     url1,
                     HttpMethod.GET,
                     null,
@@ -189,14 +191,14 @@ class RankingV1ApiE2ETest extends IntegrationTest {
 
             // assert
             assertThat(response1.getStatusCode()).isEqualTo(HttpStatus.OK);
-            RankingV1Dto.DailyRankingListResponse page1 = response1.getBody().data();
+            RankingListResponse page1 = response1.getBody().data();
             assertThat(page1.rankings()).hasSize(2);
             assertThat(page1.rankings().get(0).productId()).isEqualTo(product1.getId());
             assertThat(page1.rankings().get(1).productId()).isEqualTo(product2.getId());
 
             // act - 두 번째 페이지
             String url2 = ENDPOINT_RANKING + "?date=" + date.format(DATE_FORMATTER) + "&page=2&size=2";
-            ResponseEntity<ApiResponse<RankingV1Dto.DailyRankingListResponse>> response2 = testRestTemplate.exchange(
+            ResponseEntity<ApiResponse<RankingListResponse>> response2 = testRestTemplate.exchange(
                     url2,
                     HttpMethod.GET,
                     null,
@@ -205,7 +207,7 @@ class RankingV1ApiE2ETest extends IntegrationTest {
 
             // assert
             assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.OK);
-            RankingV1Dto.DailyRankingListResponse page2 = response2.getBody().data();
+            RankingListResponse page2 = response2.getBody().data();
             assertThat(page2.rankings()).hasSize(1);
             assertThat(page2.rankings().get(0).productId()).isEqualTo(product3.getId());
         }

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,0 +1,24 @@
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // batch
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // querydsl
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
@@ -1,0 +1,13 @@
+package com.loopers;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CommerceBatchApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CommerceBatchApplication.class, args);
+    }
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
@@ -1,10 +1,21 @@
 package com.loopers;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
+@EnableScheduling
 public class CommerceBatchApplication {
+    
+    @PostConstruct
+    public void started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(CommerceBatchApplication.class, args);

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/JobParameterUtils.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/JobParameterUtils.java
@@ -1,0 +1,47 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankingType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepExecution;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+public class JobParameterUtils {
+
+    private static final String TARGET_DATE_PARAM = "targetDate";
+    private static final String RANKING_TYPE_PARAM = "rankingType";
+
+    public static LocalDate getTargetDate(StepExecution stepExecution) {
+        if (stepExecution == null) {
+            return LocalDate.now().minusDays(1);
+        }
+
+        String targetDateStr = stepExecution.getJobParameters().getString(TARGET_DATE_PARAM);
+        if (targetDateStr == null || targetDateStr.isEmpty()) {
+            return LocalDate.now().minusDays(1);
+        }
+
+        try {
+            return LocalDate.parse(targetDateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        } catch (Exception e) {
+            log.warn("targetDate 형식이 올바르지 않습니다: {}", targetDateStr);
+            return LocalDate.now().minusDays(1);
+        }
+    }
+
+    public static RankingType getRankingType(StepExecution stepExecution) {
+        if (stepExecution == null) {
+            return null;
+        }
+
+        String rankingTypeStr = stepExecution.getJobParameters().getString(RANKING_TYPE_PARAM);
+        if (rankingTypeStr == null || rankingTypeStr.isEmpty()) {
+            return RankingType.WEEKLY;
+        }
+
+        return RankingType.valueOf(rankingTypeStr.toUpperCase());
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/ProductMetricsItemReader.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/ProductMetricsItemReader.java
@@ -1,0 +1,66 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemStream;
+import org.springframework.batch.item.ItemStreamException;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ProductMetricsItemReader implements ItemReader<ProductMetrics>, ItemStream {
+
+    private static final String CURRENT_INDEX_KEY = "current.index";
+
+    private final ProductMetricsService productMetricsService;
+    private StepExecution stepExecution;
+    private List<ProductMetrics> productMetricsList;
+    private int currentIndex = 0;
+
+    @BeforeStep
+    public void beforeStep(StepExecution stepExecution) {
+        this.stepExecution = stepExecution;
+    }
+
+    @Override
+    public ProductMetrics read() {
+        if (productMetricsList == null || currentIndex >= productMetricsList.size()) {
+            return null;
+        }
+        return productMetricsList.get(currentIndex++);
+    }
+
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        if (executionContext.containsKey(CURRENT_INDEX_KEY)) {
+            currentIndex = executionContext.getInt(CURRENT_INDEX_KEY);
+        } else {
+            currentIndex = 0;
+        }
+
+        LocalDate targetDate = JobParameterUtils.getTargetDate(stepExecution);
+        log.info("ProductMetrics 조회 시작: targetDate={}", targetDate);
+        productMetricsList = productMetricsService.findByMetricsDate(targetDate);
+        log.info("ProductMetrics 조회 완료: size={}", productMetricsList.size());
+    }
+
+    @Override
+    public void update(ExecutionContext executionContext) throws ItemStreamException {
+        executionContext.putInt(CURRENT_INDEX_KEY, currentIndex);
+    }
+
+    @Override
+    public void close() throws ItemStreamException {
+        productMetricsList = null;
+        currentIndex = 0;
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingCalculationTasklet.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingCalculationTasklet.java
@@ -1,0 +1,48 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingService;
+import com.loopers.domain.ranking.RankingPeriod;
+import com.loopers.domain.ranking.RankingType;
+import com.loopers.domain.ranking.WeeklyRankingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingCalculationTasklet implements Tasklet {
+
+    private final WeeklyRankingService weeklyRankingService;
+    private final MonthlyRankingService monthlyRankingService;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        var stepExecution = chunkContext.getStepContext().getStepExecution();
+
+        LocalDate targetDate = JobParameterUtils.getTargetDate(stepExecution);
+        RankingType rankingType = JobParameterUtils.getRankingType(stepExecution);
+        RankingPeriod period;
+
+        log.info("랭킹 계산 시작: rankingType={}, targetDate={}", rankingType, targetDate);
+
+        if (rankingType == RankingType.WEEKLY) {
+            period = RankingPeriod.ofWeek(targetDate);
+            weeklyRankingService.calculateAndUpdateRanking(period);
+            log.info("주간 랭킹 계산 완료: targetDate={}, period={} ~ {}", targetDate, period.startDate(), period.endDate());
+        } else {
+            period = RankingPeriod.ofMonth(targetDate);
+            monthlyRankingService.calculateAndUpdateRanking(period);
+            log.info("월간 랭킹 계산 완료: targetDate={}, period={} ~ {}", targetDate, period.startDate(), period.endDate());
+        }
+
+        return RepeatStatus.FINISHED;
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingJobConfig.java
@@ -1,0 +1,78 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsService;
+import com.loopers.domain.ranking.MonthlyRankingService;
+import com.loopers.domain.ranking.ProductRankingAggregate;
+import com.loopers.domain.ranking.RankingCalculator;
+import com.loopers.domain.ranking.WeeklyRankingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class RankingJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ProductMetricsService productMetricsService;
+    private final RankingCalculator rankingCalculator;
+    private final RankingCalculationTasklet rankingCalculationTasklet;
+    private final WeeklyRankingService weeklyRankingService;
+    private final MonthlyRankingService monthlyRankingService;
+
+    private static final int CHUNK_SIZE = 100;
+
+    @Bean
+    public Job rankingJob() {
+        return new JobBuilder("rankingJob", jobRepository)
+                .start(rankingStep())
+                .next(rankingCalculationStep())
+                .build();
+    }
+
+    @Bean
+    public Step rankingStep() {
+        return new StepBuilder("rankingStep", jobRepository)
+                .<ProductMetrics, ProductRankingAggregate>chunk(CHUNK_SIZE, transactionManager)
+                .reader(rankingReader())
+                .processor(rankingProcessor())
+                .writer(rankingWriter())
+                .build();
+    }
+
+    @Bean
+    public Step rankingCalculationStep() {
+        return new StepBuilder("rankingCalculationStep", jobRepository)
+                .tasklet(rankingCalculationTasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public ItemReader<ProductMetrics> rankingReader() {
+        return new ProductMetricsItemReader(productMetricsService);
+    }
+
+    @Bean
+    public ItemProcessor<ProductMetrics, ProductRankingAggregate> rankingProcessor() {
+        return new RankingProcessor(rankingCalculator);
+    }
+
+    @Bean
+    public ItemWriter<ProductRankingAggregate> rankingWriter() {
+        return new RankingWriter(weeklyRankingService, monthlyRankingService);
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingProcessor.java
@@ -1,0 +1,22 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.ranking.ProductRankingAggregate;
+import com.loopers.domain.ranking.RankingCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+
+@RequiredArgsConstructor
+public class RankingProcessor implements ItemProcessor<ProductMetrics, ProductRankingAggregate> {
+
+    private final RankingCalculator rankingCalculator;
+
+    @Override
+    public ProductRankingAggregate process(ProductMetrics item) throws Exception {
+        ProductRankingAggregate aggregate = new ProductRankingAggregate(item.getProductId());
+        aggregate.addMetrics(item.getLikeCount(), item.getViewCount(), item.getSalesCount());
+        aggregate.calculateScore(rankingCalculator);
+        return aggregate;
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingWriter.java
@@ -1,0 +1,65 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingService;
+import com.loopers.domain.ranking.ProductRankingAggregate;
+import com.loopers.domain.ranking.RankingPeriod;
+import com.loopers.domain.ranking.RankingType;
+import com.loopers.domain.ranking.WeeklyRankingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RequiredArgsConstructor
+public class RankingWriter implements ItemWriter<ProductRankingAggregate> {
+
+    private final WeeklyRankingService weeklyRankingService;
+    private final MonthlyRankingService monthlyRankingService;
+
+    private RankingPeriod period;
+    private RankingType rankingType;
+
+    @BeforeStep
+    public void beforeStep(StepExecution stepExecution) {
+        LocalDate targetDate = JobParameterUtils.getTargetDate(stepExecution);
+        this.rankingType = JobParameterUtils.getRankingType(stepExecution);
+        
+        if (rankingType == RankingType.WEEKLY) {
+            this.period = RankingPeriod.ofWeek(targetDate);
+        } else {
+            this.period = RankingPeriod.ofMonth(targetDate);
+        }
+    }
+
+    @Override
+    public void write(Chunk<? extends ProductRankingAggregate> items) throws Exception {
+        for (ProductRankingAggregate aggregate : items) {
+            Long productId = aggregate.getProductId();
+            
+            if (rankingType == RankingType.WEEKLY) {
+                weeklyRankingService.upsertMetrics(
+                        productId,
+                        period,
+                        aggregate.getScore(),
+                        aggregate.getTotalLikeCount(),
+                        aggregate.getTotalViewCount(),
+                        aggregate.getTotalSalesCount()
+                );
+            } else {
+                monthlyRankingService.upsertMetrics(
+                        productId,
+                        period,
+                        aggregate.getScore(),
+                        aggregate.getTotalLikeCount(),
+                        aggregate.getTotalViewCount(),
+                        aggregate.getTotalSalesCount()
+                );
+            }
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/BatchConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/BatchConfig.java
@@ -1,0 +1,20 @@
+package com.loopers.batch.job;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+
+@Configuration
+@EnableBatchProcessing
+public class BatchConfig {
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        SimpleAsyncTaskExecutor taskExecutor = new SimpleAsyncTaskExecutor();
+        taskExecutor.setConcurrencyLimit(10);
+        return taskExecutor;
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -1,0 +1,66 @@
+package com.loopers.domain.metrics;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+    name = "product_metrics",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"product_id", "metrics_date"})
+    }
+)
+@Getter
+public class ProductMetrics extends BaseEntity {
+
+    @Column(nullable = false)
+    private Long productId;
+
+    @Column(name = "metrics_date", nullable = false)
+    private LocalDate metricsDate;
+
+    @Column(nullable = false)
+    private Long likeCount;
+
+    @Column(nullable = false)
+    private Long salesCount;
+
+    @Column(nullable = false)
+    private Long viewCount;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    @Builder
+    private ProductMetrics(Long productId, LocalDate metricsDate, Long likeCount, Long salesCount, Long viewCount) {
+        this.productId = productId;
+        this.metricsDate = metricsDate;
+        this.likeCount = likeCount;
+        this.salesCount = salesCount;
+        this.viewCount = viewCount;
+    }
+
+    public ProductMetrics() {
+    }
+
+    public static ProductMetrics create(Long productId, LocalDate metricsDate) {
+        return ProductMetrics.builder()
+                .productId(productId)
+                .metricsDate(metricsDate)
+                .likeCount(0L)
+                .salesCount(0L)
+                .viewCount(0L)
+                .build();
+    }
+}
+
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.metrics;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ProductMetricsRepository {
+    List<ProductMetrics> findByMetricsDate(LocalDate metricsDate);
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsService.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsService.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.metrics;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductMetricsService {
+
+    private final ProductMetricsRepository productMetricsRepository;
+
+    public List<ProductMetrics> findByMetricsDate(LocalDate metricsDate) {
+        return productMetricsRepository.findByMetricsDate(metricsDate);
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingService.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingService.java
@@ -1,0 +1,86 @@
+package com.loopers.domain.ranking;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MonthlyRankingService {
+
+    private static final int TOP_RANKING_SIZE = 100;
+
+    private final MvProductRankMonthlyRepository mvProductRankMonthlyRepository;
+
+    @Transactional
+    public void upsertMetrics(Long productId, RankingPeriod period, Double score, Long likeCount, Long viewCount, Long salesCount) {
+        mvProductRankMonthlyRepository.findByProductIdAndPeriod(productId, period.startDate(), period.endDate())
+                .ifPresentOrElse(
+                        existing -> {
+                            existing.updateMetrics(score, likeCount, viewCount, salesCount);
+                            mvProductRankMonthlyRepository.save(existing);
+                        },
+                        () -> {
+                            MvProductRankMonthly newRank = MvProductRankMonthly.create(
+                                    productId,
+                                    null,
+                                    score,
+                                    period.startDate(),
+                                    period.endDate(),
+                                    likeCount,
+                                    viewCount,
+                                    salesCount
+                            );
+                            mvProductRankMonthlyRepository.save(newRank);
+                        }
+                );
+    }
+
+    @Transactional
+    public void calculateAndUpdateRanking(RankingPeriod period) {
+        List<MvProductRankMonthly> allRanks = mvProductRankMonthlyRepository.findByPeriodOrderByRankingAsc(
+                period.startDate(), period.endDate());
+
+        if (allRanks.isEmpty()) {
+            log.info("월간 랭킹 데이터가 없습니다: period={} ~ {}", period.startDate(), period.endDate());
+            return;
+        }
+
+        // score 기준으로 정렬하여 TOP 100 추출
+        List<MvProductRankMonthly> top100 = allRanks.stream()
+                .sorted((a, b) -> Double.compare(b.getScore(), a.getScore()))
+                .limit(TOP_RANKING_SIZE)
+                .toList();
+
+        // TOP 100 상품의 랭킹만 업데이트
+        int updatedCount = 0;
+        for (int i = 0; i < top100.size(); i++) {
+            MvProductRankMonthly rank = top100.get(i);
+            rank.updateRanking(i + 1);
+            mvProductRankMonthlyRepository.save(rank);
+            updatedCount++;
+        }
+
+        // TOP 100에서 밀려난 기존 데이터 삭제
+        Set<Long> top100ProductIds = top100.stream()
+                .map(MvProductRankMonthly::getProductId)
+                .collect(Collectors.toSet());
+
+        int deletedCount = 0;
+        for (MvProductRankMonthly existing : allRanks) {
+            if (!top100ProductIds.contains(existing.getProductId())) {
+                mvProductRankMonthlyRepository.delete(existing);
+                deletedCount++;
+            }
+        }
+
+        log.info("월간 랭킹 계산 완료: period={} ~ {}, updated={}, deleted={}",
+                period.startDate(), period.endDate(), updatedCount, deletedCount);
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MvProductRankMonthly.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MvProductRankMonthly.java
@@ -1,0 +1,97 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "mv_product_rank_monthly",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"product_id", "period_start_date", "period_end_date"})
+        }
+)
+@Getter
+public class MvProductRankMonthly extends BaseEntity {
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(nullable = true)
+    private Integer ranking;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Column(name = "period_start_date", nullable = false)
+    private LocalDate periodStartDate;
+
+    @Column(name = "period_end_date", nullable = false)
+    private LocalDate periodEndDate;
+
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    @Column(name = "sales_count", nullable = false)
+    private Long salesCount;
+
+    @Builder
+    private MvProductRankMonthly(Long productId, Integer ranking, Double score, LocalDate periodStartDate,
+                                 LocalDate periodEndDate, Long likeCount, Long viewCount, Long salesCount) {
+        this.productId = productId;
+        this.ranking = ranking;
+        this.score = score;
+        this.periodStartDate = periodStartDate;
+        this.periodEndDate = periodEndDate;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.salesCount = salesCount;
+    }
+
+    public MvProductRankMonthly() {
+    }
+
+    public static MvProductRankMonthly create(Long productId, Integer ranking, Double score, LocalDate periodStartDate,
+                                              LocalDate periodEndDate, Long likeCount, Long viewCount, Long salesCount) {
+        return MvProductRankMonthly.builder()
+                .productId(productId)
+                .ranking(ranking)
+                .score(score)
+                .periodStartDate(periodStartDate)
+                .periodEndDate(periodEndDate)
+                .likeCount(likeCount)
+                .viewCount(viewCount)
+                .salesCount(salesCount)
+                .build();
+    }
+
+    public void update(Integer ranking, Double score, Long likeCount, Long viewCount, Long salesCount) {
+        this.ranking = ranking;
+        this.score = score;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.salesCount = salesCount;
+    }
+
+    public void updateMetrics(Double score, Long likeCount, Long viewCount, Long salesCount) {
+        this.score = score;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.salesCount = salesCount;
+    }
+
+    public void updateRanking(Integer ranking) {
+        this.ranking = ranking;
+    }
+}
+
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MvProductRankMonthlyRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MvProductRankMonthlyRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface MvProductRankMonthlyRepository {
+    Optional<MvProductRankMonthly> findByProductIdAndPeriod(Long productId, LocalDate periodStartDate, LocalDate periodEndDate);
+
+    List<MvProductRankMonthly> findByPeriodOrderByRankingAsc(LocalDate periodStartDate, LocalDate periodEndDate);
+
+    void save(MvProductRankMonthly rank);
+
+    void delete(MvProductRankMonthly rank);
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MvProductRankWeekly.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MvProductRankWeekly.java
@@ -1,0 +1,97 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "mv_product_rank_weekly",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"product_id", "period_start_date", "period_end_date"})
+        }
+)
+@Getter
+public class MvProductRankWeekly extends BaseEntity {
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(nullable = true)
+    private Integer ranking;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Column(name = "period_start_date", nullable = false)
+    private LocalDate periodStartDate;
+
+    @Column(name = "period_end_date", nullable = false)
+    private LocalDate periodEndDate;
+
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    @Column(name = "sales_count", nullable = false)
+    private Long salesCount;
+
+    @Builder
+    private MvProductRankWeekly(Long productId, Integer ranking, Double score, LocalDate periodStartDate, LocalDate periodEndDate,
+                                Long likeCount, Long viewCount, Long salesCount) {
+        this.productId = productId;
+        this.ranking = ranking;
+        this.score = score;
+        this.periodStartDate = periodStartDate;
+        this.periodEndDate = periodEndDate;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.salesCount = salesCount;
+    }
+
+    public MvProductRankWeekly() {
+    }
+
+    public static MvProductRankWeekly create(Long productId, Integer ranking, Double score, LocalDate periodStartDate,
+                                             LocalDate periodEndDate, Long likeCount, Long viewCount, Long salesCount) {
+        return MvProductRankWeekly.builder()
+                .productId(productId)
+                .ranking(ranking)
+                .score(score)
+                .periodStartDate(periodStartDate)
+                .periodEndDate(periodEndDate)
+                .likeCount(likeCount)
+                .viewCount(viewCount)
+                .salesCount(salesCount)
+                .build();
+    }
+
+    public void update(Integer ranking, Double score, Long likeCount, Long viewCount, Long salesCount) {
+        this.ranking = ranking;
+        this.score = score;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.salesCount = salesCount;
+    }
+
+    public void updateMetrics(Double score, Long likeCount, Long viewCount, Long salesCount) {
+        this.score = score;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.salesCount = salesCount;
+    }
+
+    public void updateRanking(Integer ranking) {
+        this.ranking = ranking;
+    }
+}
+
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MvProductRankWeeklyRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MvProductRankWeeklyRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface MvProductRankWeeklyRepository {
+    Optional<MvProductRankWeekly> findByProductIdAndPeriod(Long productId, LocalDate periodStartDate, LocalDate periodEndDate);
+
+    List<MvProductRankWeekly> findByPeriodOrderByRankingAsc(LocalDate periodStartDate, LocalDate periodEndDate);
+
+    void save(MvProductRankWeekly rank);
+
+    void delete(MvProductRankWeekly rank);
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/ProductRankingAggregate.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/ProductRankingAggregate.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.ranking;
+
+import lombok.Getter;
+
+@Getter
+public class ProductRankingAggregate {
+    private final Long productId;
+    private Long totalLikeCount;
+    private Long totalViewCount;
+    private Long totalSalesCount;
+    private Double score;
+
+    public ProductRankingAggregate(Long productId) {
+        this.productId = productId;
+        this.totalLikeCount = 0L;
+        this.totalViewCount = 0L;
+        this.totalSalesCount = 0L;
+        this.score = 0.0;
+    }
+
+    public void addMetrics(Long likeCount, Long viewCount, Long salesCount) {
+        this.totalLikeCount += (likeCount != null ? likeCount : 0L);
+        this.totalViewCount += (viewCount != null ? viewCount : 0L);
+        this.totalSalesCount += (salesCount != null ? salesCount : 0L);
+    }
+
+    public void calculateScore(RankingCalculator calculator) {
+        this.score = calculator.calculateScore(totalLikeCount, totalViewCount, totalSalesCount);
+    }
+}
+
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingCalculator.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingCalculator.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.ranking;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RankingCalculator {
+
+    public double calculateScore(Long likeCount, Long viewCount, Long salesCount) {
+        double score = 0.0;
+        
+        if (viewCount != null && viewCount > 0) {
+            score += viewCount * RankingWeight.VIEW.getWeight();
+        }
+        
+        if (likeCount != null && likeCount > 0) {
+            score += likeCount * RankingWeight.LIKE.getWeight();
+        }
+        
+        if (salesCount != null && salesCount > 0) {
+            score += salesCount * RankingWeight.ORDER_CREATED.getWeight();
+        }
+        
+        return score;
+    }
+}
+
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingPeriod.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingPeriod.java
@@ -1,0 +1,25 @@
+package com.loopers.domain.ranking;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.temporal.TemporalAdjusters;
+
+public record RankingPeriod(
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static RankingPeriod ofWeek(LocalDate date) {
+        LocalDate weekStart = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEnd = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        return new RankingPeriod(weekStart, weekEnd);
+    }
+
+    public static RankingPeriod ofMonth(LocalDate date) {
+        YearMonth yearMonth = YearMonth.from(date);
+        LocalDate monthStart = yearMonth.atDay(1);
+        LocalDate monthEnd = yearMonth.atEndOfMonth();
+        return new RankingPeriod(monthStart, monthEnd);
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingType.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingType.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+public enum RankingType {
+    WEEKLY,
+    MONTHLY
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingWeight.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingWeight.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.ranking;
+
+import lombok.Getter;
+
+@Getter
+public enum RankingWeight {
+    VIEW(0.1, "조회수"),
+    LIKE(0.2, "좋아요"),
+    ORDER_CREATED(0.7, "주문 생성");
+
+    private final double weight;
+    private final String description;
+
+    RankingWeight(double weight, String description) {
+        this.weight = weight;
+        this.description = description;
+    }
+}
+
+

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingService.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingService.java
@@ -1,0 +1,87 @@
+package com.loopers.domain.ranking;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeeklyRankingService {
+
+    private static final int TOP_RANKING_SIZE = 100;
+
+    private final MvProductRankWeeklyRepository mvProductRankWeeklyRepository;
+
+    @Transactional
+    public void upsertMetrics(Long productId, RankingPeriod period, Double score, Long likeCount, Long viewCount, Long salesCount) {
+        mvProductRankWeeklyRepository.findByProductIdAndPeriod(productId, period.startDate(), period.endDate())
+                .ifPresentOrElse(
+                        existing -> {
+                            existing.updateMetrics(score, likeCount, viewCount, salesCount);
+                            mvProductRankWeeklyRepository.save(existing);
+                        },
+                        () -> {
+                            MvProductRankWeekly newRank = MvProductRankWeekly.create(
+                                    productId,
+                                    null,
+                                    score,
+                                    period.startDate(),
+                                    period.endDate(),
+                                    likeCount,
+                                    viewCount,
+                                    salesCount
+                            );
+                            mvProductRankWeeklyRepository.save(newRank);
+                        }
+                );
+    }
+
+    @Transactional
+    public void calculateAndUpdateRanking(RankingPeriod period) {
+        // MV 테이블에서 period에 해당하는 모든 데이터 조회
+        List<MvProductRankWeekly> allRanks = mvProductRankWeeklyRepository.findByPeriodOrderByRankingAsc(
+                period.startDate(), period.endDate());
+
+        if (allRanks.isEmpty()) {
+            log.info("주간 랭킹 데이터가 없습니다: period={} ~ {}", period.startDate(), period.endDate());
+            return;
+        }
+
+        // score 기준으로 정렬하여 TOP 100 추출
+        List<MvProductRankWeekly> top100 = allRanks.stream()
+                .sorted((a, b) -> Double.compare(b.getScore(), a.getScore()))
+                .limit(TOP_RANKING_SIZE)
+                .toList();
+
+        // TOP 100 상품의 랭킹만 업데이트
+        int updatedCount = 0;
+        for (int i = 0; i < top100.size(); i++) {
+            MvProductRankWeekly rank = top100.get(i);
+            rank.updateRanking(i + 1);
+            mvProductRankWeeklyRepository.save(rank);
+            updatedCount++;
+        }
+
+        // TOP 100에서 밀려난 기존 데이터 삭제
+        Set<Long> top100ProductIds = top100.stream()
+                .map(MvProductRankWeekly::getProductId)
+                .collect(Collectors.toSet());
+
+        int deletedCount = 0;
+        for (MvProductRankWeekly existing : allRanks) {
+            if (!top100ProductIds.contains(existing.getProductId())) {
+                mvProductRankWeeklyRepository.delete(existing);
+                deletedCount++;
+            }
+        }
+
+        log.info("주간 랭킹 계산 완료: period={} ~ {}, updated={}, deleted={}",
+                period.startDate(), period.endDate(), updatedCount, deletedCount);
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
+    @Query("SELECT pm FROM ProductMetrics pm WHERE pm.metricsDate = :date ORDER BY pm.productId")
+    List<ProductMetrics> findByMetricsDate(@Param("date") LocalDate date);
+}
+
+

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
+
+    private final ProductMetricsJpaRepository jpaRepository;
+
+    @Override
+    public List<ProductMetrics> findByMetricsDate(LocalDate metricsDate) {
+        return jpaRepository.findByMetricsDate(metricsDate);
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MvProductRankMonthlyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MvProductRankMonthlyJpaRepository.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MvProductRankMonthly;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface MvProductRankMonthlyJpaRepository extends JpaRepository<MvProductRankMonthly, Long> {
+    
+    Optional<MvProductRankMonthly> findByProductIdAndPeriodStartDateAndPeriodEndDate(
+            Long productId,
+            LocalDate periodStartDate,
+            LocalDate periodEndDate
+    );
+    
+    List<MvProductRankMonthly> findByPeriodStartDateAndPeriodEndDateOrderByRankingAsc(
+            LocalDate periodStartDate,
+            LocalDate periodEndDate
+    );
+}
+
+

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MvProductRankMonthlyRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MvProductRankMonthlyRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MvProductRankMonthly;
+import com.loopers.domain.ranking.MvProductRankMonthlyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MvProductRankMonthlyRepositoryImpl implements MvProductRankMonthlyRepository {
+
+    private final MvProductRankMonthlyJpaRepository jpaRepository;
+
+    @Override
+    public Optional<MvProductRankMonthly> findByProductIdAndPeriod(Long productId, LocalDate periodStartDate, LocalDate periodEndDate) {
+        return jpaRepository.findByProductIdAndPeriodStartDateAndPeriodEndDate(productId, periodStartDate, periodEndDate);
+    }
+
+    @Override
+    public List<MvProductRankMonthly> findByPeriodOrderByRankingAsc(LocalDate periodStartDate, LocalDate periodEndDate) {
+        return jpaRepository.findByPeriodStartDateAndPeriodEndDateOrderByRankingAsc(periodStartDate, periodEndDate);
+    }
+
+    @Override
+    public void save(MvProductRankMonthly rank) {
+        jpaRepository.save(rank);
+    }
+
+    @Override
+    public void delete(MvProductRankMonthly rank) {
+        jpaRepository.delete(rank);
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MvProductRankWeeklyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MvProductRankWeeklyJpaRepository.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MvProductRankWeekly;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface MvProductRankWeeklyJpaRepository extends JpaRepository<MvProductRankWeekly, Long> {
+    
+    Optional<MvProductRankWeekly> findByProductIdAndPeriodStartDateAndPeriodEndDate(
+            Long productId,
+            LocalDate periodStartDate,
+            LocalDate periodEndDate
+    );
+    
+    List<MvProductRankWeekly> findByPeriodStartDateAndPeriodEndDateOrderByRankingAsc(
+            LocalDate periodStartDate,
+            LocalDate periodEndDate
+    );
+}
+
+

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MvProductRankWeeklyRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MvProductRankWeeklyRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MvProductRankWeekly;
+import com.loopers.domain.ranking.MvProductRankWeeklyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MvProductRankWeeklyRepositoryImpl implements MvProductRankWeeklyRepository {
+
+    private final MvProductRankWeeklyJpaRepository jpaRepository;
+
+    @Override
+    public Optional<MvProductRankWeekly> findByProductIdAndPeriod(Long productId, LocalDate periodStartDate, LocalDate periodEndDate) {
+        return jpaRepository.findByProductIdAndPeriodStartDateAndPeriodEndDate(productId, periodStartDate, periodEndDate);
+    }
+
+    @Override
+    public List<MvProductRankWeekly> findByPeriodOrderByRankingAsc(LocalDate periodStartDate, LocalDate periodEndDate) {
+        return jpaRepository.findByPeriodStartDateAndPeriodEndDateOrderByRankingAsc(periodStartDate, periodEndDate);
+    }
+
+    @Override
+    public void save(MvProductRankWeekly rank) {
+        jpaRepository.save(rank);
+    }
+
+    @Override
+    public void delete(MvProductRankWeekly rank) {
+        jpaRepository.delete(rank);
+    }
+}
+

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/scheduler/RankingBatchScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/scheduler/RankingBatchScheduler.java
@@ -1,0 +1,75 @@
+package com.loopers.interfaces.scheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+public class RankingBatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job rankingJob;
+
+    public RankingBatchScheduler(
+            JobLauncher jobLauncher,
+            @Qualifier("rankingJob") Job rankingJob
+    ) {
+        this.jobLauncher = jobLauncher;
+        this.rankingJob = rankingJob;
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void runWeeklyRankingJob() {
+        try {
+            LocalDate yesterday = LocalDate.now().minusDays(1);
+            String targetDate = yesterday.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+            
+            log.info("주간 랭킹 배치 작업 시작: targetDate={}, time={}", targetDate, LocalDateTime.now());
+            
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("rankingType", "WEEKLY")
+                    .addString("targetDate", targetDate)
+                    .addString("executionTime", LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                    .toJobParameters();
+            
+            jobLauncher.run(rankingJob, jobParameters);
+            
+            log.info("주간 랭킹 배치 작업 완료: targetDate={}, time={}", targetDate, LocalDateTime.now());
+        } catch (Exception e) {
+            log.error("주간 랭킹 배치 작업 실패", e);
+        }
+    }
+
+    @Scheduled(cron = "0 30 3 * * *")
+    public void runMonthlyRankingJob() {
+        try {
+            LocalDate yesterday = LocalDate.now().minusDays(1);
+            String targetDate = yesterday.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+            
+            log.info("월간 랭킹 배치 작업 시작: targetDate={}, time={}", targetDate, LocalDateTime.now());
+            
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("rankingType", "MONTHLY")
+                    .addString("targetDate", targetDate)
+                    .addString("executionTime", LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                    .toJobParameters();
+            
+            jobLauncher.run(rankingJob, jobParameters);
+            
+            log.info("월간 랭킹 배치 작업 완료: targetDate={}, time={}", targetDate, LocalDateTime.now());
+        } catch (Exception e) {
+            log.error("월간 랭킹 배치 작업 실패", e);
+        }
+    }
+}
+

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,0 +1,49 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # ?? ?? ??? ? (default : 200)
+      min-spare: 10 # ?? ?? ??? ? (default : 10)
+    connection-timeout: 1m # ?? ???? (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # ?? ?? ?? ? (default : 8192)
+    accept-count: 100 # ?? ? ?? (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-batch
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd

--- a/apps/commerce-batch/src/test/java/com/loopers/CommerceBatchApplicationTests.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/CommerceBatchApplicationTests.java
@@ -1,0 +1,13 @@
+package com.loopers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CommerceBatchApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -4,17 +4,28 @@ import com.loopers.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Entity
-@Table(name = "product_metrics")
+@Table(
+    name = "product_metrics",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"product_id", "metrics_date"})
+    }
+)
 @Getter
 public class ProductMetrics extends BaseEntity {
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private Long productId;
+
+    @Column(name = "metrics_date", nullable = false)
+    private LocalDate metricsDate;
 
     @Column(nullable = false)
     private Long likeCount;
@@ -30,8 +41,9 @@ public class ProductMetrics extends BaseEntity {
     private Long version;
 
     @Builder
-    private ProductMetrics(Long productId, Long likeCount, Long salesCount, Long viewCount) {
+    private ProductMetrics(Long productId, LocalDate metricsDate, Long likeCount, Long salesCount, Long viewCount) {
         this.productId = productId;
+        this.metricsDate = metricsDate;
         this.likeCount = likeCount;
         this.salesCount = salesCount;
         this.viewCount = viewCount;
@@ -40,9 +52,10 @@ public class ProductMetrics extends BaseEntity {
     public ProductMetrics() {
     }
 
-    public static ProductMetrics create(Long productId) {
+    public static ProductMetrics create(Long productId, LocalDate metricsDate) {
         return ProductMetrics.builder()
                 .productId(productId)
+                .metricsDate(metricsDate)
                 .likeCount(0L)
                 .salesCount(0L)
                 .viewCount(0L)

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.metrics;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface ProductMetricsRepository {
@@ -7,6 +8,8 @@ public interface ProductMetricsRepository {
 
     Optional<ProductMetrics> findByProductId(Long productId);
 
-    int incrementLikeCount(Long productId);
+    Optional<ProductMetrics> findByProductIdAndMetricsDate(Long productId, LocalDate metricsDate);
+
+    int incrementLikeCount(Long productId, LocalDate metricsDate);
 }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -1,6 +1,7 @@
 package com.loopers.infrastructure.metrics;
 
 import com.loopers.domain.metrics.ProductMetrics;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,8 +11,10 @@ import org.springframework.data.repository.query.Param;
 public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
     Optional<ProductMetrics> findByProductId(Long productId);
 
+    Optional<ProductMetrics> findByProductIdAndMetricsDate(Long productId, LocalDate metricsDate);
+
     @Modifying
-    @Query("UPDATE ProductMetrics m SET m.likeCount = m.likeCount + 1 WHERE m.productId = :productId")
-    int incrementLikeCount(@Param("productId") Long productId);
+    @Query("UPDATE ProductMetrics m SET m.likeCount = m.likeCount + 1 WHERE m.productId = :productId AND m.metricsDate = :metricsDate")
+    int incrementLikeCount(@Param("productId") Long productId, @Param("metricsDate") LocalDate metricsDate);
 }
 

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.metrics;
 
 import com.loopers.domain.metrics.ProductMetrics;
 import com.loopers.domain.metrics.ProductMetricsRepository;
+import java.time.LocalDate;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -23,8 +24,13 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
     }
 
     @Override
-    public int incrementLikeCount(Long productId) {
-        return productMetricsJpaRepository.incrementLikeCount(productId);
+    public Optional<ProductMetrics> findByProductIdAndMetricsDate(Long productId, LocalDate metricsDate) {
+        return productMetricsJpaRepository.findByProductIdAndMetricsDate(productId, metricsDate);
+    }
+
+    @Override
+    public int incrementLikeCount(Long productId, LocalDate metricsDate) {
+        return productMetricsJpaRepository.incrementLikeCount(productId, metricsDate);
     }
 }
 

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/MetricsConsumerIdempotencyTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/MetricsConsumerIdempotencyTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.support.Acknowledgment;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -74,7 +75,8 @@ class MetricsConsumerIdempotencyTest {
             );
 
             // assert - 첫 번째 처리 결과 확인
-            ProductMetrics metrics1 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            LocalDate today = LocalDate.now();
+            ProductMetrics metrics1 = productMetricsJpaRepository.findByProductIdAndMetricsDate(productId, today).orElseThrow();
             assertThat(metrics1.getLikeCount()).isEqualTo(1L);
             assertThat(eventHandledJpaRepository.existsByEventId(eventId)).isTrue();
 
@@ -85,7 +87,7 @@ class MetricsConsumerIdempotencyTest {
             );
 
             // assert - 두 번째 처리 후에도 좋아요 수가 증가하지 않음
-            ProductMetrics metrics2 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            ProductMetrics metrics2 = productMetricsJpaRepository.findByProductIdAndMetricsDate(productId, today).orElseThrow();
             assertThat(metrics2.getLikeCount()).isEqualTo(1L);
 
             // act - 세 번째 처리 (중복)
@@ -95,7 +97,7 @@ class MetricsConsumerIdempotencyTest {
             );
 
             // assert - 세 번째 처리 후에도 좋아요 수가 증가하지 않음
-            ProductMetrics metrics3 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            ProductMetrics metrics3 = productMetricsJpaRepository.findByProductIdAndMetricsDate(productId, today).orElseThrow();
             assertThat(metrics3.getLikeCount()).isEqualTo(1L);
 
             // verify - EventHandled는 한 번만 저장됨
@@ -136,7 +138,8 @@ class MetricsConsumerIdempotencyTest {
             );
 
             // assert - 첫 번째 처리 결과 확인
-            ProductMetrics metrics1 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            LocalDate today = LocalDate.now();
+            ProductMetrics metrics1 = productMetricsJpaRepository.findByProductIdAndMetricsDate(productId, today).orElseThrow();
             assertThat(metrics1.getViewCount()).isEqualTo(1L);
 
             // act - 두 번째 처리 (중복)
@@ -146,7 +149,7 @@ class MetricsConsumerIdempotencyTest {
             );
 
             // assert - 두 번째 처리 후에도 조회 수가 증가하지 않음
-            ProductMetrics metrics2 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            ProductMetrics metrics2 = productMetricsJpaRepository.findByProductIdAndMetricsDate(productId, today).orElseThrow();
             assertThat(metrics2.getViewCount()).isEqualTo(1L);
         }
     }
@@ -194,8 +197,9 @@ class MetricsConsumerIdempotencyTest {
             );
 
             // assert - 첫 번째 처리 결과 확인
-            ProductMetrics metrics1_product1 = productMetricsJpaRepository.findByProductId(10L).orElseThrow();
-            ProductMetrics metrics1_product2 = productMetricsJpaRepository.findByProductId(20L).orElseThrow();
+            LocalDate today = LocalDate.now();
+            ProductMetrics metrics1_product1 = productMetricsJpaRepository.findByProductIdAndMetricsDate(10L, today).orElseThrow();
+            ProductMetrics metrics1_product2 = productMetricsJpaRepository.findByProductIdAndMetricsDate(20L, today).orElseThrow();
             assertThat(metrics1_product1.getSalesCount()).isEqualTo(2L);
             assertThat(metrics1_product2.getSalesCount()).isEqualTo(1L);
 
@@ -206,8 +210,8 @@ class MetricsConsumerIdempotencyTest {
             );
 
             // assert - 두 번째 처리 후에도 판매량이 증가하지 않음
-            ProductMetrics metrics2_product1 = productMetricsJpaRepository.findByProductId(10L).orElseThrow();
-            ProductMetrics metrics2_product2 = productMetricsJpaRepository.findByProductId(20L).orElseThrow();
+            ProductMetrics metrics2_product1 = productMetricsJpaRepository.findByProductIdAndMetricsDate(10L, today).orElseThrow();
+            ProductMetrics metrics2_product2 = productMetricsJpaRepository.findByProductIdAndMetricsDate(20L, today).orElseThrow();
             assertThat(metrics2_product1.getSalesCount()).isEqualTo(2L);
             assertThat(metrics2_product2.getSalesCount()).isEqualTo(1L);
         }
@@ -253,7 +257,8 @@ class MetricsConsumerIdempotencyTest {
             metricsConsumer.handleProductViewedEvents(List.of(viewedRecord1), acknowledgment);
 
             // assert - 첫 번째 처리 결과 확인
-            ProductMetrics metrics1 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            LocalDate today = LocalDate.now();
+            ProductMetrics metrics1 = productMetricsJpaRepository.findByProductIdAndMetricsDate(productId, today).orElseThrow();
             assertThat(metrics1.getLikeCount()).isEqualTo(1L);
             assertThat(metrics1.getViewCount()).isEqualTo(1L);
 
@@ -262,7 +267,7 @@ class MetricsConsumerIdempotencyTest {
             metricsConsumer.handleProductViewedEvents(List.of(viewedRecord2), acknowledgment);
 
             // assert - 두 번째 처리 후에도 증가하지 않음
-            ProductMetrics metrics2 = productMetricsJpaRepository.findByProductId(productId).orElseThrow();
+            ProductMetrics metrics2 = productMetricsJpaRepository.findByProductIdAndMetricsDate(productId, today).orElseThrow();
             assertThat(metrics2.getLikeCount()).isEqualTo(1L);
             assertThat(metrics2.getViewCount()).isEqualTo(1L);
 

--- a/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
+++ b/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
@@ -47,6 +47,17 @@ public class KafkaConfig {
     }
 
     @Bean
+    public ProducerFactory<String, String> stringProducerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildProducerProperties());
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> stringKafkaTemplate(ProducerFactory<String, String> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+
+    @Bean
     public ByteArrayJsonMessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
         return new ByteArrayJsonMessageConverter(objectMapper);
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     ":apps:commerce-api",
     ":apps:pg-simulator",
     ":apps:commerce-streamer",
+    ":apps:commerce-batch",
     ":modules:jpa",
     ":modules:redis",
     ":modules:kafka",


### PR DESCRIPTION
## 📌 Summary
- Spring Batch 구현 (commerce-batch)
	- 파라미터 기반 Job: rankingType(WEEKLY/MONTHLY)과 targetDate(yyyyMMdd)를 JobParameters로 받아 하나의 Job으로 주간/월간 랭킹을 처리
	- rankingStep
		- 전날 product_metrics 데이터를 청크 단위(100건)로 읽어 점수 계산 후 MV 테이블에 UPSERT (ranking=null)
	- rankingCalculationStep
		- MV 테이블에서 데이터를 조회해 score 기준 정렬 후 TOP 100 추출 및 ranking 업데이트
	- 스케줄러: 매일 새벽 3시에 주간 랭킹, 3시 30분에 월간 랭킹 배치 실행
	- Materialized View: `mv_product_rank_weekly`, `mv_product_rank_monthly` 테이블에 주간/월간 TOP 100 랭킹 저장
- Ranking API 구현 (commerce-api)
	- 통합 API: `GET` `/api/v1/rankings?date=yyyyMMdd&type=DAILY|WEEKLY|MONTHLY&page=1&size=20`
	- 데이터 소스 분리:
		- 일간 랭킹: Redis에서 조회
		- 주간/월간 랭킹: 각각의 MV 테이블에서 조회
		- 페이징 지원

---

## 💬 Review Points

### 1. 배치 애플리케이션과 API 애플리케이션 간의 데이터베이스 공유 방식
배치 애플리케이션은 commerce-batch로 따로 만들었습니다. 
commerce-batch에서 MV 테이블에 랭킹을 계산해서 저장하고, API 애플리케이션(commerce-api)은 MV 테이블에서 조회합니다.
이렇게 commerce-batch와 commerce-api에서 같은 데이터베이스를 공유하고 있는데 이걸 어떻게 처리해야 할지 궁금합니다. 

현재는 각 애플리케이션에 (같은 테이블을 가리키지만) 별도 엔티티 클래스를 구현했습니다.
modules/jpa 모듈의 공통 설정으로 하나의 클래스만 구현해야 할까요? 


---

## ✅ Checklist

### 🧱 Spring Batch
- [x]  Spring Batch Job 을 작성하고, 파라미터 기반으로 동작시킬 수 있다.
- [x]  Chunk Oriented Processing (Reader/Processor/Writer or Tasklet) 기반의 배치 처리를 구현했다.
- [x]  집계 결과를 저장할 Materialized View 의 구조를 설계하고 올바르게 적재했다.

### 🧩 Ranking API
- [x]  API 가 일간, 주간, 월간 랭킹을 제공하며 조회해야 하는 형태에 따라 적절한 데이터를 기반으로 랭킹을 제공한다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 상품 랭킹 조회 기능 확대: 일간 랭킹에서 주간, 월간 랭킹으로 확장
  * 랭킹 조회 API에 랭킹 타입 파라미터 추가 (일간/주간/월간 선택 가능)
  * 랭킹 조회 응답에 상품 가격, 좋아요 수, 순위 정보 추가
  * 자동화된 배치 처리를 통한 주간/월간 랭킹 계산 시스템 도입

* **Infrastructure**
  * 주간/월간 랭킹 데이터를 위한 새로운 데이터베이스 스키마 추가
  * 메트릭스 추적 기능의 날짜 기반 범위 지정 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->